### PR TITLE
Change u256TwoAdicPrimeField to Stark252PrimeField in all relevant parts

### DIFF
--- a/math/src/field/fields/fft_friendly/mod.rs
+++ b/math/src/field/fields/fft_friendly/mod.rs
@@ -1,2 +1,2 @@
 /// Implementation of two-adic prime field over 256 bit unsigned integers.
-pub mod u256_two_adic_prime_field;
+pub mod stark_252_prime_field;

--- a/math/src/field/fields/fft_friendly/stark_252_prime_field.rs
+++ b/math/src/field/fields/fft_friendly/stark_252_prime_field.rs
@@ -7,15 +7,15 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct U256MontgomeryConfigTwoAdic;
-impl IsModulus<U256> for U256MontgomeryConfigTwoAdic {
+pub struct MontgomeryConfigStark252PrimeField;
+impl IsModulus<U256> for MontgomeryConfigStark252PrimeField {
     const MODULUS: U256 =
         U256::from("800000000000011000000000000000000000000000000000000000000000001");
 }
 
-pub type U256MontgomeryTwoAdicPrimeField = U256PrimeField<U256MontgomeryConfigTwoAdic>;
+pub type Stark252PrimeField = U256PrimeField<MontgomeryConfigStark252PrimeField>;
 
-impl IsTwoAdicField for U256MontgomeryTwoAdicPrimeField {
+impl IsTwoAdicField for Stark252PrimeField {
     const TWO_ADICITY: u64 = 48;
     // Change this line for a new function like `from_limbs`.
     const TWO_ADIC_PRIMITVE_ROOT_OF_UNITY: U256 = UnsignedInteger {
@@ -32,7 +32,7 @@ impl IsTwoAdicField for U256MontgomeryTwoAdicPrimeField {
 mod u256_two_adic_prime_field_tests {
     use proptest::{prelude::any, prop_assert_eq, prop_compose, proptest, strategy::Strategy};
 
-    use super::U256MontgomeryTwoAdicPrimeField;
+    use super::Stark252PrimeField;
     use crate::{
         fft::helpers::log2,
         field::{
@@ -42,7 +42,7 @@ mod u256_two_adic_prime_field_tests {
         polynomial::Polynomial,
     };
 
-    type F = U256MontgomeryTwoAdicPrimeField;
+    type F = Stark252PrimeField;
     type FE = FieldElement<F>;
 
     prop_compose! {

--- a/proving_system/stark/src/lib.rs
+++ b/proving_system/stark/src/lib.rs
@@ -8,7 +8,7 @@ use fri::fri_decommit::FriDecommitment;
 
 use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
 use lambdaworks_math::field::element::FieldElement;
-use lambdaworks_math::field::fields::fft_friendly::u256_two_adic_prime_field::U256MontgomeryTwoAdicPrimeField;
+use lambdaworks_math::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
 use lambdaworks_math::field::traits::IsField;
 
 pub struct ProofConfig {
@@ -16,7 +16,7 @@ pub struct ProofConfig {
     pub blowup_factor: usize,
 }
 
-pub type PrimeField = U256MontgomeryTwoAdicPrimeField;
+pub type PrimeField = Stark252PrimeField;
 pub type FE = FieldElement<PrimeField>;
 
 // TODO: change this to use more bits


### PR DESCRIPTION
# Change u256_two_adic_prime_field to Stark252PrimeField in all relevants parts

## Description

This change of names makes it easier to find the Stark252PrimeField, and avoids name collisions, since there are multiple two adic fields that fit inside a U256