### PR TITLE
Remove `new` constructor from AIR trait

### DIFF
--- a/proving_system/stark/benches/benchmarks/stark.rs
+++ b/proving_system/stark/benches/benchmarks/stark.rs
@@ -6,7 +6,6 @@ use lambdaworks_stark::{
     air::{
         context::{AirContext, ProofOptions},
         trace::TraceTable,
-        AIR,
     },
     fri::FieldElement,
     prover::prove,
@@ -62,7 +61,7 @@ fn prove_fib() {
         num_transition_constraints: 1,
     };
 
-    let fibonacci_air = simple_fibonacci::FibonacciAIR::new(context);
+    let fibonacci_air = simple_fibonacci::FibonacciAIR::from(context);
 
     let result = prove(&trace_table, &fibonacci_air);
     verify(&result, &fibonacci_air);
@@ -88,7 +87,7 @@ fn prove_fib_2_cols() {
         trace_columns: 2,
     };
 
-    let fibonacci_air = fibonacci_2_columns::Fibonacci2ColsAIR::new(context);
+    let fibonacci_air = fibonacci_2_columns::Fibonacci2ColsAIR::from(context);
 
     let result = prove(&trace_table, &fibonacci_air);
     verify(&result, &fibonacci_air);
@@ -112,7 +111,7 @@ fn prove_fib17() {
         num_transition_constraints: 1,
     };
 
-    let fibonacci_air = fibonacci_f17::Fibonacci17AIR::new(context);
+    let fibonacci_air = fibonacci_f17::Fibonacci17AIR::from(context);
 
     let result = prove(&trace_table, &fibonacci_air);
     verify(&result, &fibonacci_air);
@@ -139,7 +138,7 @@ fn prove_quadratic() {
         num_transition_constraints: 1,
     };
 
-    let fibonacci_air = quadratic_air::QuadraticAIR::new(context);
+    let fibonacci_air = quadratic_air::QuadraticAIR::from(context);
 
     let result = prove(&trace_table, &fibonacci_air);
     verify(&result, &fibonacci_air);

--- a/proving_system/stark/src/air/example/fibonacci_2_columns.rs
+++ b/proving_system/stark/src/air/example/fibonacci_2_columns.rs
@@ -16,12 +16,14 @@ pub struct Fibonacci2ColsAIR {
     context: AirContext,
 }
 
-impl AIR for Fibonacci2ColsAIR {
-    type Field = Stark252PrimeField;
-
-    fn new(context: air::context::AirContext) -> Self {
+impl From<AirContext> for Fibonacci2ColsAIR {
+    fn from(context: AirContext) -> Self {
         Self { context }
     }
+}
+
+impl AIR for Fibonacci2ColsAIR {
+    type Field = Stark252PrimeField;
 
     fn compute_transition(
         &self,

--- a/proving_system/stark/src/air/example/fibonacci_f17.rs
+++ b/proving_system/stark/src/air/example/fibonacci_f17.rs
@@ -14,12 +14,14 @@ pub struct Fibonacci17AIR {
     context: AirContext,
 }
 
-impl AIR for Fibonacci17AIR {
-    type Field = F17;
-
-    fn new(context: air::context::AirContext) -> Self {
+impl From<AirContext> for Fibonacci17AIR {
+    fn from(context: AirContext) -> Self {
         Self { context }
     }
+}
+
+impl AIR for Fibonacci17AIR {
+    type Field = F17;
 
     fn compute_transition(
         &self,

--- a/proving_system/stark/src/air/example/quadratic_air.rs
+++ b/proving_system/stark/src/air/example/quadratic_air.rs
@@ -16,12 +16,14 @@ pub struct QuadraticAIR {
     context: AirContext,
 }
 
-impl AIR for QuadraticAIR {
-    type Field = Stark252PrimeField;
-
-    fn new(context: air::context::AirContext) -> Self {
+impl From<AirContext> for QuadraticAIR {
+    fn from(context: AirContext) -> Self {
         Self { context }
     }
+}
+
+impl AIR for QuadraticAIR {
+    type Field = Stark252PrimeField;
 
     fn compute_transition(
         &self,

--- a/proving_system/stark/src/air/example/simple_fibonacci.rs
+++ b/proving_system/stark/src/air/example/simple_fibonacci.rs
@@ -16,12 +16,14 @@ pub struct FibonacciAIR {
     context: AirContext,
 }
 
-impl AIR for FibonacciAIR {
-    type Field = Stark252PrimeField;
-
-    fn new(context: air::context::AirContext) -> Self {
+impl From<AirContext> for FibonacciAIR {
+    fn from(context: AirContext) -> Self {
         Self { context }
     }
+}
+
+impl AIR for FibonacciAIR {
+    type Field = Stark252PrimeField;
 
     fn compute_transition(
         &self,

--- a/proving_system/stark/src/air/mod.rs
+++ b/proving_system/stark/src/air/mod.rs
@@ -18,7 +18,6 @@ pub mod trace;
 pub trait AIR: Clone {
     type Field: IsTwoAdicField;
 
-    fn new(context: AirContext) -> Self;
     fn compute_transition(&self, frame: &Frame<Self::Field>) -> Vec<FieldElement<Self::Field>>;
     fn boundary_constraints(&self) -> BoundaryConstraints<Self::Field>;
     fn transition_divisors(&self) -> Vec<Polynomial<FieldElement<Self::Field>>> {

--- a/proving_system/stark/tests/integration_tests.rs
+++ b/proving_system/stark/tests/integration_tests.rs
@@ -7,9 +7,8 @@ use lambdaworks_stark::air::example::{
 use lambdaworks_stark::{
     air::{
         context::{AirContext, ProofOptions},
-        example::{fibonacci_2_columns::fibonacci_trace_2_columns, simple_fibonacci::FibonacciAIR},
+        example::fibonacci_2_columns::fibonacci_trace_2_columns,
         trace::TraceTable,
-        AIR,
     },
     fri::FieldElement,
     prover::prove,
@@ -38,7 +37,7 @@ fn test_prove_fib() {
         num_transition_constraints: 1,
     };
 
-    let fibonacci_air = FibonacciAIR::new(context);
+    let fibonacci_air = simple_fibonacci::FibonacciAIR::from(context);
 
     let result = prove(&trace_table, &fibonacci_air);
     assert!(verify(&result, &fibonacci_air));
@@ -63,7 +62,7 @@ fn test_prove_fib17() {
         num_transition_constraints: 1,
     };
 
-    let fibonacci_air = fibonacci_f17::Fibonacci17AIR::new(context);
+    let fibonacci_air = fibonacci_f17::Fibonacci17AIR::from(context);
 
     let result = prove(&trace_table, &fibonacci_air);
     assert!(verify(&result, &fibonacci_air));
@@ -89,7 +88,7 @@ fn test_prove_fib_2_cols() {
         trace_columns: 2,
     };
 
-    let fibonacci_air = fibonacci_2_columns::Fibonacci2ColsAIR::new(context);
+    let fibonacci_air = fibonacci_2_columns::Fibonacci2ColsAIR::from(context);
 
     let result = prove(&trace_table, &fibonacci_air);
     assert!(verify(&result, &fibonacci_air));
@@ -117,7 +116,7 @@ fn test_prove_quadratic() {
         num_transition_constraints: 1,
     };
 
-    let fibonacci_air = quadratic_air::QuadraticAIR::new(context);
+    let fibonacci_air = quadratic_air::QuadraticAIR::from(context);
 
     let result = prove(&trace_table, &fibonacci_air);
     assert!(verify(&result, &fibonacci_air));


### PR DESCRIPTION
# Remove the `new` constructor method from the `AIR` trait.

## Description

We need to add more parameters to our `AIR` implementation, but the trait only allows for a constructor with a `AirContext` parameter. I removed the constructor from the trait since it's not used by other functions, and updated the tests that used it by replacing the `new` method with a `From<AirContext>` implementation.

## Type of change

- Refactor

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
