### PR TITLE
Implement MSM on CPU using Pippenger's algorithm

### DIFF
--- a/crypto/src/commitments/kzg.rs
+++ b/crypto/src/commitments/kzg.rs
@@ -2,7 +2,7 @@ use lambdaworks_math::{
     cyclic_group::IsGroup,
     elliptic_curve::traits::IsPairing,
     field::{element::FieldElement, traits::IsPrimeField},
-    msm::msm,
+    msm::naive::msm,
     polynomial::Polynomial,
 };
 use std::marker::PhantomData;

--- a/crypto/src/commitments/kzg.rs
+++ b/crypto/src/commitments/kzg.rs
@@ -59,6 +59,7 @@ impl<F: IsPrimeField, P: IsPairing> IsCommitmentScheme<F> for KateZaveruchaGoldb
             &coefficients,
             &self.srs.powers_main_group[..coefficients.len()],
         )
+        .expect("`hidings` is sliced by `cs`'s length")
     }
 
     #[allow(unused)]

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -30,3 +30,7 @@ harness = false
 [[bench]]
 name = "iai_field"
 harness = false
+
+[[bench]]
+name = "criterion_msm"
+harness = false

--- a/math/benches/criterion_msm.rs
+++ b/math/benches/criterion_msm.rs
@@ -1,0 +1,68 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use lambdaworks_math::{
+    cyclic_group::IsGroup,
+    elliptic_curve::{
+        short_weierstrass::curves::bls12_381::curve::BLS12381Curve, traits::IsEllipticCurve,
+    },
+    field::traits::IsField,
+    msm::{naive, pippenger},
+    unsigned_integer::element::UnsignedInteger,
+};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+
+type F = <BLS12381Curve as IsEllipticCurve>::BaseField;
+type FP = <BLS12381Curve as IsEllipticCurve>::PointRepresentation;
+type UI = UnsignedInteger<6>;
+
+pub fn generate_cs_and_hidings(msm_size: usize) -> (Vec<UI>, Vec<FP>) {
+    // We use a seeded rng so the benchmarks are reproducible.
+    let mut rng = StdRng::seed_from_u64(42);
+
+    let g = BLS12381Curve::generator();
+
+    let cs: Vec<_> = (0..msm_size)
+        .map(|_| F::from_base_type(UI::from_limbs(rng.gen())))
+        .collect();
+
+    let hidings: Vec<_> = (0..msm_size)
+        .map(|_| g.operate_with_self(F::from_base_type(UI::from_limbs(rng.gen()))))
+        .collect();
+
+    (cs, hidings)
+}
+
+pub fn msm_benchmarks_with_size(
+    c: &mut Criterion,
+    cs: &[UI],
+    hidings: &[FP],
+    window_sizes: &[usize],
+) {
+    assert_eq!(cs.len(), hidings.len());
+    let msm_size = cs.len();
+
+    let mut group = c.benchmark_group(format!("MSM benchmarks with size {msm_size}"));
+
+    group.bench_function("naive", |bench| {
+        bench.iter(|| black_box(naive::msm(cs, hidings)));
+    });
+
+    for &window_size in window_sizes {
+        group.bench_function(BenchmarkId::new("pippenger", window_size), |bench| {
+            bench.iter(|| black_box(pippenger::msm_with(cs, hidings, window_size)));
+        });
+    }
+}
+
+pub fn run_benchmarks(c: &mut Criterion) {
+    let msm_sizes = vec![10, 100, 1000, 10000];
+    let window_sizes = vec![1, 2, 4, 8, 16];
+
+    for msm_size in msm_sizes {
+        let (cs, hidings) = generate_cs_and_hidings(msm_size);
+
+        msm_benchmarks_with_size(c, &cs, &hidings, &window_sizes);
+    }
+}
+
+criterion_group!(msm, run_benchmarks);
+criterion_main!(msm);

--- a/math/benches/criterion_msm.rs
+++ b/math/benches/criterion_msm.rs
@@ -54,10 +54,11 @@ pub fn msm_benchmarks_with_size(
 }
 
 pub fn run_benchmarks(c: &mut Criterion) {
-    let msm_sizes = vec![10, 100, 1000, 10000];
-    let window_sizes = vec![1, 2, 4, 8, 16];
+    let exponents = 1..=10;
+    let window_sizes = vec![1, 2, 4, 8, 12];
 
-    for msm_size in msm_sizes {
+    for exp in exponents {
+        let msm_size = 1 << exp;
         let (cs, hidings) = generate_cs_and_hidings(msm_size);
 
         msm_benchmarks_with_size(c, &cs, &hidings, &window_sizes);

--- a/math/src/msm/mod.rs
+++ b/math/src/msm/mod.rs
@@ -1,0 +1,2 @@
+pub mod naive;
+pub mod pippenger;

--- a/math/src/msm/naive.rs
+++ b/math/src/msm/naive.rs
@@ -12,8 +12,9 @@ use crate::unsigned_integer::traits::IsUnsignedInteger;
 /// If `hidings` and `cs` are empty, then `msm` returns the zero element of the group.
 ///
 /// Panics if `cs` and `hidings` have different lengths.
-pub fn msm<C: IsUnsignedInteger, T>(cs: &[C], hidings: &[T]) -> T
+pub fn msm<C, T>(cs: &[C], hidings: &[T]) -> T
 where
+    C: IsUnsignedInteger,
     T: IsGroup,
 {
     debug_assert_eq!(

--- a/math/src/msm/naive.rs
+++ b/math/src/msm/naive.rs
@@ -1,6 +1,12 @@
 use crate::cyclic_group::IsGroup;
 use crate::unsigned_integer::traits::IsUnsignedInteger;
 
+#[derive(Debug, thiserror::Error)]
+pub enum MSMError {
+    #[error("`cs` and `hidings` must be of the same length to compute `msm`. Got: {0} and {1}")]
+    LengthMismatch(usize, usize),
+}
+
 /// This function computes the multiscalar multiplication (MSM).
 ///
 /// Assume a group G of order r is given.
@@ -12,21 +18,22 @@ use crate::unsigned_integer::traits::IsUnsignedInteger;
 /// If `hidings` and `cs` are empty, then `msm` returns the zero element of the group.
 ///
 /// Panics if `cs` and `hidings` have different lengths.
-pub fn msm<C, T>(cs: &[C], hidings: &[T]) -> T
+pub fn msm<C, T>(cs: &[C], hidings: &[T]) -> Result<T, MSMError>
 where
     C: IsUnsignedInteger,
     T: IsGroup,
 {
-    debug_assert_eq!(
-        cs.len(),
-        hidings.len(),
-        "Slices `cs` and `hidings` must be of the same length to compute `msm`."
-    );
-    cs.iter()
+    if cs.len() != hidings.len() {
+        return Err(MSMError::LengthMismatch(cs.len(), hidings.len()));
+    }
+    let res = cs
+        .iter()
         .zip(hidings.iter())
         .map(|(&c, h)| h.operate_with_self(c))
         .reduce(|acc, x| acc.operate_with(&x))
-        .unwrap_or_else(T::neutral_element)
+        .unwrap_or_else(T::neutral_element);
+
+    Ok(res)
 }
 
 #[cfg(test)]
@@ -44,14 +51,14 @@ mod tests {
     fn msm_11_is_1_over_elliptic_curves() {
         let c: [u64; 1] = [1];
         let hiding = [TestCurve1::generator()];
-        assert_eq!(msm(&c, &hiding), TestCurve1::generator());
+        assert_eq!(msm(&c, &hiding).unwrap(), TestCurve1::generator());
     }
 
     #[test]
     fn msm_23_is_6_over_field_elements() {
         let c: [u64; 1] = [3];
         let hiding = [FE::new(2)];
-        assert_eq!(msm(&c, &hiding), FE::new(6));
+        assert_eq!(msm(&c, &hiding).unwrap(), FE::new(6));
     }
 
     #[test]
@@ -59,14 +66,14 @@ mod tests {
         let c: [u64; 1] = [3];
         let g = TestCurve1::generator();
         let hiding = [g.operate_with_self(2_u16)];
-        assert_eq!(msm(&c, &hiding), g.operate_with_self(6_u16));
+        assert_eq!(msm(&c, &hiding).unwrap(), g.operate_with_self(6_u16));
     }
 
     #[test]
     fn msm_with_c_2_3_hiding_3_4_is_18_over_field_elements() {
         let c: [u64; 2] = [2, 3];
         let hiding = [FE::new(3), FE::new(4)];
-        assert_eq!(msm(&c, &hiding), FE::new(18));
+        assert_eq!(msm(&c, &hiding).unwrap(), FE::new(18));
     }
 
     #[test]
@@ -74,14 +81,14 @@ mod tests {
         let c: [u64; 2] = [2, 3];
         let g = TestCurve1::generator();
         let hiding = [g.operate_with_self(3_u16), g.operate_with_self(4_u16)];
-        assert_eq!(msm(&c, &hiding), g.operate_with_self(18_u16));
+        assert_eq!(msm(&c, &hiding).unwrap(), g.operate_with_self(18_u16));
     }
 
     #[test]
     fn msm_with_empty_input_over_field_elements() {
         let c: [u64; 0] = [];
         let hiding: [FE; 0] = [];
-        assert_eq!(msm(&c, &hiding), FE::new(0));
+        assert_eq!(msm(&c, &hiding).unwrap(), FE::new(0));
     }
 
     #[test]
@@ -89,7 +96,7 @@ mod tests {
         let c: [u64; 0] = [];
         let hiding: [ShortWeierstrassProjectivePoint<TestCurve1>; 0] = [];
         assert_eq!(
-            msm(&c, &hiding),
+            msm(&c, &hiding).unwrap(),
             ShortWeierstrassProjectivePoint::neutral_element()
         );
     }

--- a/math/src/msm/pippenger.rs
+++ b/math/src/msm/pippenger.rs
@@ -1,0 +1,127 @@
+use crate::{
+    cyclic_group::IsGroup,
+    field::{
+        element::FieldElement,
+        fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+    },
+    unsigned_integer::element::UnsignedInteger,
+};
+use std::fmt::Debug;
+
+pub fn msm<M, G, const NUM_LIMBS: usize>(
+    cs: &[FieldElement<MontgomeryBackendPrimeField<M, NUM_LIMBS>>],
+    hidings: &[G],
+    window_size: usize,
+) -> G
+where
+    M: IsModulus<UnsignedInteger<NUM_LIMBS>> + Clone + Debug,
+    G: IsGroup,
+{
+    debug_assert_eq!(
+        cs.len(),
+        hidings.len(),
+        "Slices `cs` and `hidings` must be of the same length to compute `msm`."
+    );
+    assert!(window_size < usize::MAX);
+    // The number of windows of size `s` is ceil(lambda/s).
+    let num_windows = (64 * NUM_LIMBS - 1) / window_size + 1;
+
+    // We define `buckets` outside of the loop so we only have to allocate once, and reuse it.
+    //
+    // This line forces a heap allocation which might be undesired. We can define this buckets
+    // variable in the Pippenger struct to only allocate once, but use a bit of extra memory.
+    // If we accept a const window_size, we could make it an array instaed of a vector
+    // avoiding the heap allocation. We should be aware if that might be too agressive for
+    // the stack and cause a potential stack overflow.
+    let mut buckets = vec![G::neutral_element(); (1 << window_size) - 1];
+
+    (0..num_windows)
+        .rev()
+        .map(|window_idx| {
+            // Put in the right bucket the corresponding ps[i] for the current window.
+            cs.iter().zip(hidings).for_each(|(k, p)| {
+                // The window_size should be lower than usize::MAX <= u64::MAX so this is ok
+                let window_unmasked = (k.representative() >> (window_idx * window_size)).limbs[0];
+                let m_ij = window_unmasked & ((1 << window_size) - 1);
+                if m_ij != 0 {
+                    let idx = (m_ij - 1) as usize;
+                    buckets[idx] = buckets[idx].operate_with(p);
+                }
+            });
+
+            // Do the reduction step for the buckets.
+            buckets
+                .iter_mut()
+                .rev()
+                .scan(G::neutral_element(), |m, b| {
+                    *m = m.operate_with(b); // Reduction step.
+                    *b = G::neutral_element(); // Cleanup bucket slot to reuse in the next window.
+                    Some(m.clone())
+                })
+                .reduce(|g, m| g.operate_with(&m))
+                .unwrap_or_else(G::neutral_element)
+        })
+        .reduce(|t, g| t.operate_with_self(1_u64 << window_size).operate_with(&g))
+        .unwrap_or_else(G::neutral_element)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cyclic_group::IsGroup;
+    use crate::msm::{naive, pippenger};
+    use crate::{
+        elliptic_curve::{
+            short_weierstrass::curves::bls12_381::{
+                curve::BLS12381Curve, field_extension::BLS12381PrimeField,
+            },
+            traits::IsEllipticCurve,
+        },
+        field::element::FieldElement,
+        unsigned_integer::element::UnsignedInteger,
+    };
+    use proptest::{collection, prelude::*, prop_assert_eq, prop_compose, proptest};
+
+    prop_compose! {
+        fn bls12381_element()(limbs: [u64; 6]) -> FieldElement::<BLS12381PrimeField> {
+            FieldElement::<BLS12381PrimeField>::new(UnsignedInteger::from_limbs(limbs))
+        }
+    }
+
+    prop_compose! {
+        fn bls12381_element_vec()(vec in collection::vec(bls12381_element(), 0..30)) -> Vec<FieldElement::<BLS12381PrimeField>> {
+            vec
+        }
+    }
+
+    prop_compose! {
+        fn point()(power: u128) -> <BLS12381Curve as IsEllipticCurve>::PointRepresentation {
+            BLS12381Curve::generator().operate_with_self(power)
+        }
+    }
+
+    prop_compose! {
+        fn points_vec()(vec in collection::vec(point(), 0..30)) -> Vec<<BLS12381Curve as IsEllipticCurve>::PointRepresentation> {
+            vec
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig {
+            cases: 1, .. ProptestConfig::default()
+          })]
+        // Property-based test that ensures FFT eval. gives same result as a naive polynomial evaluation.
+        #[test]
+        fn test_pippenger_matches_naive_msm(_window_size: usize, cs in bls12381_element_vec(), hidings in points_vec()) {
+            let min_len = cs.len().min(hidings.len());
+            let cs = cs[..min_len].to_vec();
+            let hidings = hidings[..min_len].to_vec();
+
+            let pippenger = pippenger::msm(&cs, &hidings, 4);
+
+            let cs: Vec<_> = cs.into_iter().map(|x| x.representative()).collect();
+            let naive = naive::msm(&cs, &hidings);
+
+            prop_assert_eq!(naive, pippenger);
+        }
+    }
+}

--- a/math/src/msm/pippenger.rs
+++ b/math/src/msm/pippenger.rs
@@ -25,7 +25,8 @@ where
     const SCALE_FACTORS: (usize, usize) = (4, 5);
 
     // We approximate the optimum window size with: f(n) = k * log2(n), where k is a scaling factor
-    let window_size = (cs.len().trailing_zeros() as usize) * (SCALE_FACTORS.0 / SCALE_FACTORS.1);
+    let window_size =
+        ((usize::BITS - cs.len().leading_zeros() - 1) as usize * SCALE_FACTORS.0) / SCALE_FACTORS.1;
     msm_with(cs, hidings, MIN_WINDOWS.min(window_size))
 }
 

--- a/math/src/msm/pippenger.rs
+++ b/math/src/msm/pippenger.rs
@@ -1,20 +1,22 @@
-use crate::{
-    cyclic_group::IsGroup,
-    field::{
-        element::FieldElement,
-        fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
-    },
-    unsigned_integer::element::UnsignedInteger,
-};
-use std::fmt::Debug;
+use crate::{cyclic_group::IsGroup, unsigned_integer::element::UnsignedInteger};
 
-pub fn msm<M, G, const NUM_LIMBS: usize>(
-    cs: &[FieldElement<MontgomeryBackendPrimeField<M, NUM_LIMBS>>],
+/// This function computes the multiscalar multiplication (MSM).
+///
+/// Assume a group G of order r is given.
+/// Let `hidings = [g_1, ..., g_n]` be a tuple of group points in G and
+/// let `cs = [k_1, ..., k_n]` be a tuple of scalars in the Galois field GF(r).
+///
+/// Then, with additive notation, `msm(cs, hidings)` computes k_1 * g_1 + .... + k_n * g_n.
+///
+/// If `hidings` and `cs` are empty, then `msm` returns the zero element of the group.
+///
+/// Panics if `cs` and `hidings` have different lengths.
+pub fn msm<const NUM_LIMBS: usize, G>(
+    cs: &[UnsignedInteger<NUM_LIMBS>],
     hidings: &[G],
     window_size: usize,
 ) -> G
 where
-    M: IsModulus<UnsignedInteger<NUM_LIMBS>> + Clone + Debug,
     G: IsGroup,
 {
     debug_assert_eq!(
@@ -22,7 +24,7 @@ where
         hidings.len(),
         "Slices `cs` and `hidings` must be of the same length to compute `msm`."
     );
-    assert!(window_size < usize::BITS as usize);
+    debug_assert!(window_size < usize::BITS as usize);
     // The number of windows of size `s` is ceil(lambda/s).
     let num_windows = (64 * NUM_LIMBS - 1) / window_size + 1;
 
@@ -42,9 +44,7 @@ where
             cs.iter().zip(hidings).for_each(|(k, p)| {
                 // We truncate the number to the least significative limb.
                 // This is ok because window_size < usize::BITS.
-                let window_unmasked = (dbg!(k.representative())
-                    >> (dbg!(window_idx) * dbg!(window_size)))
-                .limbs[NUM_LIMBS - 1];
+                let window_unmasked = (k >> (window_idx * window_size)).limbs[NUM_LIMBS - 1];
                 let m_ij = window_unmasked & ((1 << window_size) - 1);
                 if dbg!(m_ij) != 0 {
                     let idx = (m_ij - 1) as usize;
@@ -74,12 +74,8 @@ mod tests {
     use crate::msm::{naive, pippenger};
     use crate::{
         elliptic_curve::{
-            short_weierstrass::curves::bls12_381::{
-                curve::BLS12381Curve, field_extension::BLS12381PrimeField,
-            },
-            traits::IsEllipticCurve,
+            short_weierstrass::curves::bls12_381::curve::BLS12381Curve, traits::IsEllipticCurve,
         },
-        field::element::FieldElement,
         unsigned_integer::element::UnsignedInteger,
     };
     use proptest::{collection, prelude::*, prop_assert_eq, prop_compose, proptest};
@@ -89,13 +85,13 @@ mod tests {
     const _MAX_LEN: usize = 30;
 
     prop_compose! {
-        fn bls12381_element()(limbs: [u64; 6]) -> FieldElement::<BLS12381PrimeField> {
-            FieldElement::<BLS12381PrimeField>::new(UnsignedInteger::from_limbs(limbs))
+        fn unsigned_integer()(limbs: [u64; 6]) -> UnsignedInteger<6> {
+            UnsignedInteger::from_limbs(limbs)
         }
     }
 
     prop_compose! {
-        fn bls12381_element_vec()(vec in collection::vec(bls12381_element(), 0.._MAX_LEN)) -> Vec<FieldElement::<BLS12381PrimeField>> {
+        fn unsigned_integer_vec()(vec in collection::vec(unsigned_integer(), 0.._MAX_LEN)) -> Vec<UnsignedInteger<6>> {
             vec
         }
     }
@@ -116,16 +112,14 @@ mod tests {
         #![proptest_config(ProptestConfig {
             cases: _CASES, .. ProptestConfig::default()
           })]
-        // Property-based test that ensures FFT eval. gives same result as a naive polynomial evaluation.
-        // #[test]
-        fn test_pippenger_matches_naive_msm(window_size in 1.._MAX_WSIZE, cs in bls12381_element_vec(), hidings in points_vec()) {
+        // Property-based test that ensures `pippenger::msm` gives same result as `naive::msm`.
+        #[test]
+        fn test_pippenger_matches_naive_msm(window_size in 1.._MAX_WSIZE, cs in unsigned_integer_vec(), hidings in points_vec()) {
             let min_len = cs.len().min(hidings.len());
             let cs = cs[..min_len].to_vec();
             let hidings = hidings[..min_len].to_vec();
 
             let pippenger = pippenger::msm(&cs, &hidings, window_size);
-
-            let cs: Vec<_> = cs.into_iter().map(|x| x.representative()).collect();
             let naive = naive::msm(&cs, &hidings);
 
             prop_assert_eq!(naive, pippenger);

--- a/math/src/msm/pippenger.rs
+++ b/math/src/msm/pippenger.rs
@@ -84,7 +84,9 @@ mod tests {
     };
     use proptest::{collection, prelude::*, prop_assert_eq, prop_compose, proptest};
 
-    const MAX_WSIZE: usize = 16;
+    const _CASES: u32 = 20;
+    const _MAX_WSIZE: usize = 8;
+    const _MAX_LEN: usize = 30;
 
     prop_compose! {
         fn bls12381_element()(limbs: [u64; 6]) -> FieldElement::<BLS12381PrimeField> {
@@ -93,7 +95,7 @@ mod tests {
     }
 
     prop_compose! {
-        fn bls12381_element_vec()(vec in collection::vec(bls12381_element(), 0..100)) -> Vec<FieldElement::<BLS12381PrimeField>> {
+        fn bls12381_element_vec()(vec in collection::vec(bls12381_element(), 0.._MAX_LEN)) -> Vec<FieldElement::<BLS12381PrimeField>> {
             vec
         }
     }
@@ -105,18 +107,18 @@ mod tests {
     }
 
     prop_compose! {
-        fn points_vec()(vec in collection::vec(point(), 0..100)) -> Vec<<BLS12381Curve as IsEllipticCurve>::PointRepresentation> {
+        fn points_vec()(vec in collection::vec(point(), 0.._MAX_LEN)) -> Vec<<BLS12381Curve as IsEllipticCurve>::PointRepresentation> {
             vec
         }
     }
 
     proptest! {
         #![proptest_config(ProptestConfig {
-            cases: 1, .. ProptestConfig::default()
+            cases: _CASES, .. ProptestConfig::default()
           })]
         // Property-based test that ensures FFT eval. gives same result as a naive polynomial evaluation.
-        #[test]
-        fn test_pippenger_matches_naive_msm(window_size in 1..MAX_WSIZE, cs in bls12381_element_vec(), hidings in points_vec()) {
+        // #[test]
+        fn test_pippenger_matches_naive_msm(window_size in 1.._MAX_WSIZE, cs in bls12381_element_vec(), hidings in points_vec()) {
             let min_len = cs.len().min(hidings.len());
             let cs = cs[..min_len].to_vec();
             let hidings = hidings[..min_len].to_vec();

--- a/math/src/msm/pippenger.rs
+++ b/math/src/msm/pippenger.rs
@@ -15,12 +15,17 @@ pub fn msm<const NUM_LIMBS: usize, G>(cs: &[UnsignedInteger<NUM_LIMBS>], hidings
 where
     G: IsGroup,
 {
+    debug_assert_eq!(
+        cs.len(),
+        hidings.len(),
+        "Slices `cs` and `hidings` must be of the same length to compute `msm`."
+    );
     // TODO: set dynamically based on NUM_LIMBS and cs.len()
     let window_size = 4;
     msm_with(cs, hidings, window_size)
 }
 
-fn msm_with<const NUM_LIMBS: usize, G>(
+pub fn msm_with<const NUM_LIMBS: usize, G>(
     cs: &[UnsignedInteger<NUM_LIMBS>],
     hidings: &[G],
     window_size: usize,
@@ -28,11 +33,6 @@ fn msm_with<const NUM_LIMBS: usize, G>(
 where
     G: IsGroup,
 {
-    debug_assert_eq!(
-        cs.len(),
-        hidings.len(),
-        "Slices `cs` and `hidings` must be of the same length to compute `msm`."
-    );
     debug_assert!(window_size < usize::BITS as usize);
     // The number of windows of size `s` is ceil(lambda/s).
     let num_windows = (64 * NUM_LIMBS - 1) / window_size + 1;

--- a/math/src/msm/pippenger.rs
+++ b/math/src/msm/pippenger.rs
@@ -69,12 +69,16 @@ where
             // Do the reduction step for the buckets.
             buckets
                 .iter_mut()
+                // This first part iterates buckets in descending order, generating an iterator with the sum of
+                // each bucket and all that came before as its items; i.e: (b_n, b_n + b_n-1, ..., b_n + ... + b_0)
                 .rev()
                 .scan(G::neutral_element(), |m, b| {
                     *m = m.operate_with(b); // Reduction step.
                     *b = G::neutral_element(); // Cleanup bucket slot to reuse in the next window.
                     Some(m.clone())
                 })
+                // This next part sums all elements of the iterator: (b_n) + (b_n + b_n-1) + ...
+                // This results in: (n + 1) * b_n + n * b_n-1 + ... + b_0
                 .reduce(|g, m| g.operate_with(&m))
                 .unwrap_or_else(G::neutral_element)
         })

--- a/math/src/msm/pippenger.rs
+++ b/math/src/msm/pippenger.rs
@@ -1,5 +1,7 @@
 use crate::{cyclic_group::IsGroup, unsigned_integer::element::UnsignedInteger};
 
+use super::naive::MSMError;
+
 /// This function computes the multiscalar multiplication (MSM).
 ///
 /// Assume a group G of order r is given.
@@ -11,15 +13,16 @@ use crate::{cyclic_group::IsGroup, unsigned_integer::element::UnsignedInteger};
 /// If `hidings` and `cs` are empty, then `msm` returns the zero element of the group.
 ///
 /// Panics if `cs` and `hidings` have different lengths.
-pub fn msm<const NUM_LIMBS: usize, G>(cs: &[UnsignedInteger<NUM_LIMBS>], hidings: &[G]) -> G
+pub fn msm<const NUM_LIMBS: usize, G>(
+    cs: &[UnsignedInteger<NUM_LIMBS>],
+    hidings: &[G],
+) -> Result<G, MSMError>
 where
     G: IsGroup,
 {
-    debug_assert_eq!(
-        cs.len(),
-        hidings.len(),
-        "Slices `cs` and `hidings` must be of the same length to compute `msm`."
-    );
+    if cs.len() != hidings.len() {
+        return Err(MSMError::LengthMismatch(cs.len(), hidings.len()));
+    }
     // When input is small enough, windows of length 2 seem faster than 1.
     const MIN_WINDOWS: usize = 2;
     const SCALE_FACTORS: (usize, usize) = (4, 5);
@@ -27,7 +30,7 @@ where
     // We approximate the optimum window size with: f(n) = k * log2(n), where k is a scaling factor
     let window_size =
         ((usize::BITS - cs.len().leading_zeros() - 1) as usize * SCALE_FACTORS.0) / SCALE_FACTORS.1;
-    msm_with(cs, hidings, MIN_WINDOWS.min(window_size))
+    Ok(msm_with(cs, hidings, MIN_WINDOWS.min(window_size)))
 }
 
 pub fn msm_with<const NUM_LIMBS: usize, G>(
@@ -38,7 +41,8 @@ pub fn msm_with<const NUM_LIMBS: usize, G>(
 where
     G: IsGroup,
 {
-    debug_assert!(window_size < usize::BITS as usize);
+    assert!(window_size < usize::BITS as usize); // Program would go OOM anyways
+
     // The number of windows of size `s` is ceil(lambda/s).
     let num_windows = (64 * NUM_LIMBS - 1) / window_size + 1;
 
@@ -138,7 +142,7 @@ mod tests {
             let hidings = hidings[..min_len].to_vec();
 
             let pippenger = pippenger::msm_with(&cs, &hidings, window_size);
-            let naive = naive::msm(&cs, &hidings);
+            let naive = naive::msm(&cs, &hidings).unwrap();
 
             prop_assert_eq!(naive, pippenger);
         }

--- a/math/src/msm/pippenger.rs
+++ b/math/src/msm/pippenger.rs
@@ -20,9 +20,13 @@ where
         hidings.len(),
         "Slices `cs` and `hidings` must be of the same length to compute `msm`."
     );
-    // TODO: set dynamically based on NUM_LIMBS and cs.len()
-    let window_size = 4;
-    msm_with(cs, hidings, window_size)
+    // When input is small enough, windows of length 2 seem faster than 1.
+    const MIN_WINDOWS: usize = 2;
+    const SCALE_FACTORS: (usize, usize) = (4, 5);
+
+    // We approximate the optimum window size with: f(n) = k * log2(n), where k is a scaling factor
+    let window_size = (cs.len().trailing_zeros() as usize) * (SCALE_FACTORS.0 / SCALE_FACTORS.1);
+    msm_with(cs, hidings, MIN_WINDOWS.min(window_size))
 }
 
 pub fn msm_with<const NUM_LIMBS: usize, G>(


### PR DESCRIPTION
# Implement MSM on CPU using Pippenger's algorithm

## Description

This PR implements Multi-Scalar Multiplication on CPU using Pippenger's algorithm, speeding it up by up to _**10 times**_ (as indicated by benchmarks).

The API cannot be used right now in place of the _naive_ implementation, because it requires scalars to be `UnsignedInteger`s. This could be fixed by adding it conditionally via a trait `IsFixedSize` for `BaseType`s that adds a method or constant with the fixed number of bits of the base type of the field.

## Type of change

- [X] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [X] This change is an Optimization
  - [X] Benchmarks added/run
