### PR TITLE
add diferential fuzzer plonk vs gnark

### DIFF
--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "fuzzer"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+honggfuzz = "0.5.55"

--- a/fuzzer/Makefile
+++ b/fuzzer/Makefile
@@ -1,0 +1,10 @@
+FFI_LIB_PATH=./gnark_backend
+
+check: clippy test test-go
+
+build-go:
+	$ cd ${FFI_LIB_PATH}; \
+		go build -buildmode=c-archive -o libgnark_backend.a main.go
+
+build: build-go
+	$ RUSTFLAGS="-L${FFI_LIB_PATH}" cargo build

--- a/fuzzer/build.rs
+++ b/fuzzer/build.rs
@@ -1,0 +1,16 @@
+fn build_go_backend() {
+    std::process::Command::new("make")
+        .arg("-C")
+        .arg(
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .to_str()
+                .unwrap(),
+        )
+        .arg("build-go")
+        .spawn()
+        .unwrap();
+}
+
+fn main() {
+    build_go_backend();
+}

--- a/fuzzer/fuzzer/Cargo.toml
+++ b/fuzzer/fuzzer/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fuzzer"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/fuzzer/fuzzer/Makefile
+++ b/fuzzer/fuzzer/Makefile
@@ -1,0 +1,10 @@
+FFI_LIB_PATH=./gnark_backend
+
+check: clippy test test-go
+
+build-go:
+	$ cd ${FFI_LIB_PATH}; \
+		go build -buildmode=c-archive -o libgnark_backend.a main.go
+
+build: build-go
+	$ RUSTFLAGS="-L${FFI_LIB_PATH}" cargo build

--- a/fuzzer/fuzzer/build.rs
+++ b/fuzzer/fuzzer/build.rs
@@ -1,0 +1,22 @@
+fn build_go_backend() {
+    std::process::Command::new("make")
+        .arg("-C")
+        .arg(
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .to_str()
+                .unwrap(),
+        )
+        .arg("build-go")
+        .spawn()
+        .unwrap();
+}
+
+fn main() {
+    build_go_backend();
+
+    let path = "gnark_backend_ffi";
+    let lib = "gnark_backend";
+
+    println!("cargo:rustc-link-search=native={path}");
+    println!("cargo:rustc-link-lib=static={lib}");
+}

--- a/fuzzer/fuzzer/gnark_backend/go.mod
+++ b/fuzzer/fuzzer/gnark_backend/go.mod
@@ -1,0 +1,5 @@
+module gnark_backend
+
+go 1.20
+
+require github.com/consensys/gnark-crypto v0.9.1

--- a/fuzzer/fuzzer/gnark_backend/main.go
+++ b/fuzzer/fuzzer/gnark_backend/main.go
@@ -1,0 +1,96 @@
+package main
+
+import "C"
+import (
+	
+	"math/big"
+	"reflect"
+
+	"github.com/consensys/gnark/backend/plonk"
+	"github.com/consensys/gnark/backend/witness"
+	"github.com/consensys/gnark/frontend/schema"
+)
+
+// export Circuit
+type Circuit struct {
+	// tagging a variable is optional
+	// default uses variable name and secret visibility.
+	X frontend.Variable `gnark:",public"`
+	E frontend.Variable `gnark:",public"`
+
+	Y frontend.Variable
+}
+
+// export Define
+func (circuit *Circuit) Define(api frontend.API) error {
+	// specify constraints
+    output := api.Mul(circuit.X, circuit.Y)
+
+	api.AssertIsEqual(circuit.E, output)
+
+	return nil
+}
+
+// export CreateCircuit
+func CreateCircuit(privateInputX big.Int, privateInputY big.Int, publiInput big.Int)(circuit Circuit) {
+	var w Circuit
+		w.X = 2
+		w.E = 2
+		w.Y = 4
+
+}
+
+// export VerityWithCircuitWitness
+func VerityWithCircuitWitness(circuit *Circuit, witness.Witness)() {
+
+}
+
+// export NewWitness
+func NewWitness(assignment Circuit, field *big.Int, opts ...WitnessOption) (witness.Witness, error) {
+	opt, err := options(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// count the leaves
+	s, err := schema.Walk(assignment, tVariable, nil)
+	if err != nil {
+		return nil, err
+	}
+	if opt.publicOnly {
+		s.Secret = 0
+	}
+
+	// allocate the witness
+	w, err := witness.New(field)
+	if err != nil {
+		return nil, err
+	}
+
+	// write the public | secret values in a chan
+	chValues := make(chan any)
+	go func() {
+		defer close(chValues)
+		schema.Walk(assignment, tVariable, func(leaf schema.LeafInfo, tValue reflect.Value) error {
+			if leaf.Visibility == schema.Public {
+				chValues <- tValue.Interface()
+			}
+			return nil
+		})
+		if !opt.publicOnly {
+			schema.Walk(assignment, tVariable, func(leaf schema.LeafInfo, tValue reflect.Value) error {
+				if leaf.Visibility == schema.Secret {
+					chValues <- tValue.Interface()
+				}
+				return nil
+			})
+		}
+	}()
+	if err := w.Fill(s.Public, s.Secret, chValues); err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
+

--- a/fuzzer/fuzzer/src/gnark_backend_wrapper/c_go_structures.rs
+++ b/fuzzer/fuzzer/src/gnark_backend_wrapper/c_go_structures.rs
@@ -1,0 +1,26 @@
+use crate::gnark_backend_wrapper::GnarkBackendError;
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct GoString {
+    pub ptr: *const c_char,
+    length: usize,
+}
+
+impl TryFrom<&CString> for GoString {
+    type Error = GnarkBackendError;
+
+    fn try_from(value: &CString) -> std::result::Result<Self, Self::Error> {
+        let ptr = value.as_ptr();
+        let length = value.as_bytes().len();
+        Ok(Self { ptr, length })
+    }
+}
+
+#[repr(C)]
+pub struct KeyPair {
+    pub proving_key: *const c_char,
+    pub verifying_key: *const c_char,
+}

--- a/fuzzer/fuzzer/src/gnark_backend_wrapper/errors.rs
+++ b/fuzzer/fuzzer/src/gnark_backend_wrapper/errors.rs
@@ -1,0 +1,38 @@
+use acvm::OpcodeResolutionError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GnarkBackendError {
+    #[error("an error occurred while serializing the circuit: {0}")]
+    SerializeCircuitError(String),
+
+    #[error("an error occurred while serializing a key: {0}")]
+    SerializeKeyError(String),
+
+    #[error("an error occurred while serializing a proof: {0}")]
+    SerializeProofError(String),
+
+    #[error("an error ocurred while serializing felts: {0}")]
+    SerializeFeltsError(String),
+
+    #[error("an error occurred while deserializing a proof: {0}")]
+    DeserializeProofError(String),
+
+    #[error("an error occurred while deserializing a key: {0}")]
+    DeserializeKeyError(String),
+
+    #[error("currently we do not support this opcode: {0}")]
+    UnsupportedOpcodeError(String),
+
+    #[error("Verify did not return a valid bool")]
+    VerifyInvalidBoolError,
+
+    #[error("Opcode resolution error: {0}")]
+    OpcodeResolutionError(#[from] OpcodeResolutionError),
+
+    #[error("an error occurred while serializing felt: {0}")]
+    SerializeFeltError(String),
+
+    #[error("an error occurred: {0}")]
+    Error(String),
+}

--- a/fuzzer/fuzzer/src/gnark_backend_wrapper/mod.rs
+++ b/fuzzer/fuzzer/src/gnark_backend_wrapper/mod.rs
@@ -1,0 +1,73 @@
+use crate::acvm;
+
+mod errors;
+pub use errors::GnarkBackendError;
+
+mod c_go_structures;
+pub use c_go_structures::{GoString, KeyPair};
+
+mod serialize;
+
+// Arkworks's types are generic for `Field` but Noir's types are concrete and
+// its value depends on the feature flag.
+cfg_if::cfg_if! {
+    if #[cfg(feature = "bn254")] {
+        pub use ark_bn254::{Bn254 as Curve, Fr};
+
+        // Converts a FieldElement to a Fr
+        // noir_field uses arkworks for bn254
+        pub fn from_felt(felt: acvm::FieldElement) -> Fr {
+            felt.into_repr()
+        }
+    } else if #[cfg(feature = "bls12_381")] {
+        pub use ark_bls12_381::{Bls12_381 as Curve, Fr};
+
+        // Converts a FieldElement to a Fr
+        // noir_field uses arkworks for bls12_381
+        pub fn from_felt(felt: FieldElement) -> Fr {
+            felt.into_repr()
+        }
+    } else {
+        compile_error!("please specify a field to compile with");
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "groth16")] {
+        mod groth16;
+        pub use groth16::{AddTerm, Fr, GoString, MulTerm, RawGate, RawR1CS};
+        pub use groth16::verify_with_meta;
+        pub use groth16::prove_with_meta;
+        pub use groth16::verify_with_vk;
+        pub use groth16::prove_with_pk;
+        pub use groth16::get_exact_circuit_size;
+        pub use groth16::preprocess;
+    } else if #[cfg(feature = "plonk")] {
+        mod plonk;
+        pub use plonk::verify_with_meta;
+        pub use plonk::prove_with_meta;
+        pub use plonk::verify_with_vk;
+        pub use plonk::prove_with_pk;
+        pub use plonk::get_exact_circuit_size;
+        pub use plonk::preprocess;
+    }
+}
+
+pub fn num_constraints(acir: &acvm::Circuit) -> Result<usize, GnarkBackendError> {
+    // each multiplication term adds an extra constraint
+    let mut num_opcodes = acir.opcodes.len();
+
+    for opcode in acir.opcodes.iter() {
+        match opcode {
+            acvm::Opcode::Arithmetic(arith) => num_opcodes += arith.num_mul_terms() + 1, // plus one for the linear combination gate
+            acvm::Opcode::Directive(_) => (),
+            _ => {
+                return Err(GnarkBackendError::UnsupportedOpcodeError(
+                    opcode.to_string(),
+                ))
+            }
+        }
+    }
+
+    Ok(num_opcodes)
+}

--- a/fuzzer/fuzzer/src/gnark_backend_wrapper/serialize.rs
+++ b/fuzzer/fuzzer/src/gnark_backend_wrapper/serialize.rs
@@ -1,0 +1,106 @@
+use super::GnarkBackendError;
+use crate::gnark_backend_wrapper as gnark_backend;
+#[cfg(feature = "groth16")]
+use ark_serialize::CanonicalDeserialize;
+use ark_serialize::CanonicalSerialize;
+#[cfg(feature = "groth16")]
+use serde::Deserialize;
+use std::num::TryFromIntError;
+
+pub fn serialize_felt_unchecked(felt: &gnark_backend::Fr) -> Vec<u8> {
+    let mut serialized_felt = Vec::new();
+    #[allow(clippy::unwrap_used)]
+    felt.serialize_uncompressed(&mut serialized_felt).unwrap();
+    // Turn little-endian to big-endian.
+    serialized_felt.reverse();
+    serialized_felt
+}
+
+#[cfg(feature = "groth16")]
+pub fn serialize_felt<S>(felt: &gnark_backend::Fr, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::ser::Serializer,
+{
+    let mut serialized_felt = Vec::new();
+    felt.serialize_uncompressed(&mut serialized_felt)
+        .map_err(serde::ser::Error::custom)?;
+    // Turn little-endian to big-endian.
+    serialized_felt.reverse();
+    let encoded_coefficient = hex::encode(serialized_felt);
+    serializer.serialize_str(&encoded_coefficient)
+}
+
+pub fn encode_felts(felts: &[gnark_backend::Fr]) -> Result<String, GnarkBackendError> {
+    let mut buff: Vec<u8> = Vec::new();
+    let n_felts: u32 = felts
+        .len()
+        .try_into()
+        .map_err(|e: TryFromIntError| GnarkBackendError::SerializeFeltsError(e.to_string()))?;
+    buff.extend_from_slice(&n_felts.to_be_bytes());
+    buff.extend_from_slice(
+        &felts
+            .iter()
+            .flat_map(serialize_felt_unchecked)
+            .collect::<Vec<u8>>(),
+    );
+    Ok(hex::encode(buff))
+}
+
+pub fn serialize_felts<S>(felts: &[gnark_backend::Fr], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::ser::Serializer,
+{
+    let encoded_buff = encode_felts(felts).map_err(serde::ser::Error::custom)?;
+    serializer.serialize_str(&encoded_buff)
+}
+
+#[cfg(feature = "groth16")]
+pub fn deserialize_felt<'de, D>(deserializer: D) -> Result<gnark_backend::Fr, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let felt_bytes = String::deserialize(deserializer)?;
+    let mut decoded = hex::decode(felt_bytes).map_err(serde::de::Error::custom)?;
+    // Turn big-endian to little-endian.
+    decoded.reverse();
+    gnark_backend::Fr::deserialize_uncompressed(decoded.as_slice())
+        .map_err(serde::de::Error::custom)
+}
+
+#[cfg(feature = "groth16")]
+pub fn deserialize_felts<'de, D>(deserializer: D) -> Result<Vec<gnark_backend::Fr>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let serialized_felts = String::deserialize(deserializer)?;
+
+    let mut decoded_felts = hex::decode(serialized_felts).map_err(serde::de::Error::custom)?;
+
+    let n_felts: usize = u32::from_be_bytes(
+        decoded_felts
+            .get(..4)
+            .ok_or_else(|| serde::de::Error::custom("Error getting felts size"))?
+            .try_into()
+            .map_err(serde::de::Error::custom)?,
+    )
+    .try_into()
+    .map_err(serde::de::Error::custom)?;
+    let mut deserialized_felts: Vec<gnark_backend::Fr> = Vec::with_capacity(n_felts);
+
+    decoded_felts
+        .get_mut(4..) // Skip the vector length corresponding to the first four bytes.
+        .ok_or_else(|| serde::de::Error::custom("Error getting decoded felts"))?
+        .chunks_mut(32)
+        .try_for_each(|decoded_felt| {
+            // Turn big-endian to little-endian.
+            decoded_felt.reverse();
+            // Here I reference after dereference because I had a mutable reference and I need a non-mutable one.
+            let felt: gnark_backend::Fr =
+                CanonicalDeserialize::deserialize_uncompressed(&*decoded_felt)
+                    .map_err(serde::de::Error::custom)?;
+            deserialized_felts.push(felt);
+            Ok::<(), D::Error>(())
+        })?;
+
+    Ok(deserialized_felts)
+}

--- a/fuzzer/fuzzer/src/main.rs
+++ b/fuzzer/fuzzer/src/main.rs
@@ -1,0 +1,101 @@
+#[macro_use]
+extern crate honggfuzz;
+use crate::gnark_backend_wrapper::c_go_structures::{GoString, KeyPair};
+use crate::gnark_backend_wrapper::errors::GnarkBackendError;
+use std::ffi::{CStr, CString};
+use std::num::TryFromIntError;
+use std::os::raw::{c_char, c_uchar};
+
+// This lists all the functions in the foreign interface along with their type signature.
+extern "C" {
+    fn CreateCircuit(public_input_x: GoString, public_input_y: GoString, private_variable: GoString) -> c_uchar;
+    fn NewWitness(circuit: GoString, field: GoString) -> c_uchar;
+    fn VerityWithCircuitWitness(circuit: GoString, witness: GoString) -> c_uchar;
+}
+
+fn main() {
+    loop {
+        fuzz!(|data1: u64, data2: u64| {
+
+            // This is the circuit for x * e == y
+            let common_preprocesed_input = test_common_preprocessed_input_1();
+            let srs = fuzzer_srs();
+
+            // Public input
+            let x = FieldElement::from(data1);
+            let y = FieldElement::from(data1 * data2);
+
+            // Private variable
+            let e = FieldElement::from(data2);
+
+            let public_input = vec![x.clone(), y];
+            let witness = fuzzer_witness(x, e);
+
+            let kzg = KZG::new(srs);
+            let verifying_key = setup(&common_preprocesed_input, &kzg);
+            let random_generator = TestRandomFieldGenerator {};
+
+            let prover = Prover::new(kzg.clone(), random_generator);
+
+            let circuit = unsafe { CreateCircuit(x, y, e) };
+            let  witness = unsafe { VerityWithCircuitWitness(circuit, witness) };
+
+            let  verify_with_gnark = unsafe { NewWitness(witness, e) };
+            
+            let proof = prover.prove(
+                &witness,
+                &public_input,
+                &common_preprocesed_input,
+                &verifying_key,
+            );
+
+            let verifier = Verifier::new(kzg);
+            assert_eq!(verifier.verify(
+                &proof,
+                &public_input,
+                &common_preprocesed_input,
+                &verifying_key
+            ), verify_with_gnark);        
+        });
+    }
+}
+
+fn fuzzer_witness(x: FrElement, e: FrElement) -> Witness<FrField> {
+    let y = &x * &e;
+    let empty = x.clone();
+    Witness {
+        a: vec![
+            x.clone(), // Public input
+            y.clone(), // Public input
+            x.clone(), // LHS for multiplication
+            y,         // LHS for ==
+        ],
+        b: vec![
+            empty.clone(),
+            empty.clone(),
+            e.clone(), // RHS for multiplication
+            &x * &e,   // RHS for ==
+        ],
+        c: vec![
+            empty.clone(),
+            empty.clone(),
+            &x * &e, // Output of multiplication
+            empty,
+        ],
+    }
+}
+
+fn fuzzer_srs() -> StructuredReferenceString<G1Point, G2Point> {
+    let s = FrElement::from(2);
+    let g1 = <BLS12381Curve as IsEllipticCurve>::generator();
+    let g2 = <BLS12381TwistCurve as IsEllipticCurve>::generator();
+
+    let powers_main_group: Vec<G1Point> = (0..40)
+        .map(|exp| g1.operate_with_self(s.pow(exp as u64).representative()))
+        .collect();
+    let powers_secondary_group = [g2.clone(), g2.operate_with_self(s.representative())];
+
+    StructuredReferenceString::new(&powers_main_group, &powers_secondary_group)
+}
+
+

--- a/fuzzer/gnark_backend/go.mod
+++ b/fuzzer/gnark_backend/go.mod
@@ -1,0 +1,5 @@
+module gnark_backend
+
+go 1.20
+
+require github.com/consensys/gnark-crypto v0.9.1

--- a/fuzzer/gnark_backend/main.go
+++ b/fuzzer/gnark_backend/main.go
@@ -1,0 +1,96 @@
+package main
+
+import "C"
+import (
+	
+	"math/big"
+	"reflect"
+
+	"github.com/consensys/gnark/backend/plonk"
+	"github.com/consensys/gnark/backend/witness"
+	"github.com/consensys/gnark/frontend/schema"
+)
+
+// export Circuit
+type Circuit struct {
+	// tagging a variable is optional
+	// default uses variable name and secret visibility.
+	X frontend.Variable `gnark:",public"`
+	E frontend.Variable `gnark:",public"`
+
+	Y frontend.Variable
+}
+
+// export Define
+func (circuit *Circuit) Define(api frontend.API) error {
+	// specify constraints
+    output := api.Mul(circuit.X, circuit.Y)
+
+	api.AssertIsEqual(circuit.E, output)
+
+	return nil
+}
+
+// export CreateCircuit
+func CreateCircuit(privateInputX big.Int, privateInputY big.Int, publiInput big.Int)(circuit Circuit) {
+	var w Circuit
+		w.X = 2
+		w.E = 2
+		w.Y = 4
+
+}
+
+// export VerityWithCircuitWitness
+func VerityWithCircuitWitness(circuit *Circuit, witness.Witness)() {
+
+}
+
+// export NewWitness
+func NewWitness(assignment Circuit, field *big.Int, opts ...WitnessOption) (witness.Witness, error) {
+	opt, err := options(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// count the leaves
+	s, err := schema.Walk(assignment, tVariable, nil)
+	if err != nil {
+		return nil, err
+	}
+	if opt.publicOnly {
+		s.Secret = 0
+	}
+
+	// allocate the witness
+	w, err := witness.New(field)
+	if err != nil {
+		return nil, err
+	}
+
+	// write the public | secret values in a chan
+	chValues := make(chan any)
+	go func() {
+		defer close(chValues)
+		schema.Walk(assignment, tVariable, func(leaf schema.LeafInfo, tValue reflect.Value) error {
+			if leaf.Visibility == schema.Public {
+				chValues <- tValue.Interface()
+			}
+			return nil
+		})
+		if !opt.publicOnly {
+			schema.Walk(assignment, tVariable, func(leaf schema.LeafInfo, tValue reflect.Value) error {
+				if leaf.Visibility == schema.Secret {
+					chValues <- tValue.Interface()
+				}
+				return nil
+			})
+		}
+	}()
+	if err := w.Fill(s.Public, s.Secret, chValues); err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
+

--- a/fuzzer/src/gnark_backend_wrapper/c_go_structures.rs
+++ b/fuzzer/src/gnark_backend_wrapper/c_go_structures.rs
@@ -1,0 +1,26 @@
+use crate::gnark_backend_wrapper::GnarkBackendError;
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct GoString {
+    pub ptr: *const c_char,
+    length: usize,
+}
+
+impl TryFrom<&CString> for GoString {
+    type Error = GnarkBackendError;
+
+    fn try_from(value: &CString) -> std::result::Result<Self, Self::Error> {
+        let ptr = value.as_ptr();
+        let length = value.as_bytes().len();
+        Ok(Self { ptr, length })
+    }
+}
+
+#[repr(C)]
+pub struct KeyPair {
+    pub proving_key: *const c_char,
+    pub verifying_key: *const c_char,
+}

--- a/fuzzer/src/gnark_backend_wrapper/errors.rs
+++ b/fuzzer/src/gnark_backend_wrapper/errors.rs
@@ -1,0 +1,38 @@
+use acvm::OpcodeResolutionError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GnarkBackendError {
+    #[error("an error occurred while serializing the circuit: {0}")]
+    SerializeCircuitError(String),
+
+    #[error("an error occurred while serializing a key: {0}")]
+    SerializeKeyError(String),
+
+    #[error("an error occurred while serializing a proof: {0}")]
+    SerializeProofError(String),
+
+    #[error("an error ocurred while serializing felts: {0}")]
+    SerializeFeltsError(String),
+
+    #[error("an error occurred while deserializing a proof: {0}")]
+    DeserializeProofError(String),
+
+    #[error("an error occurred while deserializing a key: {0}")]
+    DeserializeKeyError(String),
+
+    #[error("currently we do not support this opcode: {0}")]
+    UnsupportedOpcodeError(String),
+
+    #[error("Verify did not return a valid bool")]
+    VerifyInvalidBoolError,
+
+    #[error("Opcode resolution error: {0}")]
+    OpcodeResolutionError(#[from] OpcodeResolutionError),
+
+    #[error("an error occurred while serializing felt: {0}")]
+    SerializeFeltError(String),
+
+    #[error("an error occurred: {0}")]
+    Error(String),
+}

--- a/fuzzer/src/gnark_backend_wrapper/mod.rs
+++ b/fuzzer/src/gnark_backend_wrapper/mod.rs
@@ -1,0 +1,73 @@
+use crate::acvm;
+
+mod errors;
+pub use errors::GnarkBackendError;
+
+mod c_go_structures;
+pub use c_go_structures::{GoString, KeyPair};
+
+mod serialize;
+
+// Arkworks's types are generic for `Field` but Noir's types are concrete and
+// its value depends on the feature flag.
+cfg_if::cfg_if! {
+    if #[cfg(feature = "bn254")] {
+        pub use ark_bn254::{Bn254 as Curve, Fr};
+
+        // Converts a FieldElement to a Fr
+        // noir_field uses arkworks for bn254
+        pub fn from_felt(felt: acvm::FieldElement) -> Fr {
+            felt.into_repr()
+        }
+    } else if #[cfg(feature = "bls12_381")] {
+        pub use ark_bls12_381::{Bls12_381 as Curve, Fr};
+
+        // Converts a FieldElement to a Fr
+        // noir_field uses arkworks for bls12_381
+        pub fn from_felt(felt: FieldElement) -> Fr {
+            felt.into_repr()
+        }
+    } else {
+        compile_error!("please specify a field to compile with");
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "groth16")] {
+        mod groth16;
+        pub use groth16::{AddTerm, Fr, GoString, MulTerm, RawGate, RawR1CS};
+        pub use groth16::verify_with_meta;
+        pub use groth16::prove_with_meta;
+        pub use groth16::verify_with_vk;
+        pub use groth16::prove_with_pk;
+        pub use groth16::get_exact_circuit_size;
+        pub use groth16::preprocess;
+    } else if #[cfg(feature = "plonk")] {
+        mod plonk;
+        pub use plonk::verify_with_meta;
+        pub use plonk::prove_with_meta;
+        pub use plonk::verify_with_vk;
+        pub use plonk::prove_with_pk;
+        pub use plonk::get_exact_circuit_size;
+        pub use plonk::preprocess;
+    }
+}
+
+pub fn num_constraints(acir: &acvm::Circuit) -> Result<usize, GnarkBackendError> {
+    // each multiplication term adds an extra constraint
+    let mut num_opcodes = acir.opcodes.len();
+
+    for opcode in acir.opcodes.iter() {
+        match opcode {
+            acvm::Opcode::Arithmetic(arith) => num_opcodes += arith.num_mul_terms() + 1, // plus one for the linear combination gate
+            acvm::Opcode::Directive(_) => (),
+            _ => {
+                return Err(GnarkBackendError::UnsupportedOpcodeError(
+                    opcode.to_string(),
+                ))
+            }
+        }
+    }
+
+    Ok(num_opcodes)
+}

--- a/fuzzer/src/gnark_backend_wrapper/serialize.rs
+++ b/fuzzer/src/gnark_backend_wrapper/serialize.rs
@@ -1,0 +1,106 @@
+use super::GnarkBackendError;
+use crate::gnark_backend_wrapper as gnark_backend;
+#[cfg(feature = "groth16")]
+use ark_serialize::CanonicalDeserialize;
+use ark_serialize::CanonicalSerialize;
+#[cfg(feature = "groth16")]
+use serde::Deserialize;
+use std::num::TryFromIntError;
+
+pub fn serialize_felt_unchecked(felt: &gnark_backend::Fr) -> Vec<u8> {
+    let mut serialized_felt = Vec::new();
+    #[allow(clippy::unwrap_used)]
+    felt.serialize_uncompressed(&mut serialized_felt).unwrap();
+    // Turn little-endian to big-endian.
+    serialized_felt.reverse();
+    serialized_felt
+}
+
+#[cfg(feature = "groth16")]
+pub fn serialize_felt<S>(felt: &gnark_backend::Fr, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::ser::Serializer,
+{
+    let mut serialized_felt = Vec::new();
+    felt.serialize_uncompressed(&mut serialized_felt)
+        .map_err(serde::ser::Error::custom)?;
+    // Turn little-endian to big-endian.
+    serialized_felt.reverse();
+    let encoded_coefficient = hex::encode(serialized_felt);
+    serializer.serialize_str(&encoded_coefficient)
+}
+
+pub fn encode_felts(felts: &[gnark_backend::Fr]) -> Result<String, GnarkBackendError> {
+    let mut buff: Vec<u8> = Vec::new();
+    let n_felts: u32 = felts
+        .len()
+        .try_into()
+        .map_err(|e: TryFromIntError| GnarkBackendError::SerializeFeltsError(e.to_string()))?;
+    buff.extend_from_slice(&n_felts.to_be_bytes());
+    buff.extend_from_slice(
+        &felts
+            .iter()
+            .flat_map(serialize_felt_unchecked)
+            .collect::<Vec<u8>>(),
+    );
+    Ok(hex::encode(buff))
+}
+
+pub fn serialize_felts<S>(felts: &[gnark_backend::Fr], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::ser::Serializer,
+{
+    let encoded_buff = encode_felts(felts).map_err(serde::ser::Error::custom)?;
+    serializer.serialize_str(&encoded_buff)
+}
+
+#[cfg(feature = "groth16")]
+pub fn deserialize_felt<'de, D>(deserializer: D) -> Result<gnark_backend::Fr, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let felt_bytes = String::deserialize(deserializer)?;
+    let mut decoded = hex::decode(felt_bytes).map_err(serde::de::Error::custom)?;
+    // Turn big-endian to little-endian.
+    decoded.reverse();
+    gnark_backend::Fr::deserialize_uncompressed(decoded.as_slice())
+        .map_err(serde::de::Error::custom)
+}
+
+#[cfg(feature = "groth16")]
+pub fn deserialize_felts<'de, D>(deserializer: D) -> Result<Vec<gnark_backend::Fr>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let serialized_felts = String::deserialize(deserializer)?;
+
+    let mut decoded_felts = hex::decode(serialized_felts).map_err(serde::de::Error::custom)?;
+
+    let n_felts: usize = u32::from_be_bytes(
+        decoded_felts
+            .get(..4)
+            .ok_or_else(|| serde::de::Error::custom("Error getting felts size"))?
+            .try_into()
+            .map_err(serde::de::Error::custom)?,
+    )
+    .try_into()
+    .map_err(serde::de::Error::custom)?;
+    let mut deserialized_felts: Vec<gnark_backend::Fr> = Vec::with_capacity(n_felts);
+
+    decoded_felts
+        .get_mut(4..) // Skip the vector length corresponding to the first four bytes.
+        .ok_or_else(|| serde::de::Error::custom("Error getting decoded felts"))?
+        .chunks_mut(32)
+        .try_for_each(|decoded_felt| {
+            // Turn big-endian to little-endian.
+            decoded_felt.reverse();
+            // Here I reference after dereference because I had a mutable reference and I need a non-mutable one.
+            let felt: gnark_backend::Fr =
+                CanonicalDeserialize::deserialize_uncompressed(&*decoded_felt)
+                    .map_err(serde::de::Error::custom)?;
+            deserialized_felts.push(felt);
+            Ok::<(), D::Error>(())
+        })?;
+
+    Ok(deserialized_felts)
+}

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -1,0 +1,106 @@
+#[macro_use]
+extern crate honggfuzz;
+use crate::gnark_backend_wrapper::c_go_structures::{GoString, KeyPair};
+use crate::gnark_backend_wrapper::errors::GnarkBackendError;
+use std::ffi::{CStr, CString};
+use std::num::TryFromIntError;
+use std::os::raw::{c_char, c_uchar};
+
+// This lists all the functions in the foreign interface along with their type signature.
+extern "C" {
+    fn CreateCircuit(public_input_x: GoString, public_input_y: GoString, private_variable: GoString) -> c_uchar;
+    fn NewWitness(circuit: GoString, field: GoString) -> c_uchar;
+    fn VerityWithCircuitWitness(circuit: GoString, witness: GoString) -> c_uchar;
+}
+
+fn main() {
+    loop {
+        fuzz!(|data1: u64, data2: u64| {
+
+            // This is the circuit for x * e == y
+            let common_preprocesed_input = test_common_preprocessed_input_1();
+            let srs = fuzzer_srs();
+
+            // Public input
+            let x = FieldElement::from(data1);
+            let go_x = GoString::try_from(data1);
+            let y = FieldElement::from(data1 * data2);
+            let go_y = GoString::try_from(data1 * data2);
+
+            // Private variable
+            let e = FieldElement::from(data2);
+            let go_e = GoString::try_from(data2);
+
+            let public_input = vec![x.clone(), y];
+            let witness = fuzzer_witness(x, e);
+
+            let kzg = KZG::new(srs);
+            let verifying_key = setup(&common_preprocesed_input, &kzg);
+            let random_generator = TestRandomFieldGenerator {};
+
+            let prover = Prover::new(kzg.clone(), random_generator);
+
+            let circuit = unsafe { CreateCircuit(go_x , go_y, go_e) };
+            let go_circuit = GoString::try_from(circuit);
+
+            let  witness = unsafe { NewWitness(go_circuit, go_e) };
+            let go_witness = GoString::try_from(witness);
+            let  verify_with_gnark = unsafe { VerityWithCircuitWitness(go_circuit, go_witness) };
+            
+            let proof = prover.prove(
+                &witness,
+                &public_input,
+                &common_preprocesed_input,
+                &verifying_key,
+            );
+
+            let verifier = Verifier::new(kzg);
+            assert_eq!(verifier.verify(
+                &proof,
+                &public_input,
+                &common_preprocesed_input,
+                &verifying_key
+            ), verify_with_gnark);        
+        });
+    }
+}
+
+fn fuzzer_witness(x: FrElement, e: FrElement) -> Witness<FrField> {
+    let y = &x * &e;
+    let empty = x.clone();
+    Witness {
+        a: vec![
+            x.clone(), // Public input
+            y.clone(), // Public input
+            x.clone(), // LHS for multiplication
+            y,         // LHS for ==
+        ],
+        b: vec![
+            empty.clone(),
+            empty.clone(),
+            e.clone(), // RHS for multiplication
+            &x * &e,   // RHS for ==
+        ],
+        c: vec![
+            empty.clone(),
+            empty.clone(),
+            &x * &e, // Output of multiplication
+            empty,
+        ],
+    }
+}
+
+fn fuzzer_srs() -> StructuredReferenceString<G1Point, G2Point> {
+    let s = FrElement::from(2);
+    let g1 = <BLS12381Curve as IsEllipticCurve>::generator();
+    let g2 = <BLS12381TwistCurve as IsEllipticCurve>::generator();
+
+    let powers_main_group: Vec<G1Point> = (0..40)
+        .map(|exp| g1.operate_with_self(s.pow(exp as u64).representative()))
+        .collect();
+    let powers_secondary_group = [g2.clone(), g2.operate_with_self(s.representative())];
+
+    StructuredReferenceString::new(&powers_main_group, &powers_secondary_group)
+}
+
+


### PR DESCRIPTION
# differential fuzzer for plonk vs gnark

## Description

this PR adds a fuzzer that compares the plonk implementation vs the gnark plonk implementation

## the structure

* in gnark_backend there is a main.go file where gnark code is imported and the functions we are going to use are defined
* there´s a build.rs file used to compile go code when running the rust program in order to use it
* there´s a Makefile that does the building
* in src folder we have the folder implementation, inside we use the go code exported as C also we have the backend helper modules

as is currently a work in progress theres still missing the logic in main.go that gets a circuit and a witness and returns the verified result

