### PR TITLE
Remove `panics` on the inv methods

### DIFF
--- a/math/src/elliptic_curve/short_weierstrass/traits.rs
+++ b/math/src/elliptic_curve/short_weierstrass/traits.rs
@@ -66,7 +66,7 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
             "The point at infinity is not affine."
         );
         let (x, y, z) = (&p[0], &p[1], &p[2]);
-        [x / z, y / z, FieldElement::one()]
+        [(x / z).unwrap(), (y / z).unwrap(), FieldElement::one()]
     }
 
     /// Returns the sum of projective points `p` and `q`
@@ -148,7 +148,7 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
                 qx - px
             } else {
                 let l = (ry - py) / (rx - px);
-                qy - py - l * (qx - px)
+                qy - py - l.unwrap() * (qx - px)
             }
         } else {
             let numerator = FieldElement::from(3) * &px.pow(2_u16) + Self::a();
@@ -157,7 +157,7 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
                 qx - px
             } else {
                 let l = numerator / denominator;
-                qy - py - l * (qx - px)
+                qy - py - l.unwrap() * (qx - px)
             }
         }
     }
@@ -189,7 +189,7 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
 
         for b in bs[1..].iter() {
             let s = Self::affine(&Self::add(&r, &r));
-            f = f.pow(2_u16) * (Self::line(&r, &r, &q) / Self::line(&s, &Self::neg(&s), &q));
+            f = f.pow(2_u16) * (Self::line(&r, &r, &q) / Self::line(&s, &Self::neg(&s), &q)).unwrap();
             r = s;
 
             if *b == Self::UIntOrders::from(1) {
@@ -197,7 +197,7 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
                 if s != Self::neutral_element() {
                     s = Self::affine(&s);
                 }
-                f = f * (Self::line(&r, &p, &q) / Self::line(&s, &Self::neg(&s), &q));
+                f = f * (Self::line(&r, &p, &q) / Self::line(&s, &Self::neg(&s), &q)).unwrap();
                 r = s;
             }
         }
@@ -217,7 +217,7 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
             let numerator = Self::miller(p, q);
             let denominator = Self::miller(q, p);
             let result = numerator / denominator;
-            -result
+            -result.unwrap()
         }
     }
 

--- a/math/src/elliptic_curve/short_weierstrass/traits.rs
+++ b/math/src/elliptic_curve/short_weierstrass/traits.rs
@@ -66,7 +66,7 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
             "The point at infinity is not affine."
         );
         let (x, y, z) = (&p[0], &p[1], &p[2]);
-        [(x / z).unwrap(), (y / z).unwrap(), FieldElement::one()]
+        [x / z, y / z, FieldElement::one()]
     }
 
     /// Returns the sum of projective points `p` and `q`
@@ -148,7 +148,7 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
                 qx - px
             } else {
                 let l = (ry - py) / (rx - px);
-                qy - py - l.unwrap() * (qx - px)
+                qy - py - l * (qx - px)
             }
         } else {
             let numerator = FieldElement::from(3) * &px.pow(2_u16) + Self::a();
@@ -157,7 +157,7 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
                 qx - px
             } else {
                 let l = numerator / denominator;
-                qy - py - l.unwrap() * (qx - px)
+                qy - py - l * (qx - px)
             }
         }
     }
@@ -189,7 +189,7 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
 
         for b in bs[1..].iter() {
             let s = Self::affine(&Self::add(&r, &r));
-            f = f.pow(2_u16) * (Self::line(&r, &r, &q) / Self::line(&s, &Self::neg(&s), &q)).unwrap();
+            f = f.pow(2_u16) * Self::line(&r, &r, &q) / Self::line(&s, &Self::neg(&s), &q);
             r = s;
 
             if *b == Self::UIntOrders::from(1) {
@@ -197,7 +197,7 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
                 if s != Self::neutral_element() {
                     s = Self::affine(&s);
                 }
-                f = f * (Self::line(&r, &p, &q) / Self::line(&s, &Self::neg(&s), &q)).unwrap();
+                f = f * Self::line(&r, &p, &q) / Self::line(&s, &Self::neg(&s), &q);
                 r = s;
             }
         }
@@ -217,7 +217,7 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
             let numerator = Self::miller(p, q);
             let denominator = Self::miller(q, p);
             let result = numerator / denominator;
-            -result.unwrap()
+            -result
         }
     }
 

--- a/math/src/fft/errors.rs
+++ b/math/src/fft/errors.rs
@@ -1,9 +1,13 @@
 use thiserror::Error;
 
+use crate::field::errors::FieldError;
+
 #[derive(Debug, Error)]
 pub enum FFTError {
     #[error("The order of the polynomial is not correct")]
     InvalidOrder(String),
     #[error("Could not calculate {1} root of unity")]
     RootOfUnityError(String, u64),
+    #[error("Field error occurred: {0}")]
+    FieldError(FieldError),
 }

--- a/math/src/fft/fft_cooley_tukey.rs
+++ b/math/src/fft/fft_cooley_tukey.rs
@@ -50,10 +50,10 @@ pub fn inverse_cooley_tukey<F: IsField>(
 ) -> Vec<FieldElement<F>> {
     let n = evaluations.len();
     let inverse_n = FieldElement::from(n as u64).inv();
-    let inverse_omega = omega.inv();
+    let inverse_omega = omega.inv().unwrap();
     cooley_tukey(evaluations, &inverse_omega)
         .iter()
-        .map(|coeff| coeff * &inverse_n)
+        .map(|coeff| coeff * inverse_n.as_ref().unwrap())
         .collect()
 }
 

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -203,11 +203,12 @@ impl<F> Div<&FieldElement<F>> for &FieldElement<F>
 where
     F: IsField,
 {
-    type Output = Result<FieldElement<F>, FieldError>;
+    type Output = FieldElement<F>;
 
-    fn div(self, rhs: &FieldElement<F>) -> Result<FieldElement<F>, FieldError> {
-        let value = F::div(&self.value, &rhs.value)?;
-        Ok(FieldElement { value })
+    fn div(self, rhs: &FieldElement<F>) -> Self::Output {
+        Self::Output {
+            value: F::div(&self.value, &rhs.value),
+        }
     }
 }
 
@@ -215,7 +216,7 @@ impl<F> Div<FieldElement<F>> for FieldElement<F>
 where
     F: IsField,
 {
-    type Output = Result<FieldElement<F>, FieldError>;
+    type Output = FieldElement<F>;
 
     fn div(self, rhs: FieldElement<F>) -> Self::Output {
         &self / &rhs
@@ -226,7 +227,7 @@ impl<F> Div<&FieldElement<F>> for FieldElement<F>
 where
     F: IsField,
 {
-    type Output =Result<FieldElement<F>, FieldError>;
+    type Output = FieldElement<F>;
 
     fn div(self, rhs: &FieldElement<F>) -> Self::Output {
         &self / rhs
@@ -237,7 +238,7 @@ impl<F> Div<FieldElement<F>> for &FieldElement<F>
 where
     F: IsField,
 {
-    type Output = Result<FieldElement<F>, FieldError>;
+    type Output = FieldElement<F>;
 
     fn div(self, rhs: FieldElement<F>) -> Self::Output {
         self / &rhs

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -1,5 +1,6 @@
 use crate::field::traits::IsField;
 use crate::unsigned_integer::traits::IsUnsignedInteger;
+use crate::field::errors::FieldError;
 use std::fmt::Debug;
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
@@ -202,12 +203,11 @@ impl<F> Div<&FieldElement<F>> for &FieldElement<F>
 where
     F: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = Result<FieldElement<F>, FieldError>;
 
-    fn div(self, rhs: &FieldElement<F>) -> Self::Output {
-        Self::Output {
-            value: F::div(&self.value, &rhs.value),
-        }
+    fn div(self, rhs: &FieldElement<F>) -> Result<FieldElement<F>, FieldError> {
+        let value = F::div(&self.value, &rhs.value)?;
+        Ok(FieldElement { value })
     }
 }
 
@@ -215,7 +215,7 @@ impl<F> Div<FieldElement<F>> for FieldElement<F>
 where
     F: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = Result<FieldElement<F>, FieldError>;
 
     fn div(self, rhs: FieldElement<F>) -> Self::Output {
         &self / &rhs
@@ -226,7 +226,7 @@ impl<F> Div<&FieldElement<F>> for FieldElement<F>
 where
     F: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output =Result<FieldElement<F>, FieldError>;
 
     fn div(self, rhs: &FieldElement<F>) -> Self::Output {
         &self / rhs
@@ -237,7 +237,7 @@ impl<F> Div<FieldElement<F>> for &FieldElement<F>
 where
     F: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = Result<FieldElement<F>, FieldError>;
 
     fn div(self, rhs: FieldElement<F>) -> Self::Output {
         self / &rhs
@@ -289,10 +289,10 @@ where
     }
 
     /// Returns the multiplicative inverse of `self`
-    pub fn inv(&self) -> Self {
-        Self {
-            value: F::inv(&self.value),
-        }
+    pub fn inv(&self) -> Result<Self, FieldError> {
+        let value = F::inv(&self.value)?;
+        Ok(Self {value})
+        
     }
 
     /// Returns `self` raised to the power of `exponent`

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -85,9 +85,11 @@ where
     fn div(
         a: &[FieldElement<Q::BaseField>; 3],
         b: &[FieldElement<Q::BaseField>; 3],
-    ) -> Result<[FieldElement<Q::BaseField>; 3], FieldError> {
-        let inv_b = Self::inv(b)?;
-        Ok(Self::mul(a, &inv_b))
+    ) -> [FieldElement<Q::BaseField>; 3] {
+        match Self::inv(b) {
+            Ok(inv_b) => Self::mul(a, &inv_b),
+            Err(FieldError::DivisionByZero) => panic!("Division by zero!"),
+        }
     }
 
     /// Returns a boolean indicating whether `a` and `b` are equal component wise.
@@ -208,7 +210,7 @@ mod tests {
         let b = FEE::new([-FE::new(2), FE::new(8), FE::new(5)]);
         let expected_result = FEE::new([FE::new(12), FE::new(6), FE::new(1)]);
         let actual_result = a / b;
-        assert_eq!(actual_result.unwrap(), expected_result);
+        assert_eq!(actual_result, expected_result);
     }
 
     #[test]
@@ -217,7 +219,7 @@ mod tests {
         let b = FEE::new([-FE::new(4), FE::new(2), FE::new(2)]);
         let expected_result = FEE::new([FE::new(3), FE::new(8), FE::new(11)]);
         let actual_result = a / b;
-        assert_eq!(actual_result.unwrap(), expected_result);
+        assert_eq!(actual_result, expected_result);
     }
 
     #[test]

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -86,10 +86,8 @@ where
         a: &[FieldElement<Q::BaseField>; 3],
         b: &[FieldElement<Q::BaseField>; 3],
     ) -> [FieldElement<Q::BaseField>; 3] {
-        match Self::inv(b) {
-            Ok(inv_b) => Self::mul(a, &inv_b),
-            Err(FieldError::DivisionByZero) => panic!("Division by zero!"),
-        }
+        let inv_b = Self::inv(b).expect("Division by zero!");
+        Self::mul(a, &inv_b)
     }
 
     /// Returns a boolean indicating whether `a` and `b` are equal component wise.

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -75,9 +75,11 @@ where
     fn div(
         a: &[FieldElement<Q::BaseField>; 2],
         b: &[FieldElement<Q::BaseField>; 2],
-    ) -> Result<[FieldElement<Q::BaseField>; 2], FieldError> {
-        let inv_b = Self::inv(b)?;
-        Ok(Self::mul(a, &inv_b))
+    ) -> [FieldElement<Q::BaseField>; 2] {
+        match Self::inv(b) {
+            Ok(inv_b) => Self::mul(a, &inv_b),
+            Err(FieldError::DivisionByZero) => panic!("Division by zero!"),
+        }
     }
 
     /// Returns a boolean indicating whether `a` and `b` are equal component wise.
@@ -186,7 +188,7 @@ mod tests {
         let b = FEE::new([-FE::new(2), FE::new(8)]);
         let expected_result = FEE::new([FE::new(42), FE::new(19)]);
         let actual_result = a / b;
-        assert_eq!(actual_result.unwrap(), expected_result);
+        assert_eq!(actual_result, expected_result);
     }
 
     #[test]
@@ -195,7 +197,7 @@ mod tests {
         let b = FEE::new([-FE::new(4), FE::new(2)]);
         let expected_result = FEE::new([FE::new(4), FE::new(45)]);
         let actual_result = a / b;
-        assert_eq!(actual_result.unwrap(), expected_result);
+        assert_eq!(actual_result, expected_result);
     }
 
     #[test]

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -1,4 +1,5 @@
 use crate::field::element::FieldElement;
+use crate::field::errors::FieldError;
 use crate::field::traits::IsField;
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -65,17 +66,18 @@ where
 
     /// Returns the multiplicative inverse of `a`
     /// This uses the equality `(a0 + a1 * t) * (a0 - a1 * t) = a0.pow(2) - a1.pow(2) * Q::residue()`
-    fn inv(a: &[FieldElement<Q::BaseField>; 2]) -> [FieldElement<Q::BaseField>; 2] {
-        let inv_norm = (a[0].pow(2_u64) - Q::residue() * a[1].pow(2_u64)).inv();
-        [&a[0] * &inv_norm, -&a[1] * inv_norm]
+    fn inv(a: &[FieldElement<Q::BaseField>; 2]) -> Result<[FieldElement<Q::BaseField>; 2], FieldError> {
+        let inv_norm = (a[0].pow(2_u64) - Q::residue() * a[1].pow(2_u64)).inv()?;
+        Ok([&a[0] * &inv_norm, -&a[1] * inv_norm])
     }
 
     /// Returns the division of `a` and `b`
     fn div(
         a: &[FieldElement<Q::BaseField>; 2],
         b: &[FieldElement<Q::BaseField>; 2],
-    ) -> [FieldElement<Q::BaseField>; 2] {
-        Self::mul(a, &Self::inv(b))
+    ) -> Result<[FieldElement<Q::BaseField>; 2], FieldError> {
+        let inv_b = Self::inv(b)?;
+        Ok(Self::mul(a, &inv_b))
     }
 
     /// Returns a boolean indicating whether `a` and `b` are equal component wise.
@@ -183,7 +185,8 @@ mod tests {
         let a = FEE::new([FE::new(0), FE::new(3)]);
         let b = FEE::new([-FE::new(2), FE::new(8)]);
         let expected_result = FEE::new([FE::new(42), FE::new(19)]);
-        assert_eq!(a / b, expected_result);
+        let actual_result = a / b;
+        assert_eq!(actual_result.unwrap(), expected_result);
     }
 
     #[test]
@@ -191,7 +194,8 @@ mod tests {
         let a = FEE::new([FE::new(12), FE::new(5)]);
         let b = FEE::new([-FE::new(4), FE::new(2)]);
         let expected_result = FEE::new([FE::new(4), FE::new(45)]);
-        assert_eq!(a / b, expected_result);
+        let actual_result = a / b;
+        assert_eq!(actual_result.unwrap(), expected_result);
     }
 
     #[test]
@@ -214,13 +218,13 @@ mod tests {
     fn test_inv_1() {
         let a = FEE::new([FE::new(0), FE::new(3)]);
         let expected_result = FEE::new([FE::new(0), FE::new(39)]);
-        assert_eq!(a.inv(), expected_result);
+        assert_eq!(a.inv().unwrap(), expected_result);
     }
 
     #[test]
     fn test_inv() {
         let a = FEE::new([FE::new(12), FE::new(5)]);
         let expected_result = FEE::new([FE::new(28), FE::new(8)]);
-        assert_eq!(a.inv(), expected_result);
+        assert_eq!(a.inv().unwrap(), expected_result);
     }
 }

--- a/math/src/field/fields/u384_prime_field.rs
+++ b/math/src/field/fields/u384_prime_field.rs
@@ -76,9 +76,11 @@ where
         Ok(Self::pow(a, C::MODULUS - Self::BaseType::from_u64(2)))
     }
 
-    fn div(a: &Self::BaseType, b: &Self::BaseType) -> Result<Self::BaseType, FieldError> {
-        let inv_b = Self::inv(b)?;
-        Ok(Self::mul(a, &inv_b))
+    fn div(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        match Self::inv(b) {
+            Ok(b_inv) => Self::mul(a, &b_inv),
+            Err(FieldError::DivisionByZero) => panic!("Division by zero"),
+        }
     }
 
     fn eq(a: &Self::BaseType, b: &Self::BaseType) -> bool {
@@ -212,15 +214,22 @@ mod tests {
         let expected = F23Element::from(2);
         let actual = F23Element::from(2) / F23Element::from(1);
 
-        assert_eq!(actual.unwrap(), expected);
+        assert_eq!(actual, expected);
     }
+
+    #[test]
+    #[should_panic]
+    fn div_2_0() {
+        let _actual = F23Element::from(2) / F23Element::from(0);
+    }
+
 
     #[test]
     fn div_4_2() {
         let expected = F23Element::from(2);
         let actual = F23Element::from(4) / F23Element::from(2);
 
-        assert_eq!(actual.unwrap(), expected);
+        assert_eq!(actual, expected);
     }
 
     #[test]
@@ -230,7 +239,7 @@ mod tests {
         let c = F23Element::from(3);
         let actual_result = a / b;
         assert_eq!(
-            actual_result.unwrap() * c,
+            actual_result * c,
             F23Element::from(4)
         )
     }

--- a/math/src/field/fields/u384_prime_field.rs
+++ b/math/src/field/fields/u384_prime_field.rs
@@ -71,16 +71,13 @@ where
     fn inv(a: &Self::BaseType) -> Result<Self::BaseType, FieldError> {
         if a == &Self::ZERO {
             return Err(FieldError::DivisionByZero);
-            // panic!("Division by zero error.")
         }
         Ok(Self::pow(a, C::MODULUS - Self::BaseType::from_u64(2)))
     }
 
     fn div(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
-        match Self::inv(b) {
-            Ok(b_inv) => Self::mul(a, &b_inv),
-            Err(FieldError::DivisionByZero) => panic!("Division by zero"),
-        }
+        let inv_b = Self::inv(b).expect("Division by zero!");
+        Self::mul(a, &inv_b)
     }
 
     fn eq(a: &Self::BaseType, b: &Self::BaseType) -> bool {

--- a/math/src/field/fields/u384_prime_field.rs
+++ b/math/src/field/fields/u384_prime_field.rs
@@ -109,7 +109,6 @@ mod tests {
         field::errors::FieldError,
     };
 
-
     use super::{IsMontgomeryConfiguration, MontgomeryBackendPrimeField};
 
     // F23

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -28,9 +28,11 @@ impl<const MODULUS: u64> IsField for U64PrimeField<MODULUS> {
         ((*a as u128 * *b as u128) % MODULUS as u128) as u64
     }
 
-    fn div(a: &u64, b: &u64) -> Result<u64, FieldError> {
-        let inv_b = Self::inv(b)?;
-        Ok(Self::mul(a, &inv_b))
+    fn div(a: &u64, b: &u64) -> u64 {
+        match Self::inv(b) {
+            Ok(b_inv) => Self::mul(a, &b_inv),
+            Err(FieldError::DivisionByZero) => panic!("Division by zero"),
+        }
     }
 
     fn inv(a: &u64) -> Result<u64, FieldError> {
@@ -169,7 +171,13 @@ mod tests {
         let expected = FE::new(2);
         let actual = FE::new(2) / FE::new(1);
 
-        assert_eq!(actual.unwrap(), expected);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    #[should_panic]
+    fn div_2_0() {
+        let _actual = FE::new(2) / FE::new(0);
     }
 
     #[test]
@@ -177,7 +185,7 @@ mod tests {
         let expected = FE::new(2);
         let actual = FE::new(4) / FE::new(2);
 
-        assert_eq!(actual.unwrap(), expected);
+        assert_eq!(actual, expected);
         
     }
 
@@ -187,7 +195,7 @@ mod tests {
         let b = FE::new(3);
         let c = FE::new(3);
         let actual_result = a / b;
-        assert_eq!(actual_result.unwrap() * c, FE::new(4))
+        assert_eq!(actual_result * c, FE::new(4))
     }
 
     #[test]

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -29,10 +29,8 @@ impl<const MODULUS: u64> IsField for U64PrimeField<MODULUS> {
     }
 
     fn div(a: &u64, b: &u64) -> u64 {
-        match Self::inv(b) {
-            Ok(b_inv) => Self::mul(a, &b_inv),
-            Err(FieldError::DivisionByZero) => panic!("Division by zero"),
-        }
+        let inv_b = Self::inv(b).expect("Division by zero!");
+        Self::mul(a, &inv_b)
     }
 
     fn inv(a: &u64) -> Result<u64, FieldError> {

--- a/math/src/field/mod.rs
+++ b/math/src/field/mod.rs
@@ -8,3 +8,5 @@ pub mod fields;
 pub(crate) mod test_fields;
 /// Common behaviour for field elements.
 pub mod traits;
+// Implementation of errors
+pub mod errors;

--- a/math/src/field/test_fields/u64_test_field.rs
+++ b/math/src/field/test_fields/u64_test_field.rs
@@ -24,10 +24,8 @@ impl<const MODULUS: u64> IsField for U64TestField<MODULUS> {
     }
 
     fn div(a: &u64, b: &u64) -> u64 {
-        match Self::inv(b) {
-            Ok(b_inv) => Self::mul(a, &b_inv),
-            Err(FieldError::DivisionByZero) => panic!("Division by zero"),
-        }
+        let inv_b = Self::inv(b).expect("Division by zero!");
+        Self::mul(a, &inv_b)
     }
 
     fn inv(a: &u64) -> Result<u64, FieldError> {

--- a/math/src/field/test_fields/u64_test_field.rs
+++ b/math/src/field/test_fields/u64_test_field.rs
@@ -1,4 +1,5 @@
 use crate::field::traits::{IsField, IsTwoAdicField};
+use crate::field::errors::FieldError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct U64TestField<const MODULUS: u64>;
@@ -22,13 +23,16 @@ impl<const MODULUS: u64> IsField for U64TestField<MODULUS> {
         ((*a as u128 * *b as u128) % MODULUS as u128) as u64
     }
 
-    fn div(a: &u64, b: &u64) -> u64 {
-        Self::mul(a, &Self::inv(b))
+    fn div(a: &u64, b: &u64) -> Result<u64, FieldError> {
+        let inv_b = Self::inv(b)?;
+        Ok(Self::mul(a, &inv_b))
     }
 
-    fn inv(a: &u64) -> u64 {
-        assert_ne!(*a, 0, "Cannot invert zero element");
-        Self::pow(a, MODULUS - 2)
+    fn inv(a: &u64) -> Result<u64, FieldError> {
+        if *a == 0 {
+            return Err(FieldError::DivisionByZero);
+        }
+        Ok(Self::pow(a, MODULUS - 2))
     }
 
     fn eq(a: &u64, b: &u64) -> bool {

--- a/math/src/field/test_fields/u64_test_field.rs
+++ b/math/src/field/test_fields/u64_test_field.rs
@@ -23,9 +23,11 @@ impl<const MODULUS: u64> IsField for U64TestField<MODULUS> {
         ((*a as u128 * *b as u128) % MODULUS as u128) as u64
     }
 
-    fn div(a: &u64, b: &u64) -> Result<u64, FieldError> {
-        let inv_b = Self::inv(b)?;
-        Ok(Self::mul(a, &inv_b))
+    fn div(a: &u64, b: &u64) -> u64 {
+        match Self::inv(b) {
+            Ok(b_inv) => Self::mul(a, &b_inv),
+            Err(FieldError::DivisionByZero) => panic!("Division by zero"),
+        }
     }
 
     fn inv(a: &u64) -> Result<u64, FieldError> {

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -77,7 +77,7 @@ pub trait IsField: Debug + Clone {
     fn inv(a: &Self::BaseType) -> Result<Self::BaseType, FieldError>;
 
     /// Returns the division of `a` and `b`.
-    fn div(a: &Self::BaseType, b: &Self::BaseType) -> Result<Self::BaseType, FieldError>;
+    fn div(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType;
 
     /// Returns a boolean indicating whether `a` and `b` are equal or not.
     fn eq(a: &Self::BaseType, b: &Self::BaseType) -> bool;

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -2,6 +2,7 @@ use crate::{fft::errors::FFTError, unsigned_integer::traits::IsUnsignedInteger};
 use std::fmt::Debug;
 
 use super::element::FieldElement;
+use super::errors::FieldError;
 
 /// Trait to define necessary parameters for FFT-friendly Fields.
 /// Two-Adic fields are ones whose order is of the form  $2^n k + 1$.
@@ -73,10 +74,10 @@ pub trait IsField: Debug + Clone {
     fn neg(a: &Self::BaseType) -> Self::BaseType;
 
     /// Returns the multiplicative inverse of `a`.
-    fn inv(a: &Self::BaseType) -> Self::BaseType;
+    fn inv(a: &Self::BaseType) -> Result<Self::BaseType, FieldError>;
 
     /// Returns the division of `a` and `b`.
-    fn div(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType;
+    fn div(a: &Self::BaseType, b: &Self::BaseType) -> Result<Self::BaseType, FieldError>;
 
     /// Returns a boolean indicating whether `a` and `b` are equal or not.
     fn eq(a: &Self::BaseType, b: &Self::BaseType) -> bool;

--- a/math/src/polynomial.rs
+++ b/math/src/polynomial.rs
@@ -42,7 +42,7 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
             let mut y_term = Polynomial::new(&[y.clone()]);
             for (j, x) in xs.iter().enumerate() {
                 if i != j {
-                    let denominator = Polynomial::new(&[(FieldElement::one() / (&xs[i] - x)).unwrap()]);
+                    let denominator = Polynomial::new(&[FieldElement::one() / (&xs[i] - x)]);
                     let numerator = Polynomial::new(&[-x, FieldElement::one()]);
                     y_term = y_term.mul_with_ref(&(numerator * denominator));
                 }
@@ -114,7 +114,7 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
             let mut n = self;
             let mut q: Vec<FieldElement<F>> = vec![FieldElement::zero(); n.degree() + 1];
             while n != Polynomial::zero() && n.degree() >= dividend.degree() {
-                let new_coefficient = (n.leading_coefficient() / dividend.leading_coefficient()).unwrap();
+                let new_coefficient = n.leading_coefficient() / dividend.leading_coefficient();
                 q[n.degree() - dividend.degree()] = new_coefficient.clone();
                 let d = dividend.mul_with_ref(&Polynomial::new_monomial(
                     new_coefficient,
@@ -433,11 +433,11 @@ mod tests {
 
     #[test]
     fn simple_interpolating_polynomial_by_hand_works() {
-        let denominator = Polynomial::new(&[(FE::new(1) / (FE::new(2) - FE::new(4))).unwrap()]);
+        let denominator = Polynomial::new(&[FE::new(1) / (FE::new(2) - FE::new(4))]);
         let numerator = Polynomial::new(&[-FE::new(4), FE::new(1)]);
         let interpolating = numerator * denominator;
         assert_eq!(
-            (FE::new(2) - FE::new(4)) * ((FE::new(1) / (FE::new(2) - FE::new(4))).unwrap()),
+            (FE::new(2) - FE::new(4)) * (FE::new(1) / (FE::new(2) - FE::new(4))),
             FE::new(1)
         );
         assert_eq!(interpolating.evaluate(&FE::new(2)), FE::new(1));

--- a/math/src/polynomial.rs
+++ b/math/src/polynomial.rs
@@ -42,7 +42,7 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
             let mut y_term = Polynomial::new(&[y.clone()]);
             for (j, x) in xs.iter().enumerate() {
                 if i != j {
-                    let denominator = Polynomial::new(&[FieldElement::one() / (&xs[i] - x)]);
+                    let denominator = Polynomial::new(&[(FieldElement::one() / (&xs[i] - x)).unwrap()]);
                     let numerator = Polynomial::new(&[-x, FieldElement::one()]);
                     y_term = y_term.mul_with_ref(&(numerator * denominator));
                 }
@@ -114,7 +114,7 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
             let mut n = self;
             let mut q: Vec<FieldElement<F>> = vec![FieldElement::zero(); n.degree() + 1];
             while n != Polynomial::zero() && n.degree() >= dividend.degree() {
-                let new_coefficient = n.leading_coefficient() / dividend.leading_coefficient();
+                let new_coefficient = (n.leading_coefficient() / dividend.leading_coefficient()).unwrap();
                 q[n.degree() - dividend.degree()] = new_coefficient.clone();
                 let d = dividend.mul_with_ref(&Polynomial::new_monomial(
                     new_coefficient,
@@ -433,11 +433,11 @@ mod tests {
 
     #[test]
     fn simple_interpolating_polynomial_by_hand_works() {
-        let denominator = Polynomial::new(&[FE::new(1) / (FE::new(2) - FE::new(4))]);
+        let denominator = Polynomial::new(&[(FE::new(1) / (FE::new(2) - FE::new(4))).unwrap()]);
         let numerator = Polynomial::new(&[-FE::new(4), FE::new(1)]);
         let interpolating = numerator * denominator;
         assert_eq!(
-            (FE::new(2) - FE::new(4)) * (FE::new(1) / (FE::new(2) - FE::new(4))),
+            (FE::new(2) - FE::new(4)) * ((FE::new(1) / (FE::new(2) - FE::new(4))).unwrap()),
             FE::new(1)
         );
         assert_eq!(interpolating.evaluate(&FE::new(2)), FE::new(1));


### PR DESCRIPTION
I removed the `panics` in the inv methods and returned the `DivisionByZero` error, this PR is related to [#77](https://github.com/lambdaclass/lambdaworks/issues/77) issue.