### PR TITLE
Fix from base type for FieldElement

### DIFF
--- a/crypto/src/merkle_tree/utils.rs
+++ b/crypto/src/merkle_tree/utils.rs
@@ -106,7 +106,7 @@ mod tests {
         let hashed_leaves = complete_until_power_of_two(&mut values);
 
         let mut expected_leaves = (1..6).map(FE::new).collect::<Vec<FE>>();
-        expected_leaves.extend(&[FE::new(5); 3]);
+        expected_leaves.extend([FE::new(5); 3]);
 
         for (leaf, expected_leaves) in hashed_leaves.iter().zip(expected_leaves) {
             assert_eq!(*leaf, expected_leaves);

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -20,7 +20,7 @@ where
 {
     fn from(value: &F::BaseType) -> Self {
         Self {
-            value: value.clone(),
+            value: F::from_base_type(value.clone()),
         }
     }
 }

--- a/math/src/field/fields/u384_prime_field.rs
+++ b/math/src/field/fields/u384_prime_field.rs
@@ -149,6 +149,13 @@ mod tests {
     type F23Element = FieldElement<F23>;
 
     #[test]
+    fn from_base_type_works() {
+        let x = F23Element::from(&U384::from_u64(1));
+        let expected_value = U384::from_u64(12);
+        assert_eq!(x.value(), &expected_value);
+    }
+
+    #[test]
     fn montgomery_backend_multiplication_works_0() {
         let x = F23Element::from(11_u64);
         let y = F23Element::from(10_u64);


### PR DESCRIPTION
# Fix from base type for FieldElement

## Description
This PR fixes a constrctor for FieldElement. The implementation of `From<&BaseType>` should call `from_base_type`.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
