### PR TITLE
Refactor MontgomeryConfig to improve usability

### DIFF
--- a/crypto/src/hash/poseidon/mod.rs
+++ b/crypto/src/hash/poseidon/mod.rs
@@ -147,9 +147,7 @@ where
 #[cfg(test)]
 mod tests {
     use lambdaworks_math::{
-        field::fields::montgomery_backed_prime_fields::{
-            IsMontgomeryConfiguration, U384PrimeField,
-        },
+        field::fields::montgomery_backed_prime_fields::{IsModulus, U384PrimeField},
         unsigned_integer::element::U384,
     };
 
@@ -157,7 +155,7 @@ mod tests {
 
     #[derive(Clone, Debug)]
     pub struct TestFieldConfig;
-    impl IsMontgomeryConfiguration<6> for TestFieldConfig {
+    impl IsModulus<U384> for TestFieldConfig {
         const MODULUS: U384 =
             U384::from("2000000000000080000000000000000000000000000000000000000000000001");
     }

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/field_extension.rs
@@ -1,8 +1,6 @@
 use crate::field::{
     element::FieldElement,
-    fields::montgomery_backed_prime_fields::{
-        IsMontgomeryConfiguration, MontgomeryBackendPrimeField,
-    },
+    fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
 };
 use crate::unsigned_integer::element::U384;
 
@@ -11,7 +9,7 @@ pub const BLS12377_PRIME_FIELD_ORDER: U384 = U384::from("1ae3a4617c510eac63b05c0
 // FPBLS12377
 #[derive(Clone, Debug)]
 pub struct BLS12377FieldConfig;
-impl IsMontgomeryConfiguration<6> for BLS12377FieldConfig {
+impl IsModulus<U384> for BLS12377FieldConfig {
     const MODULUS: U384 = BLS12377_PRIME_FIELD_ORDER;
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -4,9 +4,7 @@ use crate::field::{
         cubic::{CubicExtensionField, HasCubicNonResidue},
         quadratic::{HasQuadraticNonResidue, QuadraticExtensionField},
     },
-    fields::montgomery_backed_prime_fields::{
-        IsMontgomeryConfiguration, MontgomeryBackendPrimeField,
-    },
+    fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
 };
 use crate::unsigned_integer::element::U384;
 
@@ -15,7 +13,7 @@ pub const BLS12381_PRIME_FIELD_ORDER: U384 = U384::from("1a0111ea397fe69a4b1ba7b
 // FPBLS12381
 #[derive(Clone, Debug)]
 pub struct BLS12381FieldConfig;
-impl IsMontgomeryConfiguration<6> for BLS12381FieldConfig {
+impl IsModulus<U384> for BLS12381FieldConfig {
     const MODULUS: U384 = BLS12381_PRIME_FIELD_ORDER;
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
@@ -1,7 +1,7 @@
 use crate::elliptic_curve::short_weierstrass::point::ShortWeierstrassProjectivePoint;
 use crate::elliptic_curve::traits::IsEllipticCurve;
 use crate::field::fields::montgomery_backed_prime_fields::{
-    IsMontgomeryConfiguration, MontgomeryBackendPrimeField,
+    IsModulus, MontgomeryBackendPrimeField,
 };
 use crate::unsigned_integer::element::U384;
 use crate::{
@@ -21,7 +21,7 @@ pub const TEST_CURVE_2_MAIN_SUBGROUP_ORDER: U384 = U384::from("40a065fb5a76390de
 // FPBLS12381
 #[derive(Clone, Debug)]
 pub struct TestCurve2MontgomeryConfig;
-impl IsMontgomeryConfiguration<6> for TestCurve2MontgomeryConfig {
+impl IsModulus<U384> for TestCurve2MontgomeryConfig {
     const MODULUS: U384 = TEST_CURVE_2_PRIME_FIELD_ORDER;
 }
 

--- a/proving-system/stark/src/lib.rs
+++ b/proving-system/stark/src/lib.rs
@@ -11,14 +11,14 @@ use lambdaworks_math::polynomial::{self, Polynomial};
 
 use lambdaworks_math::field::element::FieldElement;
 use lambdaworks_math::{
-    field::fields::montgomery_backed_prime_fields::{IsMontgomeryConfiguration, U384PrimeField},
+    field::fields::montgomery_backed_prime_fields::{IsModulus, U384PrimeField},
     unsigned_integer::element::U384,
 };
 
 // DEFINITION OF THE USED FIELD
 #[derive(Clone, Debug)]
 pub struct MontgomeryConfig;
-impl IsMontgomeryConfiguration<6> for MontgomeryConfig {
+impl IsModulus<U384> for MontgomeryConfig {
     const MODULUS: U384 =
         // hex 17
         U384::from("800000000000011000000000000000000000000000000000000000000000001");


### PR DESCRIPTION
# Refactor MontgomeryConfig to improve usability

## Description
This PR refactors IsMontgomeryConfig to pass it the type of the modulus instead of the number of limbs of the corresponding UnsignedInteger. It also renames it to IsModulus and moves R2 and MU precomputed values to MontgomeryBackendPrimeField. The const functions that compute them are also moved to the field.

## Type of change

- [x] Refactor