### PR TITLE
Fix degree calculations for composition polynomial

### DIFF
--- a/proving_system/stark/src/lib.rs
+++ b/proving_system/stark/src/lib.rs
@@ -203,10 +203,11 @@ mod test_utils {
         }
 
         fn transition_divisors(&self) -> Vec<Polynomial<FieldElement<Self::Field>>> {
-            let roots_of_unity_order = self.context().trace_length.trailing_zeros();
+            let trace_length = self.context().trace_length;
+            let roots_of_unity_order = trace_length.trailing_zeros();
             let roots_of_unity = Self::Field::get_powers_of_primitive_root_coset(
                 roots_of_unity_order as u64,
-                self.context().trace_length,
+                trace_length,
                 &FieldElement::<Self::Field>::one(),
             )
             .unwrap();
@@ -214,12 +215,10 @@ mod test_utils {
             let mut result = vec![];
 
             for _ in 0..self.context().num_transition_constraints {
-                // X^(roots_of_unity_order) - 1
+                // X^(trace_length) - 1
                 let roots_of_unity_vanishing_polynomial =
-                    Polynomial::new_monomial(
-                        FieldElement::<Self::Field>::one(),
-                        roots_of_unity_order as usize,
-                    ) - Polynomial::new_monomial(FieldElement::<Self::Field>::one(), 0);
+                    Polynomial::new_monomial(FieldElement::<Self::Field>::one(), trace_length)
+                        - Polynomial::new_monomial(FieldElement::<Self::Field>::one(), 0);
 
                 let mut exemptions_polynomial =
                     Polynomial::new_monomial(FieldElement::<Self::Field>::one(), 0);
@@ -274,10 +273,11 @@ mod test_utils {
         }
 
         fn transition_divisors(&self) -> Vec<Polynomial<FieldElement<Self::Field>>> {
-            let roots_of_unity_order = self.context().trace_length.trailing_zeros();
+            let trace_length = self.context().trace_length;
+            let roots_of_unity_order = trace_length.trailing_zeros();
             let roots_of_unity = Self::Field::get_powers_of_primitive_root_coset(
                 roots_of_unity_order as u64,
-                self.context().trace_length,
+                trace_length,
                 &FieldElement::<Self::Field>::one(),
             )
             .unwrap();
@@ -285,12 +285,10 @@ mod test_utils {
             let mut result = vec![];
 
             for _ in 0..self.context().num_transition_constraints {
-                // X^(roots_of_unity_order) - 1
+                // X^(trace_length) - 1
                 let roots_of_unity_vanishing_polynomial =
-                    Polynomial::new_monomial(
-                        FieldElement::<Self::Field>::one(),
-                        roots_of_unity_order as usize,
-                    ) - Polynomial::new_monomial(FieldElement::<Self::Field>::one(), 0);
+                    Polynomial::new_monomial(FieldElement::<Self::Field>::one(), trace_length)
+                        - Polynomial::new_monomial(FieldElement::<Self::Field>::one(), 0);
 
                 let mut exemptions_polynomial =
                     Polynomial::new_monomial(FieldElement::<Self::Field>::one(), 0);

--- a/proving_system/stark/src/verifier.rs
+++ b/proving_system/stark/src/verifier.rs
@@ -67,9 +67,17 @@ where
     let alpha = transcript_to_field(transcript);
     let beta = transcript_to_field(transcript);
 
-    let max_degree =
-        air.context().trace_length * air.context().transition_degrees().iter().max().unwrap();
-
+    let mut degrees = vec![];
+    for (transition_degree, zerofier) in air
+        .context()
+        .transition_degrees()
+        .iter()
+        .zip(air.transition_divisors())
+    {
+        let degree = transition_degree * (air.context().trace_length - 1) - zerofier.degree();
+        degrees.push(degree);
+    }
+    let max_degree = *degrees.iter().max().unwrap();
     let max_degree_power_of_two = helpers::next_power_of_two(max_degree as u64);
 
     // TODO: This is assuming one column


### PR DESCRIPTION
## Description

- The degree of `roots_of_unity_vanishing_polynomial` used to calculate AIR transition divisors was calculated using log2 of the trace length instead of using simply the trace length.
- Substracted max degree used for the composition polynomial with zerofier degree.
- Calculated transition constraint zerofier degree using trace length.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
