### PR TITLE
Make sure two addicity params are only used for the appropriate modulus.

### DIFF
--- a/math/src/fft/operations.rs
+++ b/math/src/fft/operations.rs
@@ -41,8 +41,7 @@ mod fft_test {
 
     use super::*;
 
-    const MODULUS: u64 = 0xFFFFFFFF00000001;
-    type F = U64TestField<MODULUS>;
+    type F = U64TestField;
     type FE = FieldElement<F>;
 
     prop_compose! {
@@ -56,7 +55,7 @@ mod fft_test {
         }
     }
     prop_compose! {
-        fn offset()(num in 1..MODULUS - 1) -> FE { FE::from(num) }
+        fn offset()(num in 1..F::neg(&1)) -> FE { FE::from(num) }
     }
     prop_compose! {
         fn field_vec(max_exp: u8)(elem in field_element(), size in powers_of_two(max_exp)) -> Vec<FE> {

--- a/math/src/field/test_fields/u64_test_field.rs
+++ b/math/src/field/test_fields/u64_test_field.rs
@@ -1,9 +1,9 @@
 use crate::field::traits::{IsField, IsTwoAdicField};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct U64TestField<const MODULUS: u64>;
+pub struct U64Field<const MODULUS: u64>;
 
-impl<const MODULUS: u64> IsField for U64TestField<MODULUS> {
+impl<const MODULUS: u64> IsField for U64Field<MODULUS> {
     type BaseType = u64;
 
     fn add(a: &u64, b: &u64) -> u64 {
@@ -52,7 +52,10 @@ impl<const MODULUS: u64> IsField for U64TestField<MODULUS> {
     }
 }
 
-impl<const MODULUS: u64> IsTwoAdicField for U64TestField<MODULUS> {
+pub type U64TestField = U64Field<18446744069414584321>;
+
+// These params correspond to the 18446744069414584321 modulus.
+impl IsTwoAdicField for U64TestField {
     const TWO_ADICITY: u64 = 32;
     const TWO_ADIC_PRIMITVE_ROOT_OF_UNITY: u64 = 1753635133440165772;
     const GENERATOR: u64 = 7;


### PR DESCRIPTION
## Description
Make sure two addicity params are only used for the appropriate modulus, before this change, one could create a test field with a different modulus that would still retain the same two addicity params, thus giving wrong results.
