### PR TITLE
Added Hash trait to U64PrimeField and FieldElement

### DIFF
--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -1,7 +1,10 @@
 use crate::field::traits::IsField;
 use crate::unsigned_integer::traits::IsUnsignedInteger;
-use std::{fmt::Debug, hash::{Hash, Hasher}};
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
+use std::{
+    fmt::Debug,
+    hash::{Hash, Hasher},
+};
 
 /// A field element with operations algorithms defined in `F`
 #[derive(Debug, Clone)]
@@ -46,7 +49,10 @@ where
 
 impl<F> Eq for FieldElement<F> where F: IsField {}
 
-impl<F> Hash for FieldElement<F> where F: IsField {
+impl<F> Hash for FieldElement<F>
+where
+    F: IsField,
+{
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.value.hash(state);
     }

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 /// A field element with operations algorithms defined in `F`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub struct FieldElement<F: IsField> {
     value: F::BaseType,
 }

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -1,10 +1,10 @@
 use crate::field::traits::IsField;
 use crate::unsigned_integer::traits::IsUnsignedInteger;
-use std::fmt::Debug;
+use std::{fmt::Debug, hash::{Hash, Hasher}};
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 /// A field element with operations algorithms defined in `F`
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone)]
 pub struct FieldElement<F: IsField> {
     value: F::BaseType,
 }
@@ -45,6 +45,12 @@ where
 }
 
 impl<F> Eq for FieldElement<F> where F: IsField {}
+
+impl<F> Hash for FieldElement<F> where F: IsField {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
+}
 
 /// Addition operator overloading for field elements
 impl<F> Add<&FieldElement<F>> for &FieldElement<F>

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -5,7 +5,7 @@ use crate::field::traits::IsField;
 use crate::traits::ByteConversion;
 
 /// Type representing prime fields over unsigned 64-bit integers.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct U64PrimeField<const MODULUS: u64>;
 pub type U64FieldElement<const MODULUS: u64> = FieldElement<U64PrimeField<MODULUS>>;
 

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -1,5 +1,5 @@
 use crate::{fft::errors::FFTError, unsigned_integer::traits::IsUnsignedInteger};
-use std::fmt::Debug;
+use std::{fmt::Debug, hash::Hash};
 
 use super::element::FieldElement;
 
@@ -40,7 +40,7 @@ pub trait IsTwoAdicField: IsField {
 /// Trait to add field behaviour to a struct.
 pub trait IsField: Debug + Clone {
     /// The underlying base type for representing elements from the field.
-    type BaseType: Clone + Debug;
+    type BaseType: Clone + Debug + Hash;
 
     /// Returns the sum of `a` and `b`.
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType;

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -15,7 +15,7 @@ pub type U256 = UnsignedInteger<4>;
 /// The most significant bit is in the left-most position.
 /// That is, the array `[a_n, ..., a_0]` represents the
 /// integer 2^{64 * n} * a_n + ... + 2^{64} * a_1 + a_0.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UnsignedInteger<const NUM_LIMBS: usize> {
     pub limbs: [u64; NUM_LIMBS],
 }


### PR DESCRIPTION
# Added Hash trait to U64PrimeField and FieldElement

## Description

This improvement allows to hash FieldElements, eg. to put it into a HashSet

## Type of change

- [x] Optimization
