### PR TITLE
Rework on Serialization to allow G2 points to be serialized

### DIFF
--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -1,12 +1,15 @@
-use crate::{field::{
-    element::FieldElement,
-    extensions::{
-        cubic::{CubicExtensionField, HasCubicNonResidue},
-        quadratic::{HasQuadraticNonResidue, QuadraticExtensionField},
-    },
-    fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
-}, traits::ByteConversion};
 use crate::unsigned_integer::element::U384;
+use crate::{
+    field::{
+        element::FieldElement,
+        extensions::{
+            cubic::{CubicExtensionField, HasCubicNonResidue},
+            quadratic::{HasQuadraticNonResidue, QuadraticExtensionField},
+        },
+        fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+    },
+    traits::ByteConversion,
+};
 
 pub const BLS12381_PRIME_FIELD_ORDER: U384 = U384::from("1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab");
 
@@ -89,20 +92,22 @@ impl ByteConversion for FieldElement<Degree2ExtensionField> {
 
     fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
-        Self: std::marker::Sized {
-            const BYTES_PER_FIELD: usize = 48;
-            let x0 = FieldElement::from_bytes_be(&bytes[0..BYTES_PER_FIELD])?;
-            let x1 = FieldElement::from_bytes_be(&bytes[BYTES_PER_FIELD..BYTES_PER_FIELD*2])?;
-            Ok(Self::new([x0,x1]))
+        Self: std::marker::Sized,
+    {
+        const BYTES_PER_FIELD: usize = 48;
+        let x0 = FieldElement::from_bytes_be(&bytes[0..BYTES_PER_FIELD])?;
+        let x1 = FieldElement::from_bytes_be(&bytes[BYTES_PER_FIELD..BYTES_PER_FIELD * 2])?;
+        Ok(Self::new([x0, x1]))
     }
 
     fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
-        Self: std::marker::Sized {
-            const BYTES_PER_FIELD: usize = 48;
-            let x0 = FieldElement::from_bytes_le(&bytes[0..BYTES_PER_FIELD])?;
-            let x1 = FieldElement::from_bytes_le(&bytes[BYTES_PER_FIELD..BYTES_PER_FIELD*2])?;
-            Ok(Self::new([x0,x1]))
+        Self: std::marker::Sized,
+    {
+        const BYTES_PER_FIELD: usize = 48;
+        let x0 = FieldElement::from_bytes_le(&bytes[0..BYTES_PER_FIELD])?;
+        let x1 = FieldElement::from_bytes_le(&bytes[BYTES_PER_FIELD..BYTES_PER_FIELD * 2])?;
+        Ok(Self::new([x0, x1]))
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -72,6 +72,10 @@ impl FieldElement<Degree2ExtensionField> {
     pub fn new_base(a_hex: &str) -> Self {
         Self::new([FieldElement::new(U384::from(a_hex)), FieldElement::zero()])
     }
+
+    pub fn deserialize(&self, bytes: &[u8]) {
+        let v = self.value();
+    }
 }
 
 impl FieldElement<Degree6ExtensionField> {

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -85,12 +85,13 @@ mod tests {
         elliptic_curve::{
             short_weierstrass::{
                 curves::bls12_381::field_extension::{BLS12381PrimeField, Degree2ExtensionField},
-                traits::IsShortWeierstrass, point::{FieldEndianness, PointFormat, ShortWeierstrassProjectivePoint},
+                point::{FieldEndianness, PointFormat, ShortWeierstrassProjectivePoint},
+                traits::IsShortWeierstrass,
             },
             traits::IsEllipticCurve,
         },
         field::element::FieldElement,
-        unsigned_integer::element::U384, traits::ByteConversion,
+        unsigned_integer::element::U384,
     };
 
     use super::BLS12381TwistCurve;
@@ -112,7 +113,12 @@ mod tests {
         let g = BLS12381TwistCurve::generator();
         let bytes = g.serialize(PointFormat::Projective, FieldEndianness::LittleEndian);
 
-        let deserialized = ShortWeierstrassProjectivePoint::<BLS12381TwistCurve>::deserialize(&bytes,PointFormat::Projective, FieldEndianness::LittleEndian).unwrap();
+        let deserialized = ShortWeierstrassProjectivePoint::<BLS12381TwistCurve>::deserialize(
+            &bytes,
+            PointFormat::Projective,
+            FieldEndianness::LittleEndian,
+        )
+        .unwrap();
 
         assert_eq!(deserialized, g);
     }

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -85,7 +85,7 @@ mod tests {
         elliptic_curve::{
             short_weierstrass::{
                 curves::bls12_381::field_extension::{BLS12381PrimeField, Degree2ExtensionField},
-                point::{FieldEndianness, PointFormat, ShortWeierstrassProjectivePoint},
+                point::{Endianness, PointFormat, ShortWeierstrassProjectivePoint},
                 traits::IsShortWeierstrass,
             },
             traits::IsEllipticCurve,
@@ -111,12 +111,12 @@ mod tests {
     #[test]
     fn serialize_deserialize_generator() {
         let g = BLS12381TwistCurve::generator();
-        let bytes = g.serialize(PointFormat::Projective, FieldEndianness::LittleEndian);
+        let bytes = g.serialize(PointFormat::Projective, Endianness::LittleEndian);
 
         let deserialized = ShortWeierstrassProjectivePoint::<BLS12381TwistCurve>::deserialize(
             &bytes,
             PointFormat::Projective,
-            FieldEndianness::LittleEndian,
+            Endianness::LittleEndian,
         )
         .unwrap();
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -85,12 +85,12 @@ mod tests {
         elliptic_curve::{
             short_weierstrass::{
                 curves::bls12_381::field_extension::{BLS12381PrimeField, Degree2ExtensionField},
-                traits::IsShortWeierstrass,
+                traits::IsShortWeierstrass, point::{FieldEndianness, PointFormat, ShortWeierstrassProjectivePoint},
             },
             traits::IsEllipticCurve,
         },
         field::element::FieldElement,
-        unsigned_integer::element::U384,
+        unsigned_integer::element::U384, traits::ByteConversion,
     };
 
     use super::BLS12381TwistCurve;
@@ -105,6 +105,16 @@ mod tests {
             BLS12381TwistCurve::defining_equation(x, y),
             Level1FE::zero()
         );
+    }
+
+    #[test]
+    fn serialize_deserialize_generator() {
+        let g = BLS12381TwistCurve::generator();
+        let bytes = g.serialize(PointFormat::Projective, FieldEndianness::LittleEndian);
+
+        let deserialized = ShortWeierstrassProjectivePoint::<BLS12381TwistCurve>::deserialize(&bytes,PointFormat::Projective, FieldEndianness::LittleEndian).unwrap();
+
+        assert_eq!(deserialized, g);
     }
 
     #[test]

--- a/math/src/elliptic_curve/short_weierstrass/errors.rs
+++ b/math/src/elliptic_curve/short_weierstrass/errors.rs
@@ -7,7 +7,7 @@ pub enum DeserializationError {
     #[error("Invalid amount of bytes")]
     InvalidAmountOfBytes,
     #[error("Error when creating a field from bytes")]
-    FieldFromBytesError
+    FieldFromBytesError,
 }
 
 impl From<ByteConversionError> for DeserializationError {

--- a/math/src/elliptic_curve/short_weierstrass/errors.rs
+++ b/math/src/elliptic_curve/short_weierstrass/errors.rs
@@ -1,0 +1,20 @@
+use thiserror::Error;
+
+use crate::errors::ByteConversionError;
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum DeserializationError {
+    #[error("Invalid amount of bytes")]
+    InvalidAmountOfBytes,
+    #[error("Error when creating a field from bytes")]
+    FieldFromBytesError
+}
+
+impl From<ByteConversionError> for DeserializationError {
+    fn from(error: ByteConversionError) -> Self {
+        match error {
+            ByteConversionError::FromBEBytesError => DeserializationError::FieldFromBytesError,
+            ByteConversionError::FromLEBytesError => DeserializationError::FieldFromBytesError,
+        }
+    }
+}

--- a/math/src/elliptic_curve/short_weierstrass/mod.rs
+++ b/math/src/elliptic_curve/short_weierstrass/mod.rs
@@ -4,3 +4,5 @@ pub mod curves;
 pub mod point;
 /// Common behaviour for Elliptic curves.
 pub mod traits;
+/// Shared errors
+pub mod errors;

--- a/math/src/elliptic_curve/short_weierstrass/mod.rs
+++ b/math/src/elliptic_curve/short_weierstrass/mod.rs
@@ -1,8 +1,8 @@
 /// Implementation of particular cases of elliptic curves.
 pub mod curves;
+/// Shared errors
+pub mod errors;
 /// Structs for points
 pub mod point;
 /// Common behaviour for Elliptic curves.
 pub mod traits;
-/// Shared errors
-pub mod errors;

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -137,7 +137,10 @@ pub enum PointFormat {
 }
 
 #[derive(PartialEq)]
-pub enum FieldEndianness {
+/// Describes the endianess of the internal types of the types
+/// For example, in a field made with limbs of u64
+/// this is the endianess of those u64
+pub enum Endianness {
     BigEndian,
     LittleEndian,
 }
@@ -148,7 +151,7 @@ where
     FieldElement<E::BaseField>: ByteConversion,
 {
     /// Serialize the points in the given format
-    pub fn serialize(&self, _point_format: PointFormat, endianness: FieldEndianness) -> Vec<u8> {
+    pub fn serialize(&self, _point_format: PointFormat, endianness: Endianness) -> Vec<u8> {
         // TODO: these can be more efficient.
         // More options for point formats should be added
         // E.g: Store the x value, the bit to indicate y.
@@ -158,7 +161,7 @@ where
         let z_bytes: Vec<u8>;
 
         let [x, y, z] = self.coordinates();
-        if endianness == FieldEndianness::BigEndian {
+        if endianness == Endianness::BigEndian {
             x_bytes = x.to_bytes_be();
             y_bytes = y.to_bytes_be();
             z_bytes = z.to_bytes_be();
@@ -178,7 +181,7 @@ where
     pub fn deserialize(
         bytes: &[u8],
         _point_format: PointFormat,
-        endianness: FieldEndianness,
+        endianness: Endianness,
     ) -> Result<Self, DeserializationError> {
         if bytes.len() % 3 != 0 {
             return Err(DeserializationError::InvalidAmountOfBytes);
@@ -189,7 +192,7 @@ where
         let y: FieldElement<E::BaseField>;
         let z: FieldElement<E::BaseField>;
 
-        if endianness == FieldEndianness::BigEndian {
+        if endianness == Endianness::BigEndian {
             x = FieldElement::from_bytes_be(&bytes[..len])?;
             y = FieldElement::from_bytes_be(&bytes[len..len * 2])?;
             z = FieldElement::from_bytes_be(&bytes[len * 2..])?;
@@ -220,7 +223,7 @@ where
     FieldElement<E::BaseField>: ByteConversion,
 {
     fn serialize(&self) -> Vec<u8> {
-        self.serialize(PointFormat::Projective, FieldEndianness::LittleEndian)
+        self.serialize(PointFormat::Projective, Endianness::LittleEndian)
     }
 }
 
@@ -247,12 +250,12 @@ mod tests {
     fn byte_conversion_from_and_to_be() {
         let expected_point = point();
         let bytes_be =
-            expected_point.serialize(PointFormat::Projective, FieldEndianness::BigEndian);
+            expected_point.serialize(PointFormat::Projective, Endianness::BigEndian);
 
         let result = ShortWeierstrassProjectivePoint::deserialize(
             &bytes_be,
             PointFormat::Projective,
-            FieldEndianness::BigEndian,
+            Endianness::BigEndian,
         );
         assert_eq!(expected_point, result.unwrap());
     }
@@ -261,24 +264,24 @@ mod tests {
     fn byte_conversion_from_and_to_le() {
         let expected_point = point();
         let bytes_be =
-            expected_point.serialize(PointFormat::Projective, FieldEndianness::LittleEndian);
+            expected_point.serialize(PointFormat::Projective, Endianness::LittleEndian);
 
         let result = ShortWeierstrassProjectivePoint::deserialize(
             &bytes_be,
             PointFormat::Projective,
-            FieldEndianness::LittleEndian,
+            Endianness::LittleEndian,
         );
         assert_eq!(expected_point, result.unwrap());
     }
 
     #[test]
     fn byte_conversion_from_and_to_with_mixed_le_and_be_does_not_work() {
-        let bytes = point().serialize(PointFormat::Projective, FieldEndianness::LittleEndian);
+        let bytes = point().serialize(PointFormat::Projective, Endianness::LittleEndian);
 
         let result = ShortWeierstrassProjectivePoint::<BLS12381Curve>::deserialize(
             &bytes,
             PointFormat::Projective,
-            FieldEndianness::BigEndian,
+            Endianness::BigEndian,
         );
 
         assert_eq!(
@@ -289,12 +292,12 @@ mod tests {
 
     #[test]
     fn byte_conversion_from_and_to_with_mixed_be_and_le_does_not_work() {
-        let bytes = point().serialize(PointFormat::Projective, FieldEndianness::BigEndian);
+        let bytes = point().serialize(PointFormat::Projective, Endianness::BigEndian);
 
         let result = ShortWeierstrassProjectivePoint::<BLS12381Curve>::deserialize(
             &bytes,
             PointFormat::Projective,
-            FieldEndianness::LittleEndian,
+            Endianness::LittleEndian,
         );
 
         assert_eq!(
@@ -310,7 +313,7 @@ mod tests {
         let result = ShortWeierstrassProjectivePoint::<BLS12381Curve>::deserialize(
             bytes,
             PointFormat::Projective,
-            FieldEndianness::LittleEndian,
+            Endianness::LittleEndian,
         );
 
         assert_eq!(
@@ -326,7 +329,7 @@ mod tests {
         let result = ShortWeierstrassProjectivePoint::<BLS12381Curve>::deserialize(
             bytes,
             PointFormat::Projective,
-            FieldEndianness::BigEndian,
+            Endianness::BigEndian,
         );
 
         assert_eq!(

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -148,7 +148,7 @@ where
     FieldElement<E::BaseField>: ByteConversion,
 {
     /// Serialize the points in the given format
-    fn serialize(&self, _point_format: PointFormat, endianness: FieldEndianness) -> Vec<u8> {
+    pub fn serialize(&self, _point_format: PointFormat, endianness: FieldEndianness) -> Vec<u8> {
         // TODO: these can be more efficient.
         // More options for point formats should be added
         // E.g: Store the x value, the bit to indicate y.
@@ -175,8 +175,7 @@ where
         bytes
     }
 
-    // Note this deserialize doesn't work for extension fields
-    fn deserialize(
+    pub fn deserialize(
         bytes: &[u8],
         _point_format: PointFormat,
         endianness: FieldEndianness,

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -4,9 +4,8 @@ use crate::{
         point::ProjectivePoint,
         traits::{EllipticCurveError, FromAffine, IsEllipticCurve},
     },
-    errors::ByteConversionError,
     field::element::FieldElement,
-    traits::ByteConversion,
+    traits::{ByteConversion, SimpleSerialization},
 };
 
 use super::traits::IsShortWeierstrass;
@@ -129,77 +128,63 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
     }
 }
 
-impl<E> ByteConversion for ShortWeierstrassProjectivePoint<E>
+#[derive(PartialEq)]
+pub enum PointFormat {
+    Projective,
+    // TO DO:
+    // Uncompressed,
+    // Compressed,
+}
+
+#[derive(PartialEq)]
+pub enum FieldEndianness {
+    BigEndian,
+    LittleEndian,
+}
+
+impl<E> ShortWeierstrassProjectivePoint<E>
 where
     E: IsShortWeierstrass,
     FieldElement<E::BaseField>: ByteConversion,
 {
-    fn to_bytes_be(&self) -> Vec<u8> {
+    /// Serialize the points in the given format
+    fn serialize(&self, 
+        _point_format: PointFormat, 
+        endianness: FieldEndianness) -> Vec<u8> {
         // TODO: these can be more efficient.
+        // More options for point formats should be added
         // E.g: Store the x value, the bit to indicate y.
+        let mut bytes: Vec<u8> = Vec::new();
+        let mut x_bytes: Vec<u8> = Vec::new();
+        let mut y_bytes: Vec<u8> = Vec::new();
+        let mut z_bytes: Vec<u8> = Vec::new();
+
         let [x, y, z] = self.coordinates();
-        let mut x_bytes = x.to_bytes_be();
-        let mut y_bytes = y.to_bytes_be();
-        let mut z_bytes = z.to_bytes_be();
-        x_bytes.append(&mut y_bytes);
-        x_bytes.append(&mut z_bytes);
-        x_bytes
-    }
-
-    fn to_bytes_le(&self) -> Vec<u8> {
-        let [x, y, z] = self.coordinates();
-        let mut x_bytes = x.to_bytes_le();
-        let mut y_bytes = y.to_bytes_le();
-        let mut z_bytes = z.to_bytes_le();
-        x_bytes.append(&mut y_bytes);
-        x_bytes.append(&mut z_bytes);
-        x_bytes
-    }
-
-    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError> {
-        if bytes.len() % 3 != 0 {
-            Err(ByteConversionError::FromBEBytesError)
+        if endianness == FieldEndianness::BigEndian {
+            x_bytes = x.to_bytes_be();
+            y_bytes = y.to_bytes_be();
+            z_bytes = z.to_bytes_be();
         } else {
-            let len = bytes.len() / 3;
-            let x = FieldElement::from_bytes_be(&bytes[..len])?;
-            let y = FieldElement::from_bytes_be(&bytes[len..len * 2])?;
-            let z = FieldElement::from_bytes_be(&bytes[len * 2..])?;
-            if z == FieldElement::zero() {
-                let point = Self::new([x, y, z]);
-                if point.is_neutral_element() {
-                    Ok(point)
-                } else {
-                    Err(ByteConversionError::FromBEBytesError)
-                }
-            } else if E::defining_equation(&(&x / &z), &(&y / &z)) == FieldElement::zero() {
-                Ok(Self::new([x, y, z]))
-            } else {
-                Err(ByteConversionError::FromBEBytesError)
-            }
+            x_bytes = x.to_bytes_le();
+            y_bytes = y.to_bytes_le();
+            z_bytes = z.to_bytes_le();
         }
-    }
 
-    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError> {
-        if bytes.len() % 3 != 0 {
-            Err(ByteConversionError::FromLEBytesError)
-        } else {
-            let len = bytes.len() / 3;
-            let x = FieldElement::from_bytes_le(&bytes[..len])?;
-            let y = FieldElement::from_bytes_le(&bytes[len..len * 2])?;
-            let z = FieldElement::from_bytes_le(&bytes[len * 2..])?;
-            if z == FieldElement::zero() {
-                let point = Self::new([x, y, z]);
-                if point.is_neutral_element() {
-                    Ok(point)
-                } else {
-                    Err(ByteConversionError::FromLEBytesError)
-                }
-            } else if E::defining_equation(&(&x / &z), &(&y / &z)) == FieldElement::zero() {
-                Ok(Self::new([x, y, z]))
-            } else {
-                Err(ByteConversionError::FromLEBytesError)
-            }
-        }
+        bytes.extend(&x_bytes);
+        bytes.extend(&y_bytes);
+        bytes.extend(&z_bytes);
+
+        bytes
+    }
+}
+
+impl<E> SimpleSerialization for ShortWeierstrassProjectivePoint<E> where
+E: IsShortWeierstrass,
+FieldElement<E::BaseField>: ByteConversion,{
+    fn simple_serialize(&self) -> Vec<u8> {
+        self.serialize(
+            PointFormat::Projective, FieldEndianness::LittleEndian
+        )
     }
 }
 
@@ -221,7 +206,7 @@ mod tests {
         let y = FEE::new_base("7acf6e49cc000ff53b06ee1d27056734019c0a1edfa16684da41ebb0c56750f73bc1b0eae4c6c241808a5e485af0ba0");
         BLS12381Curve::create_point_from_affine(x, y).unwrap()
     }
-
+    /* 
     #[test]
     fn byte_conversion_from_and_to_be() {
         let expected_point = point();
@@ -263,4 +248,5 @@ mod tests {
         let result = ShortWeierstrassProjectivePoint::<BLS12381Curve>::from_bytes_be(&[0_u8; 13]);
         assert_eq!(result.unwrap_err(), ByteConversionError::FromBEBytesError);
     }
+    */
 }

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -249,8 +249,7 @@ mod tests {
     #[test]
     fn byte_conversion_from_and_to_be() {
         let expected_point = point();
-        let bytes_be =
-            expected_point.serialize(PointFormat::Projective, Endianness::BigEndian);
+        let bytes_be = expected_point.serialize(PointFormat::Projective, Endianness::BigEndian);
 
         let result = ShortWeierstrassProjectivePoint::deserialize(
             &bytes_be,
@@ -263,8 +262,7 @@ mod tests {
     #[test]
     fn byte_conversion_from_and_to_le() {
         let expected_point = point();
-        let bytes_be =
-            expected_point.serialize(PointFormat::Projective, Endianness::LittleEndian);
+        let bytes_be = expected_point.serialize(PointFormat::Projective, Endianness::LittleEndian);
 
         let result = ShortWeierstrassProjectivePoint::deserialize(
             &bytes_be,

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -5,7 +5,7 @@ use crate::{
         traits::{EllipticCurveError, FromAffine, IsEllipticCurve},
     },
     field::element::FieldElement,
-    traits::{ByteConversion, SimpleSerialization},
+    traits::{ByteConversion, Serializable},
 };
 
 use super::{errors::DeserializationError, traits::IsShortWeierstrass};
@@ -214,12 +214,12 @@ where
     }
 }
 
-impl<E> SimpleSerialization for ShortWeierstrassProjectivePoint<E>
+impl<E> Serializable for ShortWeierstrassProjectivePoint<E>
 where
     E: IsShortWeierstrass,
     FieldElement<E::BaseField>: ByteConversion,
 {
-    fn simple_serialize(&self) -> Vec<u8> {
+    fn serialize(&self) -> Vec<u8> {
         self.serialize(PointFormat::Projective, FieldEndianness::LittleEndian)
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -152,9 +152,9 @@ where
 {
     /// Serialize the points in the given format
     pub fn serialize(&self, _point_format: PointFormat, endianness: Endianness) -> Vec<u8> {
-        // TODO: these can be more efficient.
-        // More options for point formats should be added
-        // E.g: Store the x value, the bit to indicate y.
+        // TODO: Add more compact serialization formats
+        // Uncompressed affine / Compressed
+
         let mut bytes: Vec<u8> = Vec::new();
         let x_bytes: Vec<u8>;
         let y_bytes: Vec<u8>;

--- a/math/src/traits.rs
+++ b/math/src/traits.rs
@@ -24,6 +24,16 @@ pub trait ByteConversion {
         Self: std::marker::Sized;
 }
 
+
+/// Serialize function without options
+/// Used to serialize data to feed it into Fiat Shamir
+/// in some protocols, when ByteConversion is not avaible
+/// For example, when using Curve Points
+pub trait SimpleSerialization {
+    /// Returns the byte representation of the element in big-endian order.
+    fn simple_serialize(&self) -> Vec<u8>;
+}
+
 pub trait IsRandomFieldElementGenerator<F: IsField> {
     fn generate(&self) -> FieldElement<F>;
 }

--- a/math/src/traits.rs
+++ b/math/src/traits.rs
@@ -24,7 +24,6 @@ pub trait ByteConversion {
         Self: std::marker::Sized;
 }
 
-
 /// Serialize function without options
 /// Used to serialize data to feed it into Fiat Shamir
 /// in some protocols, when ByteConversion is not avaible

--- a/math/src/traits.rs
+++ b/math/src/traits.rs
@@ -28,9 +28,9 @@ pub trait ByteConversion {
 /// Used to serialize data to feed it into Fiat Shamir
 /// in some protocols, when ByteConversion is not avaible
 /// For example, when using Curve Points
-pub trait SimpleSerialization {
+pub trait Serializable {
     /// Returns the byte representation of the element in big-endian order.
-    fn simple_serialize(&self) -> Vec<u8>;
+    fn serialize(&self) -> Vec<u8>;
 }
 
 pub trait IsRandomFieldElementGenerator<F: IsField> {

--- a/math/src/traits.rs
+++ b/math/src/traits.rs
@@ -24,12 +24,10 @@ pub trait ByteConversion {
         Self: std::marker::Sized;
 }
 
-/// Serialize function without options
-/// Used to serialize data to feed it into Fiat Shamir
-/// in some protocols, when ByteConversion is not avaible
-/// For example, when using Curve Points
+/// Serialize function without args
+/// Used for serialization when formatting options are not relevant
 pub trait Serializable {
-    /// Returns the byte representation of the element in big-endian order.
+    /// Default serialize without args
     fn serialize(&self) -> Vec<u8>;
 }
 

--- a/proving_system/plonk/src/prover.rs
+++ b/proving_system/plonk/src/prover.rs
@@ -1,5 +1,5 @@
 use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
-use lambdaworks_math::traits::{IsRandomFieldElementGenerator, SimpleSerialization};
+use lambdaworks_math::traits::{IsRandomFieldElementGenerator, Serializable};
 use std::marker::PhantomData;
 
 use crate::setup::{
@@ -127,7 +127,7 @@ where
     F: IsField,
     CS: IsCommitmentScheme<F>,
     FieldElement<F>: ByteConversion,
-    CS::Commitment: SimpleSerialization,
+    CS::Commitment: Serializable,
     R: IsRandomFieldElementGenerator<F>,
 {
     #[allow(unused)]
@@ -403,9 +403,9 @@ where
 
         // Round 1
         let round_1 = self.round_1(witness, common_preprocessed_input);
-        transcript.append(&round_1.a_1.simple_serialize());
-        transcript.append(&round_1.b_1.simple_serialize());
-        transcript.append(&round_1.c_1.simple_serialize());
+        transcript.append(&round_1.a_1.serialize());
+        transcript.append(&round_1.b_1.serialize());
+        transcript.append(&round_1.c_1.serialize());
 
         // Round 2
         // TODO: Handle error
@@ -413,7 +413,7 @@ where
         let gamma = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
 
         let round_2 = self.round_2(witness, common_preprocessed_input, beta, gamma);
-        transcript.append(&round_2.z_1.simple_serialize());
+        transcript.append(&round_2.z_1.serialize());
 
         // Round 3
         let alpha = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
@@ -424,9 +424,9 @@ where
             &round_2,
             alpha,
         );
-        transcript.append(&round_3.t_lo_1.simple_serialize());
-        transcript.append(&round_3.t_mid_1.simple_serialize());
-        transcript.append(&round_3.t_hi_1.simple_serialize());
+        transcript.append(&round_3.t_lo_1.serialize());
+        transcript.append(&round_3.t_mid_1.serialize());
+        transcript.append(&round_3.t_hi_1.serialize());
 
         // Round 4
         let zeta = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();

--- a/proving_system/plonk/src/prover.rs
+++ b/proving_system/plonk/src/prover.rs
@@ -1,5 +1,5 @@
 use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
-use lambdaworks_math::traits::IsRandomFieldElementGenerator;
+use lambdaworks_math::traits::{IsRandomFieldElementGenerator, SimpleSerialization};
 use std::marker::PhantomData;
 
 use crate::setup::{
@@ -127,7 +127,7 @@ where
     F: IsField,
     CS: IsCommitmentScheme<F>,
     FieldElement<F>: ByteConversion,
-    CS::Commitment: ByteConversion,
+    CS::Commitment: SimpleSerialization,
     R: IsRandomFieldElementGenerator<F>,
 {
     #[allow(unused)]
@@ -403,9 +403,9 @@ where
 
         // Round 1
         let round_1 = self.round_1(witness, common_preprocessed_input);
-        transcript.append(&round_1.a_1.to_bytes_be());
-        transcript.append(&round_1.b_1.to_bytes_be());
-        transcript.append(&round_1.c_1.to_bytes_be());
+        transcript.append(&round_1.a_1.simple_serialize());
+        transcript.append(&round_1.b_1.simple_serialize());
+        transcript.append(&round_1.c_1.simple_serialize());
 
         // Round 2
         // TODO: Handle error
@@ -413,7 +413,7 @@ where
         let gamma = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
 
         let round_2 = self.round_2(witness, common_preprocessed_input, beta, gamma);
-        transcript.append(&round_2.z_1.to_bytes_be());
+        transcript.append(&round_2.z_1.simple_serialize());
 
         // Round 3
         let alpha = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
@@ -424,9 +424,9 @@ where
             &round_2,
             alpha,
         );
-        transcript.append(&round_3.t_lo_1.to_bytes_be());
-        transcript.append(&round_3.t_mid_1.to_bytes_be());
-        transcript.append(&round_3.t_hi_1.to_bytes_be());
+        transcript.append(&round_3.t_lo_1.simple_serialize());
+        transcript.append(&round_3.t_mid_1.simple_serialize());
+        transcript.append(&round_3.t_hi_1.simple_serialize());
 
         // Round 4
         let zeta = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();

--- a/proving_system/plonk/src/setup.rs
+++ b/proving_system/plonk/src/setup.rs
@@ -3,7 +3,7 @@ use lambdaworks_crypto::fiat_shamir::default_transcript::DefaultTranscript;
 use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
 use lambdaworks_math::field::{element::FieldElement, traits::IsField};
 use lambdaworks_math::polynomial::Polynomial;
-use lambdaworks_math::traits::{ByteConversion, SimpleSerialization};
+use lambdaworks_math::traits::{ByteConversion, Serializable};
 
 // TODO: implement getters
 pub struct Witness<F: IsField> {
@@ -74,18 +74,18 @@ where
     F: IsField,
     FieldElement<F>: ByteConversion,
     CS: IsCommitmentScheme<F>,
-    CS::Commitment: SimpleSerialization,
+    CS::Commitment: Serializable,
 {
     let mut transcript = DefaultTranscript::new();
 
-    transcript.append(&vk.s1_1.simple_serialize());
-    transcript.append(&vk.s2_1.simple_serialize());
-    transcript.append(&vk.s3_1.simple_serialize());
-    transcript.append(&vk.ql_1.simple_serialize());
-    transcript.append(&vk.qr_1.simple_serialize());
-    transcript.append(&vk.qm_1.simple_serialize());
-    transcript.append(&vk.qo_1.simple_serialize());
-    transcript.append(&vk.qc_1.simple_serialize());
+    transcript.append(&vk.s1_1.serialize());
+    transcript.append(&vk.s2_1.serialize());
+    transcript.append(&vk.s3_1.serialize());
+    transcript.append(&vk.ql_1.serialize());
+    transcript.append(&vk.qr_1.serialize());
+    transcript.append(&vk.qm_1.serialize());
+    transcript.append(&vk.qo_1.serialize());
+    transcript.append(&vk.qc_1.serialize());
 
     for value in public_input.iter() {
         transcript.append(&value.to_bytes_be());

--- a/proving_system/plonk/src/setup.rs
+++ b/proving_system/plonk/src/setup.rs
@@ -3,7 +3,7 @@ use lambdaworks_crypto::fiat_shamir::default_transcript::DefaultTranscript;
 use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
 use lambdaworks_math::field::{element::FieldElement, traits::IsField};
 use lambdaworks_math::polynomial::Polynomial;
-use lambdaworks_math::traits::ByteConversion;
+use lambdaworks_math::traits::{ByteConversion, SimpleSerialization};
 
 // TODO: implement getters
 pub struct Witness<F: IsField> {
@@ -74,18 +74,18 @@ where
     F: IsField,
     FieldElement<F>: ByteConversion,
     CS: IsCommitmentScheme<F>,
-    CS::Commitment: ByteConversion,
+    CS::Commitment: SimpleSerialization,
 {
     let mut transcript = DefaultTranscript::new();
 
-    transcript.append(&vk.s1_1.to_bytes_be());
-    transcript.append(&vk.s2_1.to_bytes_be());
-    transcript.append(&vk.s3_1.to_bytes_be());
-    transcript.append(&vk.ql_1.to_bytes_be());
-    transcript.append(&vk.qr_1.to_bytes_be());
-    transcript.append(&vk.qm_1.to_bytes_be());
-    transcript.append(&vk.qo_1.to_bytes_be());
-    transcript.append(&vk.qc_1.to_bytes_be());
+    transcript.append(&vk.s1_1.simple_serialize());
+    transcript.append(&vk.s2_1.simple_serialize());
+    transcript.append(&vk.s3_1.simple_serialize());
+    transcript.append(&vk.ql_1.simple_serialize());
+    transcript.append(&vk.qr_1.simple_serialize());
+    transcript.append(&vk.qm_1.simple_serialize());
+    transcript.append(&vk.qo_1.simple_serialize());
+    transcript.append(&vk.qc_1.simple_serialize());
 
     for value in public_input.iter() {
         transcript.append(&value.to_bytes_be());

--- a/proving_system/plonk/src/verifier.rs
+++ b/proving_system/plonk/src/verifier.rs
@@ -4,7 +4,7 @@ use lambdaworks_math::cyclic_group::IsGroup;
 use lambdaworks_math::field::element::FieldElement;
 use lambdaworks_math::field::traits::{IsField, IsPrimeField};
 use lambdaworks_math::polynomial::Polynomial;
-use lambdaworks_math::traits::ByteConversion;
+use lambdaworks_math::traits::{ByteConversion, SimpleSerialization};
 use std::marker::PhantomData;
 
 use crate::prover::Proof;
@@ -33,23 +33,23 @@ impl<F: IsField, CS: IsCommitmentScheme<F>> Verifier<F, CS> {
     where
         F: IsField,
         CS: IsCommitmentScheme<F>,
-        CS::Commitment: ByteConversion,
+        CS::Commitment: SimpleSerialization,
         FieldElement<F>: ByteConversion,
     {
         let mut transcript = new_strong_fiat_shamir_transcript::<F, CS>(vk, public_input);
 
-        transcript.append(&p.a_1.to_bytes_be());
-        transcript.append(&p.b_1.to_bytes_be());
-        transcript.append(&p.c_1.to_bytes_be());
+        transcript.append(&p.a_1.simple_serialize());
+        transcript.append(&p.b_1.simple_serialize());
+        transcript.append(&p.c_1.simple_serialize());
         let beta = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
         let gamma = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
 
-        transcript.append(&p.z_1.to_bytes_be());
+        transcript.append(&p.z_1.simple_serialize());
         let alpha = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
 
-        transcript.append(&p.t_lo_1.to_bytes_be());
-        transcript.append(&p.t_mid_1.to_bytes_be());
-        transcript.append(&p.t_hi_1.to_bytes_be());
+        transcript.append(&p.t_lo_1.simple_serialize());
+        transcript.append(&p.t_mid_1.simple_serialize());
+        transcript.append(&p.t_hi_1.simple_serialize());
         let zeta = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
 
         transcript.append(&p.a_zeta.to_bytes_be());
@@ -74,7 +74,7 @@ impl<F: IsField, CS: IsCommitmentScheme<F>> Verifier<F, CS> {
     where
         F: IsPrimeField,
         CS: IsCommitmentScheme<F>,
-        CS::Commitment: ByteConversion + IsGroup,
+        CS::Commitment: SimpleSerialization + IsGroup,
         FieldElement<F>: ByteConversion,
     {
         // TODO: First three steps are validations: belonging to main subgroup, belonging to prime field.

--- a/proving_system/plonk/src/verifier.rs
+++ b/proving_system/plonk/src/verifier.rs
@@ -4,7 +4,7 @@ use lambdaworks_math::cyclic_group::IsGroup;
 use lambdaworks_math::field::element::FieldElement;
 use lambdaworks_math::field::traits::{IsField, IsPrimeField};
 use lambdaworks_math::polynomial::Polynomial;
-use lambdaworks_math::traits::{ByteConversion, SimpleSerialization};
+use lambdaworks_math::traits::{ByteConversion, Serializable};
 use std::marker::PhantomData;
 
 use crate::prover::Proof;
@@ -33,23 +33,23 @@ impl<F: IsField, CS: IsCommitmentScheme<F>> Verifier<F, CS> {
     where
         F: IsField,
         CS: IsCommitmentScheme<F>,
-        CS::Commitment: SimpleSerialization,
+        CS::Commitment: Serializable,
         FieldElement<F>: ByteConversion,
     {
         let mut transcript = new_strong_fiat_shamir_transcript::<F, CS>(vk, public_input);
 
-        transcript.append(&p.a_1.simple_serialize());
-        transcript.append(&p.b_1.simple_serialize());
-        transcript.append(&p.c_1.simple_serialize());
+        transcript.append(&p.a_1.serialize());
+        transcript.append(&p.b_1.serialize());
+        transcript.append(&p.c_1.serialize());
         let beta = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
         let gamma = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
 
-        transcript.append(&p.z_1.simple_serialize());
+        transcript.append(&p.z_1.serialize());
         let alpha = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
 
-        transcript.append(&p.t_lo_1.simple_serialize());
-        transcript.append(&p.t_mid_1.simple_serialize());
-        transcript.append(&p.t_hi_1.simple_serialize());
+        transcript.append(&p.t_lo_1.serialize());
+        transcript.append(&p.t_mid_1.serialize());
+        transcript.append(&p.t_hi_1.serialize());
         let zeta = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
 
         transcript.append(&p.a_zeta.to_bytes_be());
@@ -74,7 +74,7 @@ impl<F: IsField, CS: IsCommitmentScheme<F>> Verifier<F, CS> {
     where
         F: IsPrimeField,
         CS: IsCommitmentScheme<F>,
-        CS::Commitment: SimpleSerialization + IsGroup,
+        CS::Commitment: Serializable + IsGroup,
         FieldElement<F>: ByteConversion,
     {
         // TODO: First three steps are validations: belonging to main subgroup, belonging to prime field.


### PR DESCRIPTION
# Serialization rework

## Description

Rework on Serialization to allow G2 points to be serialized. This is a first step to make SRS serialization possible

## Type of change

- [x ] New feature
