### PR TITLE
Only require approvals from `@lambdaclass/zk_research_and_development`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @lambdaclass/zk_research_and_development @schouhy @ajgara
+*       @lambdaclass/zk_research_and_development


### PR DESCRIPTION
## Description
Let's add @schouhy and @ajgara to the zk_research_and_development, otherwise we will need approvals from the group and both of them.
