### PR TITLE
Define `ByteConversion` trait

### DIFF
--- a/math/src/lib.rs
+++ b/math/src/lib.rs
@@ -3,4 +3,5 @@ pub mod elliptic_curve;
 pub mod field;
 pub mod msm;
 pub mod polynomial;
+pub mod traits;
 pub mod unsigned_integer;

--- a/math/src/traits.rs
+++ b/math/src/traits.rs
@@ -1,8 +1,8 @@
 /// A trait for converting an element to its byte representation.
-pub trait ToBytes<T> {
+pub trait ToBytes {
     /// Returns the byte representation of the element in big-endian order.
-    fn to_bytes_be(&self) -> T;
+    fn to_bytes_be(&self) -> Vec<u8>;
 
     /// Returns the byte representation of the element in little-endian order.
-    fn to_bytes_le(&self) -> T;
+    fn to_bytes_le(&self) -> Vec<u8>;
 }

--- a/math/src/traits.rs
+++ b/math/src/traits.rs
@@ -1,4 +1,6 @@
-/// A trait for converting an element to its byte representation.
+/// A trait for converting an element to and from its byte representation and
+/// for getting an element from its byte representation in big-endian or
+/// little-endian order.
 pub trait ByteConversion {
     /// Returns the byte representation of the element in big-endian order.
     fn to_bytes_be(&self) -> Vec<u8>;

--- a/math/src/traits.rs
+++ b/math/src/traits.rs
@@ -1,8 +1,14 @@
 /// A trait for converting an element to its byte representation.
-pub trait ToBytes {
+pub trait ByteConversion {
     /// Returns the byte representation of the element in big-endian order.
     fn to_bytes_be(&self) -> Vec<u8>;
 
     /// Returns the byte representation of the element in little-endian order.
     fn to_bytes_le(&self) -> Vec<u8>;
+
+    /// Returns the element from its byte representation in big-endian order.
+    fn from_bytes_be(bytes: &[u8]) -> Self;
+
+    /// Returns the element from its byte representation in little-endian order.
+    fn from_bytes_le(bytes: &[u8]) -> Self;
 }

--- a/math/src/traits.rs
+++ b/math/src/traits.rs
@@ -1,0 +1,8 @@
+/// A trait for converting an element to its byte representation.
+pub trait ToBytes<T> {
+    /// Returns the byte representation of the element in big-endian order.
+    fn to_bytes_be(&self) -> T;
+
+    /// Returns the byte representation of the element in little-endian order.
+    fn to_bytes_le(&self) -> T;
+}


### PR DESCRIPTION
Resolves #36.

This trait will be later implemented for types like `EllipticCurveElement` and `FieldElement`.