### PR TITLE
Add prime field trait

### DIFF
--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -7,6 +7,8 @@ use std::{
     hash::{Hash, Hasher},
 };
 
+use super::traits::IsPrimeField;
+
 /// A field element with operations algorithms defined in `F`
 #[derive(Debug, Clone)]
 pub struct FieldElement<F: IsField> {
@@ -311,11 +313,6 @@ where
         &self.value
     }
 
-    // Returns the representative of the value stored
-    pub fn representative(&self) -> F::BaseType {
-        F::representative(self.value.clone())
-    }
-
     /// Returns the multiplicative inverse of `self`
     pub fn inv(&self) -> Self {
         Self {
@@ -341,5 +338,12 @@ where
     /// Returns the additive neutral element of the field.
     pub fn zero() -> Self {
         Self { value: F::zero() }
+    }
+}
+
+impl<F: IsPrimeField> FieldElement<F> {
+    // Returns the representative of the value stored
+    pub fn representative(&self) -> F::RepresentativeType {
+        F::representative(self.value.clone())
     }
 }

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -1,4 +1,6 @@
 use crate::field::traits::IsField;
+use crate::unsigned_integer::element::UnsignedInteger;
+use crate::unsigned_integer::montgomery::MontgomeryAlgorithms;
 use crate::unsigned_integer::traits::IsUnsignedInteger;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
@@ -7,6 +9,9 @@ use std::{
     hash::{Hash, Hasher},
 };
 
+use super::fields::montgomery_backed_prime_fields::{
+    IsMontgomeryConfiguration, MontgomeryBackendPrimeField,
+};
 use super::traits::IsPrimeField;
 
 /// A field element with operations algorithms defined in `F`
@@ -345,5 +350,18 @@ impl<F: IsPrimeField> FieldElement<F> {
     // Returns the representative of the value stored
     pub fn representative(&self) -> F::RepresentativeType {
         F::representative(self.value())
+    }
+}
+
+impl<C, const NUM_LIMBS: usize> FieldElement<MontgomeryBackendPrimeField<C, NUM_LIMBS>>
+where
+    C: IsMontgomeryConfiguration<NUM_LIMBS> + Clone + Debug,
+{
+    #[allow(unused)]
+    pub const fn from_hex(hex: &str) -> Self {
+        let integer = UnsignedInteger::<NUM_LIMBS>::from(hex);
+        Self {
+            value: MontgomeryAlgorithms::cios(&integer, &C::R2, &C::MODULUS, &C::MU),
+        }
     }
 }

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -344,6 +344,6 @@ where
 impl<F: IsPrimeField> FieldElement<F> {
     // Returns the representative of the value stored
     pub fn representative(&self) -> F::RepresentativeType {
-        F::representative(self.value.clone())
+        F::representative(self.value())
     }
 }

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -132,10 +132,6 @@ where
     fn from_base_type(x: [FieldElement<Q::BaseField>; 3]) -> [FieldElement<Q::BaseField>; 3] {
         x
     }
-
-    fn representative(_x: Self::BaseType) -> Self::BaseType {
-        todo!()
-    }
 }
 
 #[cfg(test)]

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -115,10 +115,6 @@ where
     fn from_base_type(x: [FieldElement<Q::BaseField>; 2]) -> [FieldElement<Q::BaseField>; 2] {
         x
     }
-
-    fn representative(_x: Self::BaseType) -> Self::BaseType {
-        todo!()
-    }
 }
 
 #[cfg(test)]

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -163,7 +163,6 @@ where
 {
     type RepresentativeType = Self::BaseType;
 
-    // TO DO: Add tests for representatives
     fn representative(x: &Self::BaseType) -> Self::BaseType {
         MontgomeryAlgorithms::cios(x, &UnsignedInteger::from_u64(1), &C::MODULUS, &C::MU)
     }
@@ -779,5 +778,21 @@ mod tests_u256_prime_fields {
             FP2Element::from_bytes_le(&bytes).unwrap().to_bytes_le(),
             bytes
         );
+    }
+
+    #[test]
+    fn creating_a_field_element_from_its_representative_returns_the_same_element_1() {
+        let change = U256::from_u64(1);
+        let f1 = U256FP1Element::new(U256MontgomeryConfigP1::MODULUS + change);
+        let f2 = U256FP1Element::new(f1.representative());
+        assert_eq!(f1, f2);
+    }
+
+    #[test]
+    fn creating_a_field_element_from_its_representative_returns_the_same_element_2() {
+        let change = U256::from_u64(27);
+        let f1 = U256F29Element::new(U256MontgomeryConfiguration29::MODULUS + change);
+        let f2 = U256F29Element::new(f1.representative());
+        assert_eq!(f1, f2);
     }
 }

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -1,4 +1,5 @@
 use crate::field::element::FieldElement;
+use crate::field::traits::IsPrimeField;
 use crate::traits::ByteConversion;
 use crate::{
     field::traits::IsField, unsigned_integer::element::UnsignedInteger,
@@ -154,6 +155,13 @@ where
     fn from_base_type(x: Self::BaseType) -> Self::BaseType {
         MontgomeryAlgorithms::cios(&x, &C::R2, &C::MODULUS, &C::MU)
     }
+}
+
+impl<C, const NUM_LIMBS: usize> IsPrimeField for MontgomeryBackendPrimeField<C, NUM_LIMBS>
+where
+    C: IsMontgomeryConfiguration<NUM_LIMBS> + Clone + Debug,
+{
+    type RepresentativeType = Self::BaseType;
 
     // TO DO: Add tests for representatives
     fn representative(x: Self::BaseType) -> Self::BaseType {

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -795,4 +795,20 @@ mod tests_u256_prime_fields {
         let f2 = U256F29Element::new(f1.representative());
         assert_eq!(f1, f2);
     }
+
+    #[test]
+    fn creating_a_field_element_from_hex_works_1() {
+        let a = U256FP1Element::from_hex("eb235f6144d9e91f4b14");
+        let b = U256FP1Element::new(U256 {
+            limbs: [0, 0, 60195, 6872850209053821716],
+        });
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn creating_a_field_element_from_hex_works() {
+        let a = U256F29Element::from_hex("aa");
+        let b = U256F29Element::from(25);
+        assert_eq!(a, b);
+    }
 }

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -164,8 +164,8 @@ where
     type RepresentativeType = Self::BaseType;
 
     // TO DO: Add tests for representatives
-    fn representative(x: Self::BaseType) -> Self::BaseType {
-        MontgomeryAlgorithms::cios(&x, &UnsignedInteger::from_u64(1), &C::MODULUS, &C::MU)
+    fn representative(x: &Self::BaseType) -> Self::BaseType {
+        MontgomeryAlgorithms::cios(x, &UnsignedInteger::from_u64(1), &C::MODULUS, &C::MU)
     }
 }
 

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -253,4 +253,20 @@ mod tests {
         let bytes = vec![1, 0, 0, 0, 0, 0, 0, 0];
         assert_eq!(FE::from_bytes_le(&bytes).unwrap().to_bytes_le(), bytes);
     }
+
+    #[test]
+    fn creating_a_field_element_from_its_representative_returns_the_same_element_1() {
+        let change = 1;
+        let f1 = FE::new(MODULUS + change);
+        let f2 = FE::new(f1.representative());
+        assert_eq!(f1, f2);
+    }
+
+    #[test]
+    fn creating_a_field_element_from_its_representative_returns_the_same_element_2() {
+        let change = 8;
+        let f1 = FE::new(MODULUS + change);
+        let f2 = FE::new(f1.representative());
+        assert_eq!(f1, f2);
+    }
 }

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -63,8 +63,8 @@ impl<const MODULUS: u64> Copy for U64FieldElement<MODULUS> {}
 impl<const MODULUS: u64> IsPrimeField for U64PrimeField<MODULUS> {
     type RepresentativeType = u64;
 
-    fn representative(x: u64) -> u64 {
-        x
+    fn representative(x: &u64) -> u64 {
+        *x
     }
 }
 

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -1,7 +1,7 @@
 use crate::cyclic_group::IsGroup;
 use crate::errors::ByteConversionError::{FromBEBytesError, FromLEBytesError};
 use crate::field::element::FieldElement;
-use crate::field::traits::IsField;
+use crate::field::traits::{IsField, IsPrimeField};
 use crate::traits::ByteConversion;
 
 /// Type representing prime fields over unsigned 64-bit integers.
@@ -56,13 +56,17 @@ impl<const MODULUS: u64> IsField for U64PrimeField<MODULUS> {
     fn from_base_type(x: u64) -> u64 {
         Self::from_u64(x)
     }
+}
+
+impl<const MODULUS: u64> Copy for U64FieldElement<MODULUS> {}
+
+impl<const MODULUS: u64> IsPrimeField for U64PrimeField<MODULUS> {
+    type RepresentativeType = u64;
 
     fn representative(x: u64) -> u64 {
         x
     }
 }
-
-impl<const MODULUS: u64> Copy for U64FieldElement<MODULUS> {}
 
 /// Represents an element in Fp. (E.g: 0, 1, 2 are the elements of F3)
 impl<const MODULUS: u64> IsGroup for U64FieldElement<MODULUS> {

--- a/math/src/field/test_fields/u64_test_field.rs
+++ b/math/src/field/test_fields/u64_test_field.rs
@@ -1,4 +1,4 @@
-use crate::field::traits::{IsField, IsTwoAdicField};
+use crate::field::traits::{IsField, IsPrimeField, IsTwoAdicField};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct U64TestField<const MODULUS: u64>;
@@ -50,6 +50,10 @@ impl<const MODULUS: u64> IsField for U64TestField<MODULUS> {
     fn from_base_type(x: u64) -> u64 {
         Self::from_u64(x)
     }
+}
+
+impl<const MODULUS: u64> IsPrimeField for U64TestField<MODULUS> {
+    type RepresentativeType = u64;
 
     fn representative(x: u64) -> u64 {
         x

--- a/math/src/field/test_fields/u64_test_field.rs
+++ b/math/src/field/test_fields/u64_test_field.rs
@@ -55,8 +55,8 @@ impl<const MODULUS: u64> IsField for U64TestField<MODULUS> {
 impl<const MODULUS: u64> IsPrimeField for U64TestField<MODULUS> {
     type RepresentativeType = u64;
 
-    fn representative(x: u64) -> u64 {
-        x
+    fn representative(x: &u64) -> u64 {
+        *x
     }
 }
 

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -94,7 +94,11 @@ pub trait IsField: Debug + Clone {
     /// Takes as input an element of BaseType and returns the internal representation
     /// of that element in the field.
     fn from_base_type(x: Self::BaseType) -> Self::BaseType;
+}
+
+pub trait IsPrimeField: IsField {
+    type RepresentativeType: IsUnsignedInteger;
 
     // Returns the representative of the value stored
-    fn representative(a: Self::BaseType) -> Self::BaseType;
+    fn representative(a: Self::BaseType) -> Self::RepresentativeType;
 }

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -100,5 +100,5 @@ pub trait IsPrimeField: IsField {
     type RepresentativeType: IsUnsignedInteger;
 
     // Returns the representative of the value stored
-    fn representative(a: Self::BaseType) -> Self::RepresentativeType;
+    fn representative(a: &Self::BaseType) -> Self::RepresentativeType;
 }


### PR DESCRIPTION
# Add prime field trait

## Description

Add a prime field trait to support getting an integer representative from a field element.

## Type of change
- [x] New feature

## Checklist
- [x] This change requires new documentation.
  - [ ] Documentation has been added/updated.
