### PR TITLE
Tests for Montgomery representative method

### DIFF
--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -212,6 +212,8 @@ where
 mod tests_u384_prime_fields {
     use crate::field::element::FieldElement;
     use crate::field::fields::montgomery_backed_prime_fields::{IsModulus, U384PrimeField};
+    use crate::field::traits::IsField;
+    use crate::field::traits::IsPrimeField;
     use crate::traits::ByteConversion;
     use crate::unsigned_integer::element::UnsignedInteger;
     use crate::unsigned_integer::element::U384;
@@ -224,6 +226,43 @@ mod tests_u384_prime_fields {
 
     type U384F23 = U384PrimeField<U384Modulus23>;
     type U384F23Element = FieldElement<U384F23>;
+
+    #[test]
+    fn montgomery_backend_primefield_compute_r2_parameter() {
+        let r2: U384 = UnsignedInteger {
+            limbs: [0, 0, 0, 0, 0, 6],
+        };
+        assert_eq!(U384F23::R2, r2);
+    }
+
+    #[test]
+    fn montgomery_backend_primefield_compute_mu_parameter() {
+        assert_eq!(U384F23::MU, 3208129404123400281);
+    }
+
+    #[test]
+    fn montgomery_backend_primefield_compute_zero_parameter() {
+        let zero: U384 = UnsignedInteger {
+            limbs: [0, 0, 0, 0, 0, 0],
+        };
+        assert_eq!(U384F23::ZERO, zero);
+    }
+
+    #[test]
+    fn montgomery_backend_primefield_from_u64() {
+        let a: U384 = UnsignedInteger {
+            limbs: [0, 0, 0, 0, 0, 17],
+        };
+        assert_eq!(U384F23::from_u64(770_u64), a);
+    }
+
+    #[test]
+    fn montgomery_backend_primefield_representative() {
+        let a: U384 = UnsignedInteger {
+            limbs: [0, 0, 0, 0, 0, 11],
+        };
+        assert_eq!(U384F23::representative(&U384F23::from_u64(770_u64)), a);
+    }
 
     #[test]
     fn montgomery_backend_multiplication_works_0() {
@@ -498,6 +537,8 @@ mod tests_u384_prime_fields {
 mod tests_u256_prime_fields {
     use crate::field::element::FieldElement;
     use crate::field::fields::montgomery_backed_prime_fields::{IsModulus, U256PrimeField};
+    use crate::field::traits::IsField;
+    use crate::field::traits::IsPrimeField;
     use crate::traits::ByteConversion;
     use crate::unsigned_integer::element::UnsignedInteger;
     use crate::unsigned_integer::element::U256;
@@ -510,6 +551,46 @@ mod tests_u256_prime_fields {
 
     type U256F29 = U256PrimeField<U256Modulus29>;
     type U256F29Element = FieldElement<U256F29>;
+
+    #[test]
+    fn montgomery_backend_primefield_compute_r2_parameter() {
+        let r2: U256 = UnsignedInteger {
+            limbs: [0, 0, 0, 24],
+        };
+        assert_eq!(U256F29::R2, r2);
+    }
+
+    #[test]
+    fn montgomery_backend_primefield_compute_mu_parameter() {
+        // modular multiplicative inverse
+        assert_eq!(U256F29::MU, 14630176334321368523);
+    }
+
+    #[test]
+    fn montgomery_backend_primefield_compute_zero_parameter() {
+        let zero: U256 = UnsignedInteger {
+            limbs: [0, 0, 0, 0],
+        };
+        assert_eq!(U256F29::ZERO, zero);
+    }
+
+    #[test]
+    fn montgomery_backend_primefield_from_u64() {
+        // (770*2**(256))%29
+        let a: U256 = UnsignedInteger {
+            limbs: [0, 0, 0, 24],
+        };
+        assert_eq!(U256F29::from_u64(770_u64), a);
+    }
+
+    #[test]
+    fn montgomery_backend_primefield_representative() {
+        // 770%29
+        let a: U256 = UnsignedInteger {
+            limbs: [0, 0, 0, 16],
+        };
+        assert_eq!(U256F29::representative(&U256F29::from_u64(770_u64)), a);
+    }
 
     #[test]
     fn montgomery_backend_multiplication_works_0() {

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -259,6 +259,14 @@ mod tests {
         let change = 1;
         let f1 = FE::new(MODULUS + change);
         let f2 = FE::new(f1.representative());
+        println!(
+            "test f1: {:?},
+            test {:?},
+            f1 reprensentative {:?}",
+            f1,
+            FE::new(40 * MODULUS),
+            FE::new(MODULUS).representative()
+        );
         assert_eq!(f1, f2);
     }
 

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -263,14 +263,6 @@ mod tests {
         let change = 1;
         let f1 = FE::new(MODULUS + change);
         let f2 = FE::new(f1.representative());
-        println!(
-            "test f1: {:?},
-            test {:?},
-            f1 reprensentative {:?}",
-            f1,
-            FE::new(40 * MODULUS),
-            FE::new(MODULUS).representative()
-        );
         assert_eq!(f1, f2);
     }
 


### PR DESCRIPTION
# Tests for Montgomery `representative` method

## Description

The `representative` method was implemented for `MontgomeryBackendPrimeField`. As a response to #138, this PR proposes tests to validate the correct implementation.

This includes tests for both `U384PrimeField` and `U256PrimeField`:
- Proper computation of `R2` parameter
- Proper computation of `MU` parameter
- Proper computation of `ZERO` parameter
- Proper initialization using `from_u64`
- Proper `representative` implementation

## Type of change

- [x] Tests

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
