### PR TITLE
[STARKs] Fix panic when FRI folding is zero

### DIFF
--- a/proving_system/stark/src/fri/fri_decommit.rs
+++ b/proving_system/stark/src/fri/fri_decommit.rs
@@ -45,7 +45,11 @@ pub fn fri_decommit_layers<F: IsField>(
 
     // send the last element of the polynomial
     let last = commit.last().unwrap();
-    let last_evaluation = last.poly.coefficients[0].clone();
+
+    // This get can't fail, since the last will always have at least one evaluation
+    // (in fact two, but on the last step the two will be the same because the polynomial will have
+    // degree 0).
+    let last_evaluation = last.evaluation[0].clone();
 
     FriDecommitment {
         layer_merkle_paths,

--- a/proving_system/stark/src/fri/mod.rs
+++ b/proving_system/stark/src/fri/mod.rs
@@ -78,7 +78,8 @@ where
     fri_commitment_list.push(commitment_0);
     let mut degree = p_0.degree();
 
-    let mut last_coef = last_poly.coefficients.get(0).unwrap();
+    let mut last_coef = last_poly.coefficients.get(0).unwrap().clone();
+    let zero = FieldElement::zero();
 
     while degree > 0 {
         let beta = transcript_to_field(transcript);
@@ -97,7 +98,8 @@ where
         degree = p_i.degree();
 
         last_poly = p_i.clone();
-        last_coef = last_poly.coefficients.get(0).unwrap();
+        last_coef = last_poly.evaluate(&zero);
+
         last_domain = domain_i.clone();
     }
 


### PR DESCRIPTION
## Description

This is a fix for #216, but with a different solution. We don't need to resample beta, we just needed to not panic when obtaining the last coefficient/last FRI evaluation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist
- [x] Linked to Github Issue
