### PR TITLE
Add an example of AIR with more than one column in the trace

### DIFF
--- a/proving_system/stark/src/air/frame.rs
+++ b/proving_system/stark/src/air/frame.rs
@@ -49,7 +49,7 @@ impl<F: IsField> Frame<F> {
             data.push(trace.table[(step + (frame_row_idx * blowup as usize)) % trace_len].clone())
         }
 
-        Self::new(data, 1)
+        Self::new(data, trace.num_cols)
     }
 
     /// Returns the Out of Domain Frame for the given trace polynomials, out of domain evaluation point (called `z` in the literature),

--- a/proving_system/stark/src/air/mod.rs
+++ b/proving_system/stark/src/air/mod.rs
@@ -22,6 +22,7 @@ pub trait AIR: Clone {
     fn compute_boundary_constraints(&self) -> BoundaryConstraints<Self::Field>;
     fn transition_divisors(&self) -> Vec<Polynomial<FieldElement<Self::Field>>>;
     fn context(&self) -> AirContext;
+    fn trace(&self) -> TraceTable<Self::Field>;
     fn options(&self) -> ProofOptions {
         self.context().options
     }


### PR DESCRIPTION
## Description

Resolves #186.
The example added is Fibonacci with 2 columns.
This implies generalizing the number of trace table columns read in the prover.

## Type of change

- [x] New feature

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
