### PR TITLE
Move coset offset

### DIFF
--- a/proving-system/stark/src/air/context.rs
+++ b/proving-system/stark/src/air/context.rs
@@ -28,4 +28,5 @@ impl AirContext {
 pub struct ProofOptions {
     pub(crate) blowup_factor: u8,
     pub fri_number_of_queries: u8,
+    pub coset_offset: u64,
 }

--- a/proving-system/stark/src/lib.rs
+++ b/proving-system/stark/src/lib.rs
@@ -19,11 +19,6 @@ pub struct ProofConfig {
 pub type PrimeField = U256MontgomeryTwoAdicPrimeField;
 pub type FE = FieldElement<PrimeField>;
 
-// DEFINITION OF CONSTANTS
-
-// We are using 3 as the offset as it's our field's generator.
-const COSET_OFFSET: u64 = 3;
-
 // TODO: change this to use more bits
 pub fn transcript_to_field<F: IsField>(transcript: &mut Transcript) -> FieldElement<F> {
     let value: u64 = u64::from_be_bytes(transcript.challenge()[..8].try_into().unwrap());
@@ -80,6 +75,7 @@ mod tests {
             options: ProofOptions {
                 blowup_factor: 2,
                 fri_number_of_queries: 1,
+                coset_offset: 3,
             },
             trace_length: trace.len(),
             trace_info: (trace.len(), 1),
@@ -108,6 +104,7 @@ mod tests {
             options: ProofOptions {
                 blowup_factor: 2,
                 fri_number_of_queries: 1,
+                coset_offset: 3,
             },
             trace_length: trace.len(),
             trace_info: (trace.len(), 1),

--- a/proving-system/stark/src/prover.rs
+++ b/proving-system/stark/src/prover.rs
@@ -13,7 +13,7 @@ use crate::{transcript_to_field, transcript_to_usize, StarkProof};
 use super::{
     air::{constraints::evaluator::ConstraintEvaluator, frame::Frame, trace::TraceTable, AIR},
     fri::{fri, fri_decommit::fri_decommit_layers},
-    StarkQueryProof, COSET_OFFSET,
+    StarkQueryProof,
 };
 
 // FIXME remove unwrap() calls and return errors
@@ -43,7 +43,7 @@ where
     let lde_roots_of_unity_coset = F::get_powers_of_primitive_root_coset(
         lde_root_order as u64,
         air.context().trace_length * air.options().blowup_factor as usize,
-        &FieldElement::<F>::from(COSET_OFFSET),
+        &FieldElement::<F>::from(air.options().coset_offset),
     )
     .unwrap();
 

--- a/proving-system/stark/src/verifier.rs
+++ b/proving-system/stark/src/verifier.rs
@@ -16,7 +16,6 @@ use super::{
         AIR,
     },
     fri::fri_decommit::FriDecommitment,
-    COSET_OFFSET,
 };
 
 pub fn verify<F: IsField + IsTwoAdicField, A: AIR + AIR<Field = F>>(
@@ -141,6 +140,7 @@ where
             q_i,
             fri_decommitment,
             lde_root_order,
+            air.options().coset_offset,
         );
     }
     result
@@ -152,9 +152,10 @@ pub fn verify_query<F: IsField + IsTwoAdicField>(
     q_i: usize,
     fri_decommitment: &FriDecommitment<F>,
     lde_root_order: u32,
+    coset_offset: u64,
 ) -> bool {
     let mut lde_primitive_root = F::get_primitive_root_of_unity(lde_root_order as u64).unwrap();
-    let mut offset = FieldElement::<F>::from(COSET_OFFSET);
+    let mut offset = FieldElement::<F>::from(coset_offset);
 
     // For each fri layer merkle proof check:
     // That each merkle path verifies


### PR DESCRIPTION
## Description

Move the offset of the coset into AIR's ProofOptions.
Resolves #182.

## Checklist
- [x] Linked to Github Issue
