### PR TITLE
Hotfix macOS criterion benchs job

### DIFF
--- a/.github/workflows/criterion_benchs.yml
+++ b/.github/workflows/criterion_benchs.yml
@@ -50,7 +50,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run benchmark
       run: |
-        cargo bench --no-fail-fast --bench "criterion_metal" \
+        cargo bench -F metal --no-fail-fast --bench "criterion_metal" \
         -- --output-format bencher | tee output.txt
     - name: Store benchmark result
       uses: benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
# Hotfix macOS criterion benchs job

## Description

Main's CI job is failing because of a disabled cargo flag.