### PR TITLE
Compilation in ESP32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Cargo.lock
 
 **/proptest-regressions
 /output.txt
+
+.embuild

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ members = [
     "proving_system/stark",
     "proving_system/plonk",
     "gpu",
+    "test_esp32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[profile.release]
+opt-level = "s"
+
 [workspace]
 members = [
     "math",

--- a/crypto/.cargo/config.toml
+++ b/crypto/.cargo/config.toml
@@ -1,0 +1,40 @@
+[build]
+# Uncomment the relevant target for your chip here (ESP32, ESP32-S2, ESP32-S3 or ESP32-C3)
+#target = "xtensa-esp32-espidf"
+#target = "xtensa-esp32s2-espidf"
+#target = "xtensa-esp32s3-espidf"
+#target = "riscv32imc-esp-espidf"
+
+[target.xtensa-esp32-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.xtensa-esp32s2-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.xtensa-esp32s3-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.riscv32imc-esp-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+# Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
+# For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
+rustflags = ["-C", "default-linker-libraries"]
+
+#[unstable]
+
+#build-std = ["std", "panic_abort"]
+#build-std-features = ["panic_immediate_abort"] # Required for older ESP-IDF versions without a realpath implementation
+
+[env]
+# Note: these variables are not used when using pio builder (`cargo build --features pio`)
+# Builds against ESP-IDF stable (v4.4)
+ESP_IDF_VERSION = "release/v4.4"
+# Builds against ESP-IDF master (mainline)
+#ESP_IDF_VERSION = "master"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 sha3 = "0.10.6"
+sha2 = { version = "0.10.6", optional = true }
 embedded-hal = { version = "1.0.0-alpha.9", optional = true }
 esp-idf-sys = { version = "0.32", features = ["binstart"], optional = true }
 esp-idf-hal = { version = "0.40.1", optional = true }
@@ -23,4 +24,4 @@ anyhow = "1"
 
 [features]
 test_fiat_shamir = []
-esp = ["embedded-hal", "esp-idf-sys", "esp-idf-hal", "lambdaworks-math/esp"]
+esp = ["sha2", "embedded-hal", "esp-idf-sys", "esp-idf-hal", "lambdaworks-math/esp"]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -5,14 +5,22 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies.lambdaworks-math]
-path = "../math"
-
 [dependencies]
 sha3 = "0.10.6"
+embedded-hal = { version = "1.0.0-alpha.9", optional = true }
+esp-idf-sys = { version = "0.32", features = ["binstart"], optional = true }
+esp-idf-hal = { version = "0.40.1", optional = true }
+
+[dependencies.lambdaworks-math]
+path = "../math"
 
 [dependencies.rand]
 version = "0.8"
 
+[build-dependencies]
+embuild = "0.31.1"
+anyhow = "1"
+
 [features]
 test_fiat_shamir = []
+esp = ["embedded-hal", "esp-idf-sys", "esp-idf-hal", "lambdaworks-math/esp"]

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -1,0 +1,19 @@
+PORT?=/dev/cu.SLAB_USBtoUART*
+PROJECT_NAME=lambdaworks-math
+
+.PHONY: default compile_esp upload log clean
+
+default: clean compile_esp upload
+
+compile_esp: ## Compile rust
+	cargo clean
+	IDF_PYTHON_ENV_PATH=/opt/homebrew/bin/python3 cargo +nightly build --features esp --release --target riscv32imc-esp-espidf -Z build-std=std,panic_abort
+
+upload: ## Upload the firmware to the board
+	espflash $(PORT) target/riscv32imc-esp-espidf/target/$(PROJECT_NAME)
+
+log: ## Start the logs
+	espmonitor $(PORT)
+
+clean: ## Remove all build files
+	cargo clean

--- a/crypto/build.rs
+++ b/crypto/build.rs
@@ -1,0 +1,9 @@
+// Necessary because of this issue: https://github.com/rust-lang/cargo/issues/9641
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "esp")]
+    {
+        embuild::build::CfgArgs::output_propagated("ESP_IDF")?;
+        embuild::build::LinkArgs::output_propagated("ESP_IDF")?;
+    }
+    Ok(())
+}

--- a/crypto/sdkconfig.defaults
+++ b/crypto/sdkconfig.defaults
@@ -1,0 +1,10 @@
+# Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
+
+# Use this to set FreeRTOS kernel tick frequency to 1000 Hz (100 Hz by default).
+# This allows to use 1 ms granuality for thread sleeps (10 ms by default).
+#CONFIG_FREERTOS_HZ=1000
+
+# Workaround for https://github.com/espressif/esp-idf/issues/7631
+#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
+#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n

--- a/crypto/src/fiat_shamir/embedded_transcript.rs
+++ b/crypto/src/fiat_shamir/embedded_transcript.rs
@@ -1,0 +1,34 @@
+use sha2::{Digest, Sha256, Sha224};
+
+use super::transcript::Transcript;
+
+pub struct EmbeddedTranscript {
+    hasher: Sha224,
+}
+
+impl Transcript for EmbeddedTranscript {
+    fn append(&mut self, new_data: &[u8]) {
+        self.hasher.update(&mut new_data.to_owned());
+    }
+
+    fn challenge(&mut self) -> [u8; 28] {
+        let mut result_hash = [0_u8; 28];
+        result_hash.copy_from_slice(&self.hasher.finalize_reset());
+        self.hasher.update(result_hash);
+        result_hash
+    }
+}
+
+impl Default for EmbeddedTranscript {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EmbeddedTranscript {
+    pub fn new() -> Self {
+        Self {
+            hasher: Sha224::new(),
+        }
+    }
+}

--- a/crypto/src/fiat_shamir/mod.rs
+++ b/crypto/src/fiat_shamir/mod.rs
@@ -2,3 +2,5 @@ pub mod default_transcript;
 #[cfg(feature = "test_fiat_shamir")]
 pub mod test_transcript;
 pub mod transcript;
+#[cfg(feature = "esp")]
+pub mod embedded_transcript;

--- a/crypto/src/fiat_shamir/transcript.rs
+++ b/crypto/src/fiat_shamir/transcript.rs
@@ -1,4 +1,7 @@
 pub trait Transcript {
     fn append(&mut self, new_data: &[u8]);
+    #[cfg(not(feature = "esp"))]
     fn challenge(&mut self) -> [u8; 32];
+    #[cfg(feature = "esp")]
+    fn challenge(&mut self) -> [u8; 28];
 }

--- a/fft/.cargo/config.toml
+++ b/fft/.cargo/config.toml
@@ -1,0 +1,40 @@
+[build]
+# Uncomment the relevant target for your chip here (ESP32, ESP32-S2, ESP32-S3 or ESP32-C3)
+#target = "xtensa-esp32-espidf"
+#target = "xtensa-esp32s2-espidf"
+#target = "xtensa-esp32s3-espidf"
+#target = "riscv32imc-esp-espidf"
+
+[target.xtensa-esp32-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.xtensa-esp32s2-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.xtensa-esp32s3-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.riscv32imc-esp-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+# Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
+# For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
+rustflags = ["-C", "default-linker-libraries"]
+
+#[unstable]
+
+#build-std = ["std", "panic_abort"]
+#build-std-features = ["panic_immediate_abort"] # Required for older ESP-IDF versions without a realpath implementation
+
+[env]
+# Note: these variables are not used when using pio builder (`cargo build --features pio`)
+# Builds against ESP-IDF stable (v4.4)
+ESP_IDF_VERSION = "release/v4.4"
+# Builds against ESP-IDF master (mainline)
+#ESP_IDF_VERSION = "master"

--- a/fft/Cargo.toml
+++ b/fft/Cargo.toml
@@ -8,15 +8,23 @@ rand = "0.8.5"
 thiserror = "1.0.38"
 lambdaworks-math = { path = "../math" }
 lambdaworks-gpu = { path = "../gpu", optional = true }
+embedded-hal = { version = "1.0.0-alpha.9", optional = true }
+esp-idf-sys = { version = "0.32", features = ["binstart"], optional = true }
+esp-idf-hal = { version = "0.40.1", optional = true }
 
 [dev-dependencies]
 proptest = "1.1.0"
 criterion = "0.4.0"
 objc = "0.2.7"
 
+[build-dependencies]
+embuild = "0.31.1"
+anyhow = "1"
+
 [features]
 metal = ["dep:lambdaworks-gpu"]
 cuda = ["dep:lambdaworks-gpu"]
+esp = ["embedded-hal", "esp-idf-sys", "esp-idf-hal", "lambdaworks-math/esp"]
 
 [[bench]]
 name = "fft_benchmarks"

--- a/fft/Makefile
+++ b/fft/Makefile
@@ -1,0 +1,19 @@
+PORT?=/dev/cu.SLAB_USBtoUART*
+PROJECT_NAME=lambdaworks-math
+
+.PHONY: default compile_esp upload log clean
+
+default: clean compile_esp upload
+
+compile_esp: ## Compile rust
+	cargo clean
+	IDF_PYTHON_ENV_PATH=/opt/homebrew/bin/python3 cargo +nightly build --features esp --release --target riscv32imc-esp-espidf -Z build-std=std,panic_abort
+
+upload: ## Upload the firmware to the board
+	espflash $(PORT) target/riscv32imc-esp-espidf/target/$(PROJECT_NAME)
+
+log: ## Start the logs
+	espmonitor $(PORT)
+
+clean: ## Remove all build files
+	cargo clean

--- a/fft/build.rs
+++ b/fft/build.rs
@@ -1,0 +1,9 @@
+// Necessary because of this issue: https://github.com/rust-lang/cargo/issues/9641
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "esp")]
+    {
+        embuild::build::CfgArgs::output_propagated("ESP_IDF")?;
+        embuild::build::LinkArgs::output_propagated("ESP_IDF")?;
+    }
+    Ok(())
+}

--- a/fft/sdkconfig.defaults
+++ b/fft/sdkconfig.defaults
@@ -1,0 +1,10 @@
+# Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
+
+# Use this to set FreeRTOS kernel tick frequency to 1000 Hz (100 Hz by default).
+# This allows to use 1 ms granuality for thread sleeps (10 ms by default).
+#CONFIG_FREERTOS_HZ=1000
+
+# Workaround for https://github.com/espressif/esp-idf/issues/7631
+#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
+#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n

--- a/math/.cargo/config.toml
+++ b/math/.cargo/config.toml
@@ -1,0 +1,40 @@
+[build]
+# Uncomment the relevant target for your chip here (ESP32, ESP32-S2, ESP32-S3 or ESP32-C3)
+#target = "xtensa-esp32-espidf"
+#target = "xtensa-esp32s2-espidf"
+#target = "xtensa-esp32s3-espidf"
+#target = "riscv32imc-esp-espidf"
+
+[target.xtensa-esp32-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.xtensa-esp32s2-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.xtensa-esp32s3-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.riscv32imc-esp-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+# Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
+# For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
+rustflags = ["-C", "default-linker-libraries"]
+
+#[unstable]
+
+#build-std = ["std", "panic_abort"]
+#build-std-features = ["panic_immediate_abort"] # Required for older ESP-IDF versions without a realpath implementation
+
+[env]
+# Note: these variables are not used when using pio builder (`cargo build --features pio`)
+# Builds against ESP-IDF stable (v4.4)
+ESP_IDF_VERSION = "release/v4.4"
+# Builds against ESP-IDF master (mainline)
+#ESP_IDF_VERSION = "master"

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 [dependencies]
 rand = "0.8.5"
 thiserror = "1.0.38"
+embedded-hal = "1.0.0-alpha.9"
+esp-idf-sys = { version = "0.32", features = ["binstart"] }
+esp-idf-hal = "0.40.1"
 
 [dev-dependencies]
 proptest = "1.1.0"
@@ -25,3 +28,10 @@ harness = false
 [[bench]]
 name = "polynomial_benchmarks"
 harness = false
+
+[build-dependencies]
+embuild = "0.31.1"
+anyhow = "1"
+
+[features]
+pio = ["esp-idf-sys/pio"]

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -8,14 +8,18 @@ edition = "2021"
 [dependencies]
 rand = "0.8.5"
 thiserror = "1.0.38"
-embedded-hal = "1.0.0-alpha.9"
-esp-idf-sys = { version = "0.32", features = ["binstart"] }
-esp-idf-hal = "0.40.1"
+embedded-hal = { version = "1.0.0-alpha.9", optional = true }
+esp-idf-sys = { version = "0.32", features = ["binstart"], optional = true }
+esp-idf-hal = { version = "0.40.1", optional = true }
 
 [dev-dependencies]
 proptest = "1.1.0"
 criterion = "0.4"
 const-random = "0.1.15"
+
+[build-dependencies]
+embuild = "0.31.1"
+anyhow = "1"
 
 [[bench]]
 name = "all_benchmarks"
@@ -29,9 +33,6 @@ harness = false
 name = "polynomial_benchmarks"
 harness = false
 
-[build-dependencies]
-embuild = "0.31.1"
-anyhow = "1"
-
 [features]
 pio = ["esp-idf-sys/pio"]
+esp = ["embedded-hal", "esp-idf-sys", "esp-idf-hal"]

--- a/math/Makefile
+++ b/math/Makefile
@@ -1,13 +1,13 @@
 PORT?=/dev/cu.SLAB_USBtoUART*
 PROJECT_NAME=lambdaworks-math
 
-.PHONY: default compile upload log clean
+.PHONY: default compile_esp upload log clean
 
-default: clean compile upload
+default: clean compile_esp upload
 
-compile: ## Compile rust
+compile_esp: ## Compile rust
 	cargo clean
-	IDF_PYTHON_ENV_PATH=/opt/homebrew/bin/python3 cargo +nightly build --release --target riscv32imc-esp-espidf -Z build-std=std,panic_abort
+	IDF_PYTHON_ENV_PATH=/opt/homebrew/bin/python3 cargo +nightly build --features esp --release --target riscv32imc-esp-espidf -Z build-std=std,panic_abort
 
 upload: ## Upload the firmware to the board
 	espflash $(PORT) target/riscv32imc-esp-espidf/target/$(PROJECT_NAME)

--- a/math/Makefile
+++ b/math/Makefile
@@ -1,0 +1,19 @@
+PORT?=/dev/cu.SLAB_USBtoUART*
+PROJECT_NAME=lambdaworks-math
+
+.PHONY: default compile upload log clean
+
+default: clean compile upload
+
+compile: ## Compile rust
+	cargo clean
+	IDF_PYTHON_ENV_PATH=/opt/homebrew/bin/python3 cargo +nightly build --release --target riscv32imc-esp-espidf -Z build-std=std,panic_abort
+
+upload: ## Upload the firmware to the board
+	espflash $(PORT) target/riscv32imc-esp-espidf/target/$(PROJECT_NAME)
+
+log: ## Start the logs
+	espmonitor $(PORT)
+
+clean: ## Remove all build files
+	cargo clean

--- a/math/build.rs
+++ b/math/build.rs
@@ -1,0 +1,6 @@
+// Necessary because of this issue: https://github.com/rust-lang/cargo/issues/9641
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    embuild::build::CfgArgs::output_propagated("ESP_IDF")?;
+    embuild::build::LinkArgs::output_propagated("ESP_IDF")?;
+    Ok(())
+}

--- a/math/build.rs
+++ b/math/build.rs
@@ -1,6 +1,9 @@
 // Necessary because of this issue: https://github.com/rust-lang/cargo/issues/9641
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    embuild::build::CfgArgs::output_propagated("ESP_IDF")?;
-    embuild::build::LinkArgs::output_propagated("ESP_IDF")?;
+    #[cfg(feature = "esp")]
+    {
+        embuild::build::CfgArgs::output_propagated("ESP_IDF")?;
+        embuild::build::LinkArgs::output_propagated("ESP_IDF")?;
+    }
     Ok(())
 }

--- a/math/sdkconfig.defaults
+++ b/math/sdkconfig.defaults
@@ -1,0 +1,10 @@
+# Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
+
+# Use this to set FreeRTOS kernel tick frequency to 1000 Hz (100 Hz by default).
+# This allows to use 1 ms granuality for thread sleeps (10 ms by default).
+#CONFIG_FREERTOS_HZ=1000
+
+# Workaround for https://github.com/espressif/esp-idf/issues/7631
+#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
+#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n

--- a/proving_system/stark/.cargo/config.toml
+++ b/proving_system/stark/.cargo/config.toml
@@ -1,0 +1,40 @@
+[build]
+# Uncomment the relevant target for your chip here (ESP32, ESP32-S2, ESP32-S3 or ESP32-C3)
+#target = "xtensa-esp32-espidf"
+#target = "xtensa-esp32s2-espidf"
+#target = "xtensa-esp32s3-espidf"
+#target = "riscv32imc-esp-espidf"
+
+[target.xtensa-esp32-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.xtensa-esp32s2-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.xtensa-esp32s3-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.riscv32imc-esp-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+# Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
+# For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
+rustflags = ["-C", "default-linker-libraries"]
+
+#[unstable]
+
+#build-std = ["std", "panic_abort"]
+#build-std-features = ["panic_immediate_abort"] # Required for older ESP-IDF versions without a realpath implementation
+
+[env]
+# Note: these variables are not used when using pio builder (`cargo build --features pio`)
+# Builds against ESP-IDF stable (v4.4)
+ESP_IDF_VERSION = "release/v4.4"
+# Builds against ESP-IDF master (mainline)
+#ESP_IDF_VERSION = "master"

--- a/proving_system/stark/Cargo.toml
+++ b/proving_system/stark/Cargo.toml
@@ -11,13 +11,28 @@ lambdaworks-math = { path = "../../math" }
 lambdaworks-crypto = { path = "../../crypto" }
 lambdaworks-fft = { path = "../../fft" }
 thiserror = "1.0.38"
+embedded-hal = { version = "1.0.0-alpha.9", optional = true }
+esp-idf-sys = { version = "0.32", features = ["binstart"], optional = true }
+esp-idf-hal = { version = "0.40.1", optional = true }
 
 [dev-dependencies]
 hex = "0.4.3"
 criterion = "0.4"
 
+[build-dependencies]
+embuild = "0.31.1"
+anyhow = "1"
+
 [features]
 test_fiat_shamir = []
+esp = [
+    "embedded-hal",
+    "esp-idf-sys",
+    "esp-idf-hal",
+    "lambdaworks-math/esp",
+    "lambdaworks-crypto/esp",
+    "lambdaworks-fft/esp"
+]
 
 [[bench]]
 name = "all_benchmarks"

--- a/proving_system/stark/Makefile
+++ b/proving_system/stark/Makefile
@@ -1,0 +1,19 @@
+PORT?=/dev/cu.SLAB_USBtoUART*
+PROJECT_NAME=lambdaworks-math
+
+.PHONY: default compile_esp upload log clean
+
+default: clean compile_esp upload
+
+compile_esp: ## Compile rust
+	cargo clean
+	IDF_PYTHON_ENV_PATH=/opt/homebrew/bin/python3 cargo +nightly build --features esp --release --target riscv32imc-esp-espidf -Z build-std=std,panic_abort
+
+upload: ## Upload the firmware to the board
+	espflash $(PORT) target/riscv32imc-esp-espidf/target/$(PROJECT_NAME)
+
+log: ## Start the logs
+	espmonitor $(PORT)
+
+clean: ## Remove all build files
+	cargo clean

--- a/proving_system/stark/build.rs
+++ b/proving_system/stark/build.rs
@@ -1,0 +1,9 @@
+// Necessary because of this issue: https://github.com/rust-lang/cargo/issues/9641
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "esp")]
+    {
+        embuild::build::CfgArgs::output_propagated("ESP_IDF")?;
+        embuild::build::LinkArgs::output_propagated("ESP_IDF")?;
+    }
+    Ok(())
+}

--- a/proving_system/stark/sdkconfig.defaults
+++ b/proving_system/stark/sdkconfig.defaults
@@ -1,0 +1,10 @@
+# Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
+
+# Use this to set FreeRTOS kernel tick frequency to 1000 Hz (100 Hz by default).
+# This allows to use 1 ms granuality for thread sleeps (10 ms by default).
+#CONFIG_FREERTOS_HZ=1000
+
+# Workaround for https://github.com/espressif/esp-idf/issues/7631
+#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
+#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n

--- a/proving_system/stark/src/prover.rs
+++ b/proving_system/stark/src/prover.rs
@@ -61,7 +61,6 @@ where
                 &FieldElement::<F>::from(air.options().coset_offset),
                 air.options().blowup_factor as usize,
             );
-            dbg!(&res);
             res
         })
         .collect::<Result<Vec<Vec<FieldElement<F>>>, FFTError>>()

--- a/proving_system/stark/src/prover.rs
+++ b/proving_system/stark/src/prover.rs
@@ -11,6 +11,9 @@ use crate::{
 use lambdaworks_crypto::fiat_shamir::default_transcript::DefaultTranscript;
 use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
 
+#[cfg(feature = "esp")]
+use lambdaworks_crypto::fiat_shamir::embedded_transcript::EmbeddedTranscript;
+
 #[cfg(feature = "test_fiat_shamir")]
 use lambdaworks_crypto::fiat_shamir::test_transcript::TestTranscript;
 
@@ -28,7 +31,12 @@ where
     FieldElement<F>: ByteConversion,
 {
     #[cfg(not(feature = "test_fiat_shamir"))]
-    let transcript = &mut DefaultTranscript::new();
+    let transcript = {
+        #[cfg(not(feature = "esp"))]
+        {&mut DefaultTranscript::new()}
+        #[cfg(feature = "esp")]
+        {&mut EmbeddedTranscript::new()}
+    };
     #[cfg(feature = "test_fiat_shamir")]
     let transcript = &mut TestTranscript::new();
 

--- a/proving_system/stark/src/verifier.rs
+++ b/proving_system/stark/src/verifier.rs
@@ -6,6 +6,8 @@ use super::{
 use crate::{fri::HASHER, proof::StarkProof, transcript_to_field, transcript_to_usize};
 #[cfg(not(feature = "test_fiat_shamir"))]
 use lambdaworks_crypto::fiat_shamir::default_transcript::DefaultTranscript;
+#[cfg(feature = "esp")]
+use lambdaworks_crypto::fiat_shamir::embedded_transcript::EmbeddedTranscript;
 use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
 #[cfg(feature = "test_fiat_shamir")]
 use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
@@ -25,7 +27,12 @@ where
     FieldElement<F>: ByteConversion,
 {
     #[cfg(not(feature = "test_fiat_shamir"))]
-    let transcript = &mut DefaultTranscript::new();
+    let transcript = {
+        #[cfg(not(feature = "esp"))]
+        {&mut DefaultTranscript::new()}
+        #[cfg(feature = "esp")]
+        {&mut EmbeddedTranscript::new()}
+    };
     #[cfg(feature = "test_fiat_shamir")]
     let transcript = &mut TestTranscript::new();
 

--- a/test_esp32/.cargo/config.toml
+++ b/test_esp32/.cargo/config.toml
@@ -1,0 +1,40 @@
+[build]
+# Uncomment the relevant target for your chip here (ESP32, ESP32-S2, ESP32-S3 or ESP32-C3)
+#target = "xtensa-esp32-espidf"
+#target = "xtensa-esp32s2-espidf"
+#target = "xtensa-esp32s3-espidf"
+target = "riscv32imc-esp-espidf"
+
+[target.xtensa-esp32-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.xtensa-esp32s2-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.xtensa-esp32s3-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+#rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+
+[target.riscv32imc-esp-espidf]
+linker = "ldproxy"
+runner = "espflash --monitor"
+# Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3. See also https://github.com/ivmarkov/embuild/issues/16
+# For ESP-IDF 5 add `espidf_time64` and for earlier versions - remove this flag: https://github.com/esp-rs/rust/issues/110
+rustflags = ["-C", "default-linker-libraries"]
+
+[unstable]
+
+build-std = ["std", "panic_abort"]
+#build-std-features = ["panic_immediate_abort"] # Required for older ESP-IDF versions without a realpath implementation
+
+[env]
+# Note: these variables are not used when using pio builder (`cargo build --features pio`)
+# Builds against ESP-IDF stable (v4.4)
+ESP_IDF_VERSION = "release/v4.4"
+# Builds against ESP-IDF master (mainline)
+#ESP_IDF_VERSION = "master"

--- a/test_esp32/Cargo.toml
+++ b/test_esp32/Cargo.toml
@@ -10,6 +10,7 @@ embedded-hal = { version = "1.0.0-alpha.9" }
 esp-idf-sys = { version = "0.32", features = ["binstart"] }
 esp-idf-hal = { version = "0.40.1" }
 lambdaworks-math = { path = "../math", features = ["esp"]  }
+lambdaworks-stark = { path = "../proving_system/stark", features = ["esp"]  }
 
 [build-dependencies]
 embuild = "0.31.1"

--- a/test_esp32/Cargo.toml
+++ b/test_esp32/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "test_esp32"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+embedded-hal = { version = "1.0.0-alpha.9" }
+esp-idf-sys = { version = "0.32", features = ["binstart"] }
+esp-idf-hal = { version = "0.40.1" }
+lambdaworks-math = { path = "../math", features = ["esp"]  }
+
+[build-dependencies]
+embuild = "0.31.1"
+anyhow = "1"

--- a/test_esp32/Makefile
+++ b/test_esp32/Makefile
@@ -1,0 +1,20 @@
+#PORT?=/dev/cu.SLAB_USBtoUART*
+PORT=/dev/cu.usbserial-11140
+PROJECT_NAME=test_esp32
+
+.PHONY: default compile_esp upload log clean
+
+default: clean compile_esp upload
+
+compile_esp: ## Compile rust
+	cargo clean
+	IDF_PYTHON_ENV_PATH=/opt/homebrew/bin/python3 cargo +nightly build --release --target riscv32imc-esp-espidf -Z build-std=std,panic_abort
+
+upload: ## Upload the firmware to the board
+	espflash $(PORT) ../target/riscv32imc-esp-espidf/release/test_esp32
+
+log: ## Start the logs
+	espmonitor $(PORT)
+
+clean: ## Remove all build files
+	cargo clean

--- a/test_esp32/build.rs
+++ b/test_esp32/build.rs
@@ -1,0 +1,6 @@
+// Necessary because of this issue: https://github.com/rust-lang/cargo/issues/9641
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    embuild::build::CfgArgs::output_propagated("ESP_IDF")?;
+    embuild::build::LinkArgs::output_propagated("ESP_IDF")?;
+    Ok(())
+}

--- a/test_esp32/rust-toolchain.toml
+++ b/test_esp32/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/test_esp32/sdkconfig.defaults
+++ b/test_esp32/sdkconfig.defaults
@@ -1,0 +1,10 @@
+# Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
+
+# Use this to set FreeRTOS kernel tick frequency to 1000 Hz (100 Hz by default).
+# This allows to use 1 ms granuality for thread sleeps (10 ms by default).
+#CONFIG_FREERTOS_HZ=1000
+
+# Workaround for https://github.com/espressif/esp-idf/issues/7631
+#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
+#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n

--- a/test_esp32/src/main.rs
+++ b/test_esp32/src/main.rs
@@ -1,0 +1,34 @@
+//use esp_idf_hal::peripherals::Peripherals;
+//use esp_idf_hal::gpio::PinDriver;
+use esp_idf_sys as _;
+use lambdaworks_math::field::{
+    element::FieldElement, fields::u64_prime_field::U64PrimeField,
+    fields::montgomery_backed_prime_fields::{IsModulus, U256PrimeField},
+    traits::IsTwoAdicField,
+};
+use lambdaworks_math::unsigned_integer::element::{UnsignedInteger, U256};
+use std::thread;
+use std::time::Duration;
+
+
+#[derive(Clone, Debug)]
+pub struct MontgomeryConfigStark252PrimeField;
+impl IsModulus<U256> for MontgomeryConfigStark252PrimeField {
+    const MODULUS: U256 =
+        U256::from("800000000000011000000000000000000000000000000000000000000000001");
+}
+
+pub type Stark252PrimeField = U256PrimeField<MontgomeryConfigStark252PrimeField>;
+type FE = FieldElement<Stark252PrimeField>;
+
+fn main() {
+    let elem_one = FE::one();
+    let mut val = FE::zero();
+
+    loop {
+        println!("Test lambdaworks!");
+        thread::sleep(Duration::from_millis(1000));
+        val = val + &elem_one;
+        println!("{val:?}");
+    }
+}

--- a/test_esp32/src/main.rs
+++ b/test_esp32/src/main.rs
@@ -22,6 +22,7 @@ use lambdaworks_stark::air::example::{
 use lambdaworks_stark::air::trace::TraceTable;
 use lambdaworks_stark::air::AIR;
 use lambdaworks_stark::prover::prove;
+use lambdaworks_stark::verifier::verify;
 
 pub type Stark252PrimeField = U256PrimeField<MontgomeryConfigStark252PrimeField>;
 type FE = FieldElement<Stark252PrimeField>;
@@ -36,16 +37,32 @@ fn main() {
         // Enable WatchDogTask on the main (=this) task.
         //esp_idf_sys::esp_task_wdt_add(esp_idf_sys::xTaskGetCurrentTaskHandle());
     };
+    
+    let mut i = 0_u64;
 
     loop {
-        println!("Test stark! 16");
-        thread::sleep(Duration::from_millis(1000));
+
         test_prove_fib();
+/*
+        let builder = thread::Builder::new().stack_size(280 * 1024);
+        let th = builder.spawn(move || {
+            println!("New thread! {i}");
+
+            println!("Test stark! 32");
+            test_prove_fib();
+        }).unwrap();
+*/
+
+        i += 1;
+
+        //th.join().unwrap();
+
+        //thread::sleep(Duration::from_millis(1000));
     }
 }
 
 fn test_prove_fib() {
-    let trace = simple_fibonacci::fibonacci_trace([FE::from(1), FE::from(1)], 16);
+    let trace = simple_fibonacci::fibonacci_trace([FE::from(1), FE::from(1)], 32);
     let trace_length = trace[0].len();
     let trace_table = TraceTable::new_from_cols(&trace);
 
@@ -68,7 +85,8 @@ fn test_prove_fib() {
     let result = prove(&trace_table, &fibonacci_air);
     let cant_query_list = result.query_list.len();
     println!("cant: {cant_query_list}");
-    //    assert!(verify(&result, &fibonacci_air));
+    let ret_verify = verify(&result, &fibonacci_air);
+    println!("ret_verify: {ret_verify:?}");
 }
 
 fn interpolation_example() {

--- a/test_esp32/src/main.rs
+++ b/test_esp32/src/main.rs
@@ -2,33 +2,86 @@
 //use esp_idf_hal::gpio::PinDriver;
 use esp_idf_sys as _;
 use lambdaworks_math::field::{
-    element::FieldElement, fields::u64_prime_field::U64PrimeField,
+    element::FieldElement,
     fields::montgomery_backed_prime_fields::{IsModulus, U256PrimeField},
+    fields::u64_prime_field::U64PrimeField,
     traits::IsTwoAdicField,
 };
+use lambdaworks_math::polynomial::Polynomial;
 use lambdaworks_math::unsigned_integer::element::{UnsignedInteger, U256};
 use std::thread;
 use std::time::Duration;
 
-
-#[derive(Clone, Debug)]
-pub struct MontgomeryConfigStark252PrimeField;
-impl IsModulus<U256> for MontgomeryConfigStark252PrimeField {
-    const MODULUS: U256 =
-        U256::from("800000000000011000000000000000000000000000000000000000000000001");
-}
+use lambdaworks_math::field::fields::fft_friendly::stark_252_prime_field::MontgomeryConfigStark252PrimeField;
+use lambdaworks_stark::air::context::AirContext;
+use lambdaworks_stark::air::context::ProofOptions;
+use lambdaworks_stark::air::example::simple_fibonacci::FibonacciAIR;
+use lambdaworks_stark::air::example::{
+    fibonacci_2_columns, fibonacci_f17, quadratic_air, simple_fibonacci,
+};
+use lambdaworks_stark::air::trace::TraceTable;
+use lambdaworks_stark::air::AIR;
+use lambdaworks_stark::prover::prove;
 
 pub type Stark252PrimeField = U256PrimeField<MontgomeryConfigStark252PrimeField>;
 type FE = FieldElement<Stark252PrimeField>;
 
 fn main() {
+    unsafe {
+        // Disable IDLE task WatchDogTask on this CPU.
+        esp_idf_sys::esp_task_wdt_delete(esp_idf_sys::xTaskGetIdleTaskHandleForCPU(
+            esp_idf_hal::cpu::core() as u32,
+        ));
+
+        // Enable WatchDogTask on the main (=this) task.
+        //esp_idf_sys::esp_task_wdt_add(esp_idf_sys::xTaskGetCurrentTaskHandle());
+    };
+
+    loop {
+        println!("Test stark! 16");
+        thread::sleep(Duration::from_millis(1000));
+        test_prove_fib();
+    }
+}
+
+fn test_prove_fib() {
+    let trace = simple_fibonacci::fibonacci_trace([FE::from(1), FE::from(1)], 16);
+    let trace_length = trace[0].len();
+    let trace_table = TraceTable::new_from_cols(&trace);
+
+    let context = AirContext {
+        options: ProofOptions {
+            blowup_factor: 2,
+            fri_number_of_queries: 1,
+            coset_offset: 3,
+        },
+        trace_length,
+        trace_columns: trace_table.n_cols,
+        transition_degrees: vec![1],
+        transition_exemptions: vec![2],
+        transition_offsets: vec![0, 1, 2],
+        num_transition_constraints: 1,
+    };
+
+    let fibonacci_air = FibonacciAIR::new(context);
+
+    let result = prove(&trace_table, &fibonacci_air);
+    let cant_query_list = result.query_list.len();
+    println!("cant: {cant_query_list}");
+    //    assert!(verify(&result, &fibonacci_air));
+}
+
+fn interpolation_example() {
     let elem_one = FE::one();
     let mut val = FE::zero();
 
     loop {
+        let p = Polynomial::interpolate(&[FE::zero(), FE::one()], &[val.clone(), FE::one()]);
         println!("Test lambdaworks!");
         thread::sleep(Duration::from_millis(1000));
         val = val + &elem_one;
         println!("{val:?}");
+        let eval = p.evaluate(&val);
+        println!("eval: {eval:?}");
     }
 }


### PR DESCRIPTION
# Compilation in ESP32

## Description

Scripts and crates for the compilation for the target ESP32 model C3 (with Risc V architecture).


Installation pre-requirements:
```
rustup target add riscv32imc-unknown-none-elf
cargo install cargo-generate
cargo install ldproxy
cargo install espup
cargo install espflash
```

(source: https://hutscape.com/tutorials/blinky-rust-esp32c3#install-dependancies)

to compile for this target, in the folder `proving_system/stark` run:
`make compile_esp`


## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
