### PR TITLE
Use two-adic U256 fields for starks

### DIFF
--- a/math/src/field/fields/fft_friendly/u256_two_adic_prime_field.rs
+++ b/math/src/field/fields/fft_friendly/u256_two_adic_prime_field.rs
@@ -13,6 +13,8 @@ impl IsModulus<U256> for U256MontgomeryConfigTwoAdic {
         U256::from("800000000000011000000000000000000000000000000000000000000000001");
 }
 
+pub type U256MontgomeryTwoAdicPrimeField = U256PrimeField<U256MontgomeryConfigTwoAdic>;
+
 impl IsTwoAdicField for U256MontgomeryTwoAdicPrimeField {
     const TWO_ADICITY: u64 = 48;
     // Change this line for a new function like `from_limbs`.
@@ -25,8 +27,6 @@ impl IsTwoAdicField for U256MontgomeryTwoAdicPrimeField {
         ],
     };
 }
-
-pub type U256MontgomeryTwoAdicPrimeField = U256PrimeField<U256MontgomeryConfigTwoAdic>;
 
 #[cfg(test)]
 mod u256_two_adic_prime_field_tests {

--- a/proving-system/stark/src/constraints/boundary.rs
+++ b/proving-system/stark/src/constraints/boundary.rs
@@ -100,7 +100,7 @@ impl<F: IsField> BoundaryConstraints<FieldElement<F>> {
 
 #[cfg(test)]
 mod test {
-    use lambdaworks_math::unsigned_integer::element::U384;
+    use lambdaworks_math::unsigned_integer::element::U256;
 
     use crate::{generate_primitive_root, FE};
 
@@ -108,9 +108,9 @@ mod test {
 
     #[test]
     fn zerofier_is_the_correct_one() {
-        let a0 = BoundaryConstraint::new_simple(0, FE::new(U384::from("1")));
-        let a1 = BoundaryConstraint::new_simple(1, FE::new(U384::from("1")));
-        let result = BoundaryConstraint::new_simple(7, FE::new(U384::from("32")));
+        let a0 = BoundaryConstraint::new_simple(0, FE::new(U256::from("1")));
+        let a1 = BoundaryConstraint::new_simple(1, FE::new(U256::from("1")));
+        let result = BoundaryConstraint::new_simple(7, FE::new(U256::from("32")));
 
         let constraints = BoundaryConstraints::from_constraints(vec![a0, a1, result]);
 

--- a/proving-system/stark/src/constraints/boundary.rs
+++ b/proving-system/stark/src/constraints/boundary.rs
@@ -100,9 +100,9 @@ impl<F: IsField> BoundaryConstraints<FieldElement<F>> {
 
 #[cfg(test)]
 mod test {
-    use lambdaworks_math::unsigned_integer::element::U256;
+    use lambdaworks_math::{field::traits::IsTwoAdicField, unsigned_integer::element::U256};
 
-    use crate::{generate_primitive_root, FE};
+    use crate::{PrimeField, FE};
 
     use super::*;
 
@@ -114,7 +114,7 @@ mod test {
 
         let constraints = BoundaryConstraints::from_constraints(vec![a0, a1, result]);
 
-        let primitive_root = generate_primitive_root(8);
+        let primitive_root = PrimeField::get_primitive_root_of_unity(3).unwrap();
 
         let a0_zerofier = Polynomial::new(&[-FE::one(), FE::one()]);
         let a1_zerofier = Polynomial::new(&[-primitive_root.pow(1u32), FE::one()]);

--- a/proving-system/stark/src/lib.rs
+++ b/proving-system/stark/src/lib.rs
@@ -16,9 +16,6 @@ use lambdaworks_math::{
     traits::ByteConversion, unsigned_integer::element::U256,
 };
 
-// DEFINITION OF THE USED FIELD
-#[derive(Clone, Debug)]
-
 pub struct ProofConfig {
     pub count_queries: usize,
     pub blowup_factor: usize,
@@ -86,6 +83,7 @@ pub fn fibonacci_trace(initial_values: [FE; 2]) -> Vec<FE> {
     ret
 }
 
+// FIXME remove unwrap() calls and return errors
 pub fn prove(trace: &[FE], proof_config: &ProofConfig) -> StarkProof {
     let transcript = &mut Transcript::new();
     let mut query_list = Vec::<StarkQueryProof>::new();
@@ -95,6 +93,7 @@ pub fn prove(trace: &[FE], proof_config: &ProofConfig) -> StarkProof {
         ORDER_OF_ROOTS_OF_UNITY_TRACE.trailing_zeros() as u64,
     )
     .unwrap();
+
     let trace_roots_of_unity = generate_roots_of_unity_coset(1, &trace_primitive_root);
 
     let lde_primitive_root = PrimeField::get_primitive_root_of_unity(
@@ -391,6 +390,7 @@ pub fn fri_verify(
 
     // Check that v = P_{i+1}(z_i)
 
+    // FIXME remove unwrap()
     let mut lde_primitive_root = PrimeField::get_primitive_root_of_unity(
         ORDER_OF_ROOTS_OF_UNITY_FOR_LDE.trailing_zeros() as u64,
     )


### PR DESCRIPTION
# Use two-adic U256 fields for starks

## Description
Closes #170 
- We need fields with high adicity to use FFT. 
- This PR changes the primitive root of unity calculation to use the implementation from the `IsTwoAdicField`.

