### PR TITLE
Add checked and unchecked from hex

### DIFF
--- a/crypto/src/hash/hash_to_field.rs
+++ b/crypto/src/hash/hash_to_field.rs
@@ -45,7 +45,7 @@ fn os2ip<M: IsModulus<UnsignedInteger<N>> + Clone, const N: usize>(
     for item_u8 in aux_x.iter() {
         item_hex += &format!("{:x}", item_u8);
         if item_hex.len() == item_hex.capacity() {
-            result += FieldElement::from_hex(&item_hex) * two_to_the_nth.pow(j);
+            result += FieldElement::from_hex_unchecked(&item_hex) * two_to_the_nth.pow(j);
             item_hex.clear();
             j += 1;
         }
@@ -62,7 +62,7 @@ fn build_two_to_the_nth<M: IsModulus<UnsignedInteger<N>> + Clone, const N: usize
     for _ in 0..two_to_the_nth.capacity() - 1 {
         two_to_the_nth.push('1');
     }
-    FieldElement::from_hex(&two_to_the_nth) + FieldElement::one()
+    FieldElement::from_hex_unchecked(&two_to_the_nth) + FieldElement::one()
 }
 
 #[cfg(test)]

--- a/crypto/src/hash/poseidon/mod.rs
+++ b/crypto/src/hash/poseidon/mod.rs
@@ -173,8 +173,9 @@ mod tests {
     #[derive(Clone, Debug)]
     pub struct TestFieldModulus;
     impl IsModulus<U384> for TestFieldModulus {
-        const MODULUS: U384 =
-            U384::from_hex_unchecked("2000000000000080000000000000000000000000000000000000000000000001");
+        const MODULUS: U384 = U384::from_hex_unchecked(
+            "2000000000000080000000000000000000000000000000000000000000000001",
+        );
     }
 
     pub type PoseidonTestField = U384PrimeField<TestFieldModulus>;

--- a/crypto/src/hash/poseidon/mod.rs
+++ b/crypto/src/hash/poseidon/mod.rs
@@ -174,7 +174,7 @@ mod tests {
     pub struct TestFieldModulus;
     impl IsModulus<U384> for TestFieldModulus {
         const MODULUS: U384 =
-            U384::from_hex("2000000000000080000000000000000000000000000000000000000000000001");
+            U384::from_hex_unchecked("2000000000000080000000000000000000000000000000000000000000000001");
     }
 
     pub type PoseidonTestField = U384PrimeField<TestFieldModulus>;
@@ -186,7 +186,7 @@ mod tests {
 
         let round_constants = round_constants_csv
             .split(',')
-            .map(|c| TestFieldElement::new(U384::from_hex(c.trim())))
+            .map(|c| TestFieldElement::new(U384::from_hex_unchecked(c.trim())))
             .collect();
 
         let mut mds_matrix = vec![];
@@ -194,7 +194,7 @@ mod tests {
         for line in mds_constants_csv.lines() {
             let matrix_line = line
                 .split(',')
-                .map(|c| TestFieldElement::new(U384::from_hex(c.trim())))
+                .map(|c| TestFieldElement::new(U384::from_hex_unchecked(c.trim())))
                 .collect();
 
             mds_matrix.push(matrix_line);
@@ -222,13 +222,13 @@ mod tests {
 
         poseidon.ark(&mut state, 0);
         let expected = [
-            TestFieldElement::new(U384::from_hex(
+            TestFieldElement::new(U384::from_hex_unchecked(
                 "16861759ea5568dd39dd92f9562a30b9e58e2ad98109ae4780b7fd8eac77fe8a",
             )),
-            TestFieldElement::new(U384::from_hex(
+            TestFieldElement::new(U384::from_hex_unchecked(
                 "13827681995D5ADFFFC8397A3D00425A3DA43F76ABF28A64E4AB1A22F275092B",
             )),
-            TestFieldElement::new(U384::from_hex(
+            TestFieldElement::new(U384::from_hex_unchecked(
                 "BA3956D2FAD4469E7F760A2277DC7CB2CAC75DC279B2D687A0DBE17704A8310",
             )),
         ];
@@ -238,13 +238,13 @@ mod tests {
     #[test]
     fn test_mix() {
         let mut state = [
-            TestFieldElement::new(U384::from_hex(
+            TestFieldElement::new(U384::from_hex_unchecked(
                 "13f891b043b3b740cc3e1b3051127d335f08e488322f360a776b3810b7dc690a",
             )),
-            TestFieldElement::new(U384::from_hex(
+            TestFieldElement::new(U384::from_hex_unchecked(
                 "1bd24b7cb99acf0dbea719ff4007bd60105bcefef21ec509d2f8d4f9bb6a3a1a",
             )),
-            TestFieldElement::new(U384::from_hex(
+            TestFieldElement::new(U384::from_hex_unchecked(
                 "110853eb2ebee0d940454fe420229a2a0974e666d16c92bab9f36cbd1a0eded",
             )),
         ];
@@ -254,13 +254,13 @@ mod tests {
         poseidon.mix(&mut state);
 
         let expected = [
-            TestFieldElement::new(U384::from_hex(
+            TestFieldElement::new(U384::from_hex_unchecked(
                 "1d30b34b465f8cddc8dc468f137891659c7e32b510cf41cec3aac0b26741681d",
             )),
-            TestFieldElement::new(U384::from_hex(
+            TestFieldElement::new(U384::from_hex_unchecked(
                 "c445fa4dd2af583994272bede589b06b98fe9cd6d868bf718f6748ba6165620",
             )),
-            TestFieldElement::new(U384::from_hex(
+            TestFieldElement::new(U384::from_hex_unchecked(
                 "1ed95ae0ea03bb892691f5200fb5902957ac17b3466afa62be808682801f97f9",
             )),
         ];
@@ -291,13 +291,13 @@ mod tests {
         poseidon.permute(&mut state);
 
         let expected = [
-            TestFieldElement::new(U384::from_hex(
+            TestFieldElement::new(U384::from_hex_unchecked(
                 "18700783647721BB9AD092B176BBEB5348401C21132CCF83C30134DFAB5A2DEB",
             )),
-            TestFieldElement::new(U384::from_hex(
+            TestFieldElement::new(U384::from_hex_unchecked(
                 "1CC8856652601B3C81139AD5EC13E4A3A8F4A5DB242555521A09E002E7A10B2B",
             )),
-            TestFieldElement::new(U384::from_hex(
+            TestFieldElement::new(U384::from_hex_unchecked(
                 "3DCB1CEC811FC2D7401CA7B9B084D167F33B6983D4428C8E0534C9C3CECF46D",
             )),
         ];

--- a/crypto/src/hash/poseidon/mod.rs
+++ b/crypto/src/hash/poseidon/mod.rs
@@ -174,7 +174,7 @@ mod tests {
     pub struct TestFieldModulus;
     impl IsModulus<U384> for TestFieldModulus {
         const MODULUS: U384 =
-            U384::from("2000000000000080000000000000000000000000000000000000000000000001");
+            U384::from_hex("2000000000000080000000000000000000000000000000000000000000000001");
     }
 
     pub type PoseidonTestField = U384PrimeField<TestFieldModulus>;
@@ -186,7 +186,7 @@ mod tests {
 
         let round_constants = round_constants_csv
             .split(',')
-            .map(|c| TestFieldElement::new(U384::from(c.trim())))
+            .map(|c| TestFieldElement::new(U384::from_hex(c.trim())))
             .collect();
 
         let mut mds_matrix = vec![];
@@ -194,7 +194,7 @@ mod tests {
         for line in mds_constants_csv.lines() {
             let matrix_line = line
                 .split(',')
-                .map(|c| TestFieldElement::new(U384::from(c.trim())))
+                .map(|c| TestFieldElement::new(U384::from_hex(c.trim())))
                 .collect();
 
             mds_matrix.push(matrix_line);
@@ -222,13 +222,13 @@ mod tests {
 
         poseidon.ark(&mut state, 0);
         let expected = [
-            TestFieldElement::new(U384::from(
+            TestFieldElement::new(U384::from_hex(
                 "16861759ea5568dd39dd92f9562a30b9e58e2ad98109ae4780b7fd8eac77fe8a",
             )),
-            TestFieldElement::new(U384::from(
+            TestFieldElement::new(U384::from_hex(
                 "13827681995D5ADFFFC8397A3D00425A3DA43F76ABF28A64E4AB1A22F275092B",
             )),
-            TestFieldElement::new(U384::from(
+            TestFieldElement::new(U384::from_hex(
                 "BA3956D2FAD4469E7F760A2277DC7CB2CAC75DC279B2D687A0DBE17704A8310",
             )),
         ];
@@ -238,13 +238,13 @@ mod tests {
     #[test]
     fn test_mix() {
         let mut state = [
-            TestFieldElement::new(U384::from(
+            TestFieldElement::new(U384::from_hex(
                 "13f891b043b3b740cc3e1b3051127d335f08e488322f360a776b3810b7dc690a",
             )),
-            TestFieldElement::new(U384::from(
+            TestFieldElement::new(U384::from_hex(
                 "1bd24b7cb99acf0dbea719ff4007bd60105bcefef21ec509d2f8d4f9bb6a3a1a",
             )),
-            TestFieldElement::new(U384::from(
+            TestFieldElement::new(U384::from_hex(
                 "110853eb2ebee0d940454fe420229a2a0974e666d16c92bab9f36cbd1a0eded",
             )),
         ];
@@ -254,13 +254,13 @@ mod tests {
         poseidon.mix(&mut state);
 
         let expected = [
-            TestFieldElement::new(U384::from(
+            TestFieldElement::new(U384::from_hex(
                 "1d30b34b465f8cddc8dc468f137891659c7e32b510cf41cec3aac0b26741681d",
             )),
-            TestFieldElement::new(U384::from(
+            TestFieldElement::new(U384::from_hex(
                 "c445fa4dd2af583994272bede589b06b98fe9cd6d868bf718f6748ba6165620",
             )),
-            TestFieldElement::new(U384::from(
+            TestFieldElement::new(U384::from_hex(
                 "1ed95ae0ea03bb892691f5200fb5902957ac17b3466afa62be808682801f97f9",
             )),
         ];
@@ -291,13 +291,13 @@ mod tests {
         poseidon.permute(&mut state);
 
         let expected = [
-            TestFieldElement::new(U384::from(
+            TestFieldElement::new(U384::from_hex(
                 "18700783647721BB9AD092B176BBEB5348401C21132CCF83C30134DFAB5A2DEB",
             )),
-            TestFieldElement::new(U384::from(
+            TestFieldElement::new(U384::from_hex(
                 "1CC8856652601B3C81139AD5EC13E4A3A8F4A5DB242555521A09E002E7A10B2B",
             )),
-            TestFieldElement::new(U384::from(
+            TestFieldElement::new(U384::from_hex(
                 "3DCB1CEC811FC2D7401CA7B9B084D167F33B6983D4428C8E0534C9C3CECF46D",
             )),
         ];

--- a/math/src/elliptic_curve/point.rs
+++ b/math/src/elliptic_curve/point.rs
@@ -127,12 +127,12 @@ mod tests {
 
         let expected_result = TestCurve2::create_point_from_affine(
             FieldElement::new([
-                FieldElement::new(U384::from("7b8ee59e422e702458174c18eb3302e17")),
-                FieldElement::new(U384::from("1395065adef5a6a5457f1ea600b5a3e4fb")),
+                FieldElement::new(U384::from_hex("7b8ee59e422e702458174c18eb3302e17")),
+                FieldElement::new(U384::from_hex("1395065adef5a6a5457f1ea600b5a3e4fb")),
             ]),
             FieldElement::new([
-                FieldElement::new(U384::from("e29d5b15c42124cd8f05d3c8500451c33")),
-                FieldElement::new(U384::from("e836ef62db0a47a63304b67c0de69b140")),
+                FieldElement::new(U384::from_hex("e29d5b15c42124cd8f05d3c8500451c33")),
+                FieldElement::new(U384::from_hex("e836ef62db0a47a63304b67c0de69b140")),
             ]),
         )
         .unwrap();

--- a/math/src/elliptic_curve/point.rs
+++ b/math/src/elliptic_curve/point.rs
@@ -127,12 +127,20 @@ mod tests {
 
         let expected_result = TestCurve2::create_point_from_affine(
             FieldElement::new([
-                FieldElement::new(U384::from_hex_unchecked("7b8ee59e422e702458174c18eb3302e17")),
-                FieldElement::new(U384::from_hex_unchecked("1395065adef5a6a5457f1ea600b5a3e4fb")),
+                FieldElement::new(U384::from_hex_unchecked(
+                    "7b8ee59e422e702458174c18eb3302e17",
+                )),
+                FieldElement::new(U384::from_hex_unchecked(
+                    "1395065adef5a6a5457f1ea600b5a3e4fb",
+                )),
             ]),
             FieldElement::new([
-                FieldElement::new(U384::from_hex_unchecked("e29d5b15c42124cd8f05d3c8500451c33")),
-                FieldElement::new(U384::from_hex_unchecked("e836ef62db0a47a63304b67c0de69b140")),
+                FieldElement::new(U384::from_hex_unchecked(
+                    "e29d5b15c42124cd8f05d3c8500451c33",
+                )),
+                FieldElement::new(U384::from_hex_unchecked(
+                    "e836ef62db0a47a63304b67c0de69b140",
+                )),
             ]),
         )
         .unwrap();

--- a/math/src/elliptic_curve/point.rs
+++ b/math/src/elliptic_curve/point.rs
@@ -127,12 +127,12 @@ mod tests {
 
         let expected_result = TestCurve2::create_point_from_affine(
             FieldElement::new([
-                FieldElement::new(U384::from_hex("7b8ee59e422e702458174c18eb3302e17")),
-                FieldElement::new(U384::from_hex("1395065adef5a6a5457f1ea600b5a3e4fb")),
+                FieldElement::new(U384::from_hex_unchecked("7b8ee59e422e702458174c18eb3302e17")),
+                FieldElement::new(U384::from_hex_unchecked("1395065adef5a6a5457f1ea600b5a3e4fb")),
             ]),
             FieldElement::new([
-                FieldElement::new(U384::from_hex("e29d5b15c42124cd8f05d3c8500451c33")),
-                FieldElement::new(U384::from_hex("e836ef62db0a47a63304b67c0de69b140")),
+                FieldElement::new(U384::from_hex_unchecked("e29d5b15c42124cd8f05d3c8500451c33")),
+                FieldElement::new(U384::from_hex_unchecked("e836ef62db0a47a63304b67c0de69b140")),
             ]),
         )
         .unwrap();

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/field_extension.rs
@@ -4,7 +4,7 @@ use crate::field::{
 };
 use crate::unsigned_integer::element::U384;
 
-pub const BLS12377_PRIME_FIELD_ORDER: U384 = U384::from_hex("1ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001");
+pub const BLS12377_PRIME_FIELD_ORDER: U384 = U384::from_hex_unchecked("1ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001");
 
 // FPBLS12377
 #[derive(Clone, Debug)]
@@ -17,6 +17,6 @@ pub type BLS12377PrimeField = MontgomeryBackendPrimeField<BLS12377FieldModulus, 
 
 impl FieldElement<BLS12377PrimeField> {
     pub fn new_base(a_hex: &str) -> Self {
-        Self::new(U384::from_hex(a_hex))
+        Self::new(U384::from_hex_unchecked(a_hex))
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/field_extension.rs
@@ -4,7 +4,7 @@ use crate::field::{
 };
 use crate::unsigned_integer::element::U384;
 
-pub const BLS12377_PRIME_FIELD_ORDER: U384 = U384::from("1ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001");
+pub const BLS12377_PRIME_FIELD_ORDER: U384 = U384::from_hex("1ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001");
 
 // FPBLS12377
 #[derive(Clone, Debug)]
@@ -17,6 +17,6 @@ pub type BLS12377PrimeField = MontgomeryBackendPrimeField<BLS12377FieldModulus, 
 
 impl FieldElement<BLS12377PrimeField> {
     pub fn new_base(a_hex: &str) -> Self {
-        Self::new(U384::from(a_hex))
+        Self::new(U384::from_hex(a_hex))
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/default_types.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/default_types.rs
@@ -12,7 +12,7 @@ pub struct FrConfig;
 /// Modulus of bls 12 381 subgroup
 impl IsModulus<U256> for FrConfig {
     const MODULUS: U256 =
-        U256::from_hex("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001");
+        U256::from_hex_unchecked("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001");
 }
 
 /// FrField using MontgomeryBackend for bls 12 381

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/default_types.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/default_types.rs
@@ -12,7 +12,7 @@ pub struct FrConfig;
 /// Modulus of bls 12 381 subgroup
 impl IsModulus<U256> for FrConfig {
     const MODULUS: U256 =
-        U256::from("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001");
+        U256::from_hex("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001");
 }
 
 /// FrField using MontgomeryBackend for bls 12 381

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/default_types.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/default_types.rs
@@ -11,8 +11,9 @@ pub struct FrConfig;
 
 /// Modulus of bls 12 381 subgroup
 impl IsModulus<U256> for FrConfig {
-    const MODULUS: U256 =
-        U256::from_hex_unchecked("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001");
+    const MODULUS: U256 = U256::from_hex_unchecked(
+        "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001",
+    );
 }
 
 /// FrField using MontgomeryBackend for bls 12 381

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -11,7 +11,7 @@ use crate::{
     traits::ByteConversion,
 };
 
-pub const BLS12381_PRIME_FIELD_ORDER: U384 = U384::from_hex("1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab");
+pub const BLS12381_PRIME_FIELD_ORDER: U384 = U384::from_hex_unchecked("1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab");
 
 // FPBLS12381
 #[derive(Clone, Debug)]
@@ -41,8 +41,8 @@ impl HasCubicNonResidue for LevelTwoResidue {
 
     fn residue() -> FieldElement<Degree2ExtensionField> {
         FieldElement::new([
-            FieldElement::new(U384::from_hex("d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd556")),
-            FieldElement::new(U384::from_hex("d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd555"))
+            FieldElement::new(U384::from_hex_unchecked("d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd556")),
+            FieldElement::new(U384::from_hex_unchecked("d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd555"))
         ])
     }
 }
@@ -67,13 +67,13 @@ pub type Degree12ExtensionField = QuadraticExtensionField<LevelThreeResidue>;
 
 impl FieldElement<BLS12381PrimeField> {
     pub fn new_base(a_hex: &str) -> Self {
-        Self::new(U384::from_hex(a_hex))
+        Self::new(U384::from_hex_unchecked(a_hex))
     }
 }
 
 impl FieldElement<Degree2ExtensionField> {
     pub fn new_base(a_hex: &str) -> Self {
-        Self::new([FieldElement::new(U384::from_hex(a_hex)), FieldElement::zero()])
+        Self::new([FieldElement::new(U384::from_hex_unchecked(a_hex)), FieldElement::zero()])
     }
 }
 
@@ -114,7 +114,7 @@ impl ByteConversion for FieldElement<Degree2ExtensionField> {
 impl FieldElement<Degree6ExtensionField> {
     pub fn new_base(a_hex: &str) -> Self {
         Self::new([
-            FieldElement::new([FieldElement::new(U384::from_hex(a_hex)), FieldElement::zero()]),
+            FieldElement::new([FieldElement::new(U384::from_hex_unchecked(a_hex)), FieldElement::zero()]),
             FieldElement::zero(),
             FieldElement::zero(),
         ])
@@ -133,30 +133,30 @@ impl FieldElement<Degree12ExtensionField> {
         FieldElement::<Degree12ExtensionField>::new([
             FieldElement::new([
                 FieldElement::new([
-                    FieldElement::new(U384::from_hex(coefficients[0])),
-                    FieldElement::new(U384::from_hex(coefficients[1])),
+                    FieldElement::new(U384::from_hex_unchecked(coefficients[0])),
+                    FieldElement::new(U384::from_hex_unchecked(coefficients[1])),
                 ]),
                 FieldElement::new([
-                    FieldElement::new(U384::from_hex(coefficients[2])),
-                    FieldElement::new(U384::from_hex(coefficients[3])),
+                    FieldElement::new(U384::from_hex_unchecked(coefficients[2])),
+                    FieldElement::new(U384::from_hex_unchecked(coefficients[3])),
                 ]),
                 FieldElement::new([
-                    FieldElement::new(U384::from_hex(coefficients[4])),
-                    FieldElement::new(U384::from_hex(coefficients[5])),
+                    FieldElement::new(U384::from_hex_unchecked(coefficients[4])),
+                    FieldElement::new(U384::from_hex_unchecked(coefficients[5])),
                 ]),
             ]),
             FieldElement::new([
                 FieldElement::new([
-                    FieldElement::new(U384::from_hex(coefficients[6])),
-                    FieldElement::new(U384::from_hex(coefficients[7])),
+                    FieldElement::new(U384::from_hex_unchecked(coefficients[6])),
+                    FieldElement::new(U384::from_hex_unchecked(coefficients[7])),
                 ]),
                 FieldElement::new([
-                    FieldElement::new(U384::from_hex(coefficients[8])),
-                    FieldElement::new(U384::from_hex(coefficients[9])),
+                    FieldElement::new(U384::from_hex_unchecked(coefficients[8])),
+                    FieldElement::new(U384::from_hex_unchecked(coefficients[9])),
                 ]),
                 FieldElement::new([
-                    FieldElement::new(U384::from_hex(coefficients[10])),
-                    FieldElement::new(U384::from_hex(coefficients[11])),
+                    FieldElement::new(U384::from_hex_unchecked(coefficients[10])),
+                    FieldElement::new(U384::from_hex_unchecked(coefficients[11])),
                 ]),
             ]),
         ])

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -73,7 +73,10 @@ impl FieldElement<BLS12381PrimeField> {
 
 impl FieldElement<Degree2ExtensionField> {
     pub fn new_base(a_hex: &str) -> Self {
-        Self::new([FieldElement::new(U384::from_hex_unchecked(a_hex)), FieldElement::zero()])
+        Self::new([
+            FieldElement::new(U384::from_hex_unchecked(a_hex)),
+            FieldElement::zero(),
+        ])
     }
 }
 
@@ -114,7 +117,10 @@ impl ByteConversion for FieldElement<Degree2ExtensionField> {
 impl FieldElement<Degree6ExtensionField> {
     pub fn new_base(a_hex: &str) -> Self {
         Self::new([
-            FieldElement::new([FieldElement::new(U384::from_hex_unchecked(a_hex)), FieldElement::zero()]),
+            FieldElement::new([
+                FieldElement::new(U384::from_hex_unchecked(a_hex)),
+                FieldElement::zero(),
+            ]),
             FieldElement::zero(),
             FieldElement::zero(),
         ])

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -11,7 +11,7 @@ use crate::{
     traits::ByteConversion,
 };
 
-pub const BLS12381_PRIME_FIELD_ORDER: U384 = U384::from("1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab");
+pub const BLS12381_PRIME_FIELD_ORDER: U384 = U384::from_hex("1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab");
 
 // FPBLS12381
 #[derive(Clone, Debug)]
@@ -41,8 +41,8 @@ impl HasCubicNonResidue for LevelTwoResidue {
 
     fn residue() -> FieldElement<Degree2ExtensionField> {
         FieldElement::new([
-            FieldElement::new(U384::from("d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd556")),
-            FieldElement::new(U384::from("d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd555"))
+            FieldElement::new(U384::from_hex("d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd556")),
+            FieldElement::new(U384::from_hex("d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd555"))
         ])
     }
 }
@@ -67,13 +67,13 @@ pub type Degree12ExtensionField = QuadraticExtensionField<LevelThreeResidue>;
 
 impl FieldElement<BLS12381PrimeField> {
     pub fn new_base(a_hex: &str) -> Self {
-        Self::new(U384::from(a_hex))
+        Self::new(U384::from_hex(a_hex))
     }
 }
 
 impl FieldElement<Degree2ExtensionField> {
     pub fn new_base(a_hex: &str) -> Self {
-        Self::new([FieldElement::new(U384::from(a_hex)), FieldElement::zero()])
+        Self::new([FieldElement::new(U384::from_hex(a_hex)), FieldElement::zero()])
     }
 }
 
@@ -114,7 +114,7 @@ impl ByteConversion for FieldElement<Degree2ExtensionField> {
 impl FieldElement<Degree6ExtensionField> {
     pub fn new_base(a_hex: &str) -> Self {
         Self::new([
-            FieldElement::new([FieldElement::new(U384::from(a_hex)), FieldElement::zero()]),
+            FieldElement::new([FieldElement::new(U384::from_hex(a_hex)), FieldElement::zero()]),
             FieldElement::zero(),
             FieldElement::zero(),
         ])
@@ -133,30 +133,30 @@ impl FieldElement<Degree12ExtensionField> {
         FieldElement::<Degree12ExtensionField>::new([
             FieldElement::new([
                 FieldElement::new([
-                    FieldElement::new(U384::from(coefficients[0])),
-                    FieldElement::new(U384::from(coefficients[1])),
+                    FieldElement::new(U384::from_hex(coefficients[0])),
+                    FieldElement::new(U384::from_hex(coefficients[1])),
                 ]),
                 FieldElement::new([
-                    FieldElement::new(U384::from(coefficients[2])),
-                    FieldElement::new(U384::from(coefficients[3])),
+                    FieldElement::new(U384::from_hex(coefficients[2])),
+                    FieldElement::new(U384::from_hex(coefficients[3])),
                 ]),
                 FieldElement::new([
-                    FieldElement::new(U384::from(coefficients[4])),
-                    FieldElement::new(U384::from(coefficients[5])),
+                    FieldElement::new(U384::from_hex(coefficients[4])),
+                    FieldElement::new(U384::from_hex(coefficients[5])),
                 ]),
             ]),
             FieldElement::new([
                 FieldElement::new([
-                    FieldElement::new(U384::from(coefficients[6])),
-                    FieldElement::new(U384::from(coefficients[7])),
+                    FieldElement::new(U384::from_hex(coefficients[6])),
+                    FieldElement::new(U384::from_hex(coefficients[7])),
                 ]),
                 FieldElement::new([
-                    FieldElement::new(U384::from(coefficients[8])),
-                    FieldElement::new(U384::from(coefficients[9])),
+                    FieldElement::new(U384::from_hex(coefficients[8])),
+                    FieldElement::new(U384::from_hex(coefficients[9])),
                 ]),
                 FieldElement::new([
-                    FieldElement::new(U384::from(coefficients[10])),
-                    FieldElement::new(U384::from(coefficients[11])),
+                    FieldElement::new(U384::from_hex(coefficients[10])),
+                    FieldElement::new(U384::from_hex(coefficients[11])),
                 ]),
             ]),
         ])

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -104,7 +104,7 @@ fn frobenius_square(
 fn final_exponentiation(
     base: &FieldElement<Degree12ExtensionField>,
 ) -> FieldElement<Degree12ExtensionField> {
-    const PHI_DIVIDED_BY_R: UnsignedInteger<20> = UnsignedInteger::from("f686b3d807d01c0bd38c3195c899ed3cde88eeb996ca394506632528d6a9a2f230063cf081517f68f7764c28b6f8ae5a72bce8d63cb9f827eca0ba621315b2076995003fc77a17988f8761bdc51dc2378b9039096d1b767f17fcbde783765915c97f36c6f18212ed0b283ed237db421d160aeb6a1e79983774940996754c8c71a2629b0dea236905ce937335d5b68fa9912aae208ccf1e516c3f438e3ba79");
+    const PHI_DIVIDED_BY_R: UnsignedInteger<20> = UnsignedInteger::from_hex("f686b3d807d01c0bd38c3195c899ed3cde88eeb996ca394506632528d6a9a2f230063cf081517f68f7764c28b6f8ae5a72bce8d63cb9f827eca0ba621315b2076995003fc77a17988f8761bdc51dc2378b9039096d1b767f17fcbde783765915c97f36c6f18212ed0b283ed237db421d160aeb6a1e79983774940996754c8c71a2629b0dea236905ce937335d5b68fa9912aae208ccf1e516c3f438e3ba79");
 
     let f1 = base.conjugate() * base.inv();
     let f2 = frobenius_square(&f1) * f1;

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -104,7 +104,7 @@ fn frobenius_square(
 fn final_exponentiation(
     base: &FieldElement<Degree12ExtensionField>,
 ) -> FieldElement<Degree12ExtensionField> {
-    const PHI_DIVIDED_BY_R: UnsignedInteger<20> = UnsignedInteger::from_hex("f686b3d807d01c0bd38c3195c899ed3cde88eeb996ca394506632528d6a9a2f230063cf081517f68f7764c28b6f8ae5a72bce8d63cb9f827eca0ba621315b2076995003fc77a17988f8761bdc51dc2378b9039096d1b767f17fcbde783765915c97f36c6f18212ed0b283ed237db421d160aeb6a1e79983774940996754c8c71a2629b0dea236905ce937335d5b68fa9912aae208ccf1e516c3f438e3ba79");
+    const PHI_DIVIDED_BY_R: UnsignedInteger<20> = UnsignedInteger::from_hex_unchecked("f686b3d807d01c0bd38c3195c899ed3cde88eeb996ca394506632528d6a9a2f230063cf081517f68f7764c28b6f8ae5a72bce8d63cb9f827eca0ba621315b2076995003fc77a17988f8761bdc51dc2378b9039096d1b767f17fcbde783765915c97f36c6f18212ed0b283ed237db421d160aeb6a1e79983774940996754c8c71a2629b0dea236905ce937335d5b68fa9912aae208ccf1e516c3f438e3ba79");
 
     let f1 = base.conjugate() * base.inv();
     let f2 = frobenius_square(&f1) * f1;

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -8,10 +8,10 @@ use crate::{
 
 use super::field_extension::{Degree12ExtensionField, Degree2ExtensionField};
 
-const GENERATOR_X_0: U384 = U384::from("024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8");
-const GENERATOR_X_1: U384 = U384::from("13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e");
-const GENERATOR_Y_0: U384 = U384::from("0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801");
-const GENERATOR_Y_1: U384 = U384::from("0606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be");
+const GENERATOR_X_0: U384 = U384::from_hex("024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8");
+const GENERATOR_X_1: U384 = U384::from_hex("13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e");
+const GENERATOR_Y_0: U384 = U384::from_hex("0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801");
+const GENERATOR_Y_1: U384 = U384::from_hex("0606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be");
 
 /// The description of the curve.
 #[derive(Clone, Debug)]
@@ -126,28 +126,28 @@ mod tests {
     #[test]
     fn add_points() {
         let px = Level1FE::new([
-            Level0FE::new(U384::from("97798b4a61ac301bbee71e36b5174e2f4adfe3e1729bdae1fcc9965ae84181be373aa80414823eed694f1270014012d")),
-            Level0FE::new(U384::from("c9852cc6e61868966249aec153b50b29b3c22409f4c7880fd13121981c103c8ef84d9ea29b552431360e82cf69219fa"))
+            Level0FE::new(U384::from_hex("97798b4a61ac301bbee71e36b5174e2f4adfe3e1729bdae1fcc9965ae84181be373aa80414823eed694f1270014012d")),
+            Level0FE::new(U384::from_hex("c9852cc6e61868966249aec153b50b29b3c22409f4c7880fd13121981c103c8ef84d9ea29b552431360e82cf69219fa"))
         ]);
         let py = Level1FE::new([
-            Level0FE::new(U384::from("16cb3a60f3fa52c8273aceeb94c4c7303e8074aa9eedec7355bbb1e8cceedd4ec1497f573f62822140377b8e339619ed")),
-            Level0FE::new(U384::from("1cd919b08afe06bebe9adf6223a55868a6fd8b77efc5c67b60fff39be36e9b44b7f10db16827c83b43ad2dad1947778"))
+            Level0FE::new(U384::from_hex("16cb3a60f3fa52c8273aceeb94c4c7303e8074aa9eedec7355bbb1e8cceedd4ec1497f573f62822140377b8e339619ed")),
+            Level0FE::new(U384::from_hex("1cd919b08afe06bebe9adf6223a55868a6fd8b77efc5c67b60fff39be36e9b44b7f10db16827c83b43ad2dad1947778"))
         ]);
         let qx = Level1FE::new([
-            Level0FE::new(U384::from("b6bce994c23f6505131a5f6d4ce4ba30f5dab726780bef00517585cab02e17f4d015b26eeaff376dc236af26c0210f1")),
-            Level0FE::new(U384::from("163163e71fdd96a84b6a24d3e7cd9d7c0f06961e6fe8b7ec9b27bef1dbef5cbaf557563f725229fc79814a294c0b8511"))
+            Level0FE::new(U384::from_hex("b6bce994c23f6505131a5f6d4ce4ba30f5dab726780bef00517585cab02e17f4d015b26eeaff376dc236af26c0210f1")),
+            Level0FE::new(U384::from_hex("163163e71fdd96a84b6a24d3e7cd9d7c0f06961e6fe8b7ec9b27bef1dbef5cbaf557563f725229fc79814a294c0b8511"))
         ]);
         let qy = Level1FE::new([
-            Level0FE::new(U384::from("1c6afffac96cd457b4ac797e5cef6951c83bb328737f57df44ba0cc513d499f736816877a6cf87f1359e79d10151e14")),
-            Level0FE::new(U384::from("79e40e569c20182726c148ca72a6e862d03317a2cf75cd19c2be36e29e03da70acbefbfa7a4c4e1c088bf94ae6ba6ce"))
+            Level0FE::new(U384::from_hex("1c6afffac96cd457b4ac797e5cef6951c83bb328737f57df44ba0cc513d499f736816877a6cf87f1359e79d10151e14")),
+            Level0FE::new(U384::from_hex("79e40e569c20182726c148ca72a6e862d03317a2cf75cd19c2be36e29e03da70acbefbfa7a4c4e1c088bf94ae6ba6ce"))
         ]);
         let expectedx = Level1FE::new([
-            Level0FE::new(U384::from("63f209cd306e632cc91089bd6b3bb02a6679fd02931a6e2292976589426dfdff9366829d5f45d982413e8b9514e8965")),
-            Level0FE::new(U384::from("11aae43845fcb3e633217c2851889cddb939a3d2ddf00a64e4e0a723c362dff2caabc640a1095ac5be4075d4f7edf17f"))
+            Level0FE::new(U384::from_hex("63f209cd306e632cc91089bd6b3bb02a6679fd02931a6e2292976589426dfdff9366829d5f45d982413e8b9514e8965")),
+            Level0FE::new(U384::from_hex("11aae43845fcb3e633217c2851889cddb939a3d2ddf00a64e4e0a723c362dff2caabc640a1095ac5be4075d4f7edf17f"))
         ]);
         let expectedy = Level1FE::new([
-            Level0FE::new(U384::from("83e21ca01826bca9221373faf03132b80128c24760c639b44bd7e0b6c11537ef239c01d31a25a58c7f67fb16df0234b")),
-            Level0FE::new(U384::from("f45243fd699bba6c6ca644ad8070f7812e4987fb2c91f64139a293958ed373814ef7317c11c3496cd93b88871f5d2c7"))
+            Level0FE::new(U384::from_hex("83e21ca01826bca9221373faf03132b80128c24760c639b44bd7e0b6c11537ef239c01d31a25a58c7f67fb16df0234b")),
+            Level0FE::new(U384::from_hex("f45243fd699bba6c6ca644ad8070f7812e4987fb2c91f64139a293958ed373814ef7317c11c3496cd93b88871f5d2c7"))
         ]);
         let p = BLS12381TwistCurve::create_point_from_affine(px, py).unwrap();
         let q = BLS12381TwistCurve::create_point_from_affine(qx, qy).unwrap();

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -8,10 +8,10 @@ use crate::{
 
 use super::field_extension::{Degree12ExtensionField, Degree2ExtensionField};
 
-const GENERATOR_X_0: U384 = U384::from_hex("024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8");
-const GENERATOR_X_1: U384 = U384::from_hex("13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e");
-const GENERATOR_Y_0: U384 = U384::from_hex("0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801");
-const GENERATOR_Y_1: U384 = U384::from_hex("0606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be");
+const GENERATOR_X_0: U384 = U384::from_hex_unchecked("024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8");
+const GENERATOR_X_1: U384 = U384::from_hex_unchecked("13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e");
+const GENERATOR_Y_0: U384 = U384::from_hex_unchecked("0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801");
+const GENERATOR_Y_1: U384 = U384::from_hex_unchecked("0606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be");
 
 /// The description of the curve.
 #[derive(Clone, Debug)]
@@ -126,28 +126,28 @@ mod tests {
     #[test]
     fn add_points() {
         let px = Level1FE::new([
-            Level0FE::new(U384::from_hex("97798b4a61ac301bbee71e36b5174e2f4adfe3e1729bdae1fcc9965ae84181be373aa80414823eed694f1270014012d")),
-            Level0FE::new(U384::from_hex("c9852cc6e61868966249aec153b50b29b3c22409f4c7880fd13121981c103c8ef84d9ea29b552431360e82cf69219fa"))
+            Level0FE::new(U384::from_hex_unchecked("97798b4a61ac301bbee71e36b5174e2f4adfe3e1729bdae1fcc9965ae84181be373aa80414823eed694f1270014012d")),
+            Level0FE::new(U384::from_hex_unchecked("c9852cc6e61868966249aec153b50b29b3c22409f4c7880fd13121981c103c8ef84d9ea29b552431360e82cf69219fa"))
         ]);
         let py = Level1FE::new([
-            Level0FE::new(U384::from_hex("16cb3a60f3fa52c8273aceeb94c4c7303e8074aa9eedec7355bbb1e8cceedd4ec1497f573f62822140377b8e339619ed")),
-            Level0FE::new(U384::from_hex("1cd919b08afe06bebe9adf6223a55868a6fd8b77efc5c67b60fff39be36e9b44b7f10db16827c83b43ad2dad1947778"))
+            Level0FE::new(U384::from_hex_unchecked("16cb3a60f3fa52c8273aceeb94c4c7303e8074aa9eedec7355bbb1e8cceedd4ec1497f573f62822140377b8e339619ed")),
+            Level0FE::new(U384::from_hex_unchecked("1cd919b08afe06bebe9adf6223a55868a6fd8b77efc5c67b60fff39be36e9b44b7f10db16827c83b43ad2dad1947778"))
         ]);
         let qx = Level1FE::new([
-            Level0FE::new(U384::from_hex("b6bce994c23f6505131a5f6d4ce4ba30f5dab726780bef00517585cab02e17f4d015b26eeaff376dc236af26c0210f1")),
-            Level0FE::new(U384::from_hex("163163e71fdd96a84b6a24d3e7cd9d7c0f06961e6fe8b7ec9b27bef1dbef5cbaf557563f725229fc79814a294c0b8511"))
+            Level0FE::new(U384::from_hex_unchecked("b6bce994c23f6505131a5f6d4ce4ba30f5dab726780bef00517585cab02e17f4d015b26eeaff376dc236af26c0210f1")),
+            Level0FE::new(U384::from_hex_unchecked("163163e71fdd96a84b6a24d3e7cd9d7c0f06961e6fe8b7ec9b27bef1dbef5cbaf557563f725229fc79814a294c0b8511"))
         ]);
         let qy = Level1FE::new([
-            Level0FE::new(U384::from_hex("1c6afffac96cd457b4ac797e5cef6951c83bb328737f57df44ba0cc513d499f736816877a6cf87f1359e79d10151e14")),
-            Level0FE::new(U384::from_hex("79e40e569c20182726c148ca72a6e862d03317a2cf75cd19c2be36e29e03da70acbefbfa7a4c4e1c088bf94ae6ba6ce"))
+            Level0FE::new(U384::from_hex_unchecked("1c6afffac96cd457b4ac797e5cef6951c83bb328737f57df44ba0cc513d499f736816877a6cf87f1359e79d10151e14")),
+            Level0FE::new(U384::from_hex_unchecked("79e40e569c20182726c148ca72a6e862d03317a2cf75cd19c2be36e29e03da70acbefbfa7a4c4e1c088bf94ae6ba6ce"))
         ]);
         let expectedx = Level1FE::new([
-            Level0FE::new(U384::from_hex("63f209cd306e632cc91089bd6b3bb02a6679fd02931a6e2292976589426dfdff9366829d5f45d982413e8b9514e8965")),
-            Level0FE::new(U384::from_hex("11aae43845fcb3e633217c2851889cddb939a3d2ddf00a64e4e0a723c362dff2caabc640a1095ac5be4075d4f7edf17f"))
+            Level0FE::new(U384::from_hex_unchecked("63f209cd306e632cc91089bd6b3bb02a6679fd02931a6e2292976589426dfdff9366829d5f45d982413e8b9514e8965")),
+            Level0FE::new(U384::from_hex_unchecked("11aae43845fcb3e633217c2851889cddb939a3d2ddf00a64e4e0a723c362dff2caabc640a1095ac5be4075d4f7edf17f"))
         ]);
         let expectedy = Level1FE::new([
-            Level0FE::new(U384::from_hex("83e21ca01826bca9221373faf03132b80128c24760c639b44bd7e0b6c11537ef239c01d31a25a58c7f67fb16df0234b")),
-            Level0FE::new(U384::from_hex("f45243fd699bba6c6ca644ad8070f7812e4987fb2c91f64139a293958ed373814ef7317c11c3496cd93b88871f5d2c7"))
+            Level0FE::new(U384::from_hex_unchecked("83e21ca01826bca9221373faf03132b80128c24760c639b44bd7e0b6c11537ef239c01d31a25a58c7f67fb16df0234b")),
+            Level0FE::new(U384::from_hex_unchecked("f45243fd699bba6c6ca644ad8070f7812e4987fb2c91f64139a293958ed373814ef7317c11c3496cd93b88871f5d2c7"))
         ]);
         let p = BLS12381TwistCurve::create_point_from_affine(px, py).unwrap();
         let q = BLS12381TwistCurve::create_point_from_affine(qx, qy).unwrap();

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
@@ -13,10 +13,12 @@ use crate::{
 };
 
 /// Order of the base field (e.g.: order of the coordinates)
-pub const TEST_CURVE_2_PRIME_FIELD_ORDER: U384 = U384::from_hex_unchecked("150b4c0967215604b841bb57053fcb86cf");
+pub const TEST_CURVE_2_PRIME_FIELD_ORDER: U384 =
+    U384::from_hex_unchecked("150b4c0967215604b841bb57053fcb86cf");
 
 /// Order of the subgroup of the curve.
-pub const TEST_CURVE_2_MAIN_SUBGROUP_ORDER: U384 = U384::from_hex_unchecked("40a065fb5a76390de709fb229");
+pub const TEST_CURVE_2_MAIN_SUBGROUP_ORDER: U384 =
+    U384::from_hex_unchecked("40a065fb5a76390de709fb229");
 
 // FPBLS12381
 #[derive(Clone, Debug)]
@@ -51,12 +53,20 @@ impl IsEllipticCurve for TestCurve2 {
     fn generator() -> Self::PointRepresentation {
         Self::PointRepresentation::new([
             FieldElement::new([
-                FieldElement::new(U384::from_hex_unchecked("21acedb641ca6d0f8b60148123a999801")),
-                FieldElement::new(U384::from_hex_unchecked("14d34d94f7de312859a8a0d9dbc67159d3")),
+                FieldElement::new(U384::from_hex_unchecked(
+                    "21acedb641ca6d0f8b60148123a999801",
+                )),
+                FieldElement::new(U384::from_hex_unchecked(
+                    "14d34d94f7de312859a8a0d9dbc67159d3",
+                )),
             ]),
             FieldElement::new([
-                FieldElement::new(U384::from_hex_unchecked("2ac53e77afe8d841c8eb660761c4b873a")),
-                FieldElement::new(U384::from_hex_unchecked("108a9e1c5514b0921cd5781a7f71130142")),
+                FieldElement::new(U384::from_hex_unchecked(
+                    "2ac53e77afe8d841c8eb660761c4b873a",
+                )),
+                FieldElement::new(U384::from_hex_unchecked(
+                    "108a9e1c5514b0921cd5781a7f71130142",
+                )),
             ]),
             FieldElement::one(),
         ])

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
@@ -13,10 +13,10 @@ use crate::{
 };
 
 /// Order of the base field (e.g.: order of the coordinates)
-pub const TEST_CURVE_2_PRIME_FIELD_ORDER: U384 = U384::from_hex("150b4c0967215604b841bb57053fcb86cf");
+pub const TEST_CURVE_2_PRIME_FIELD_ORDER: U384 = U384::from_hex_unchecked("150b4c0967215604b841bb57053fcb86cf");
 
 /// Order of the subgroup of the curve.
-pub const TEST_CURVE_2_MAIN_SUBGROUP_ORDER: U384 = U384::from_hex("40a065fb5a76390de709fb229");
+pub const TEST_CURVE_2_MAIN_SUBGROUP_ORDER: U384 = U384::from_hex_unchecked("40a065fb5a76390de709fb229");
 
 // FPBLS12381
 #[derive(Clone, Debug)]
@@ -51,12 +51,12 @@ impl IsEllipticCurve for TestCurve2 {
     fn generator() -> Self::PointRepresentation {
         Self::PointRepresentation::new([
             FieldElement::new([
-                FieldElement::new(U384::from_hex("21acedb641ca6d0f8b60148123a999801")),
-                FieldElement::new(U384::from_hex("14d34d94f7de312859a8a0d9dbc67159d3")),
+                FieldElement::new(U384::from_hex_unchecked("21acedb641ca6d0f8b60148123a999801")),
+                FieldElement::new(U384::from_hex_unchecked("14d34d94f7de312859a8a0d9dbc67159d3")),
             ]),
             FieldElement::new([
-                FieldElement::new(U384::from_hex("2ac53e77afe8d841c8eb660761c4b873a")),
-                FieldElement::new(U384::from_hex("108a9e1c5514b0921cd5781a7f71130142")),
+                FieldElement::new(U384::from_hex_unchecked("2ac53e77afe8d841c8eb660761c4b873a")),
+                FieldElement::new(U384::from_hex_unchecked("108a9e1c5514b0921cd5781a7f71130142")),
             ]),
             FieldElement::one(),
         ])

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
@@ -13,10 +13,10 @@ use crate::{
 };
 
 /// Order of the base field (e.g.: order of the coordinates)
-pub const TEST_CURVE_2_PRIME_FIELD_ORDER: U384 = U384::from("150b4c0967215604b841bb57053fcb86cf");
+pub const TEST_CURVE_2_PRIME_FIELD_ORDER: U384 = U384::from_hex("150b4c0967215604b841bb57053fcb86cf");
 
 /// Order of the subgroup of the curve.
-pub const TEST_CURVE_2_MAIN_SUBGROUP_ORDER: U384 = U384::from("40a065fb5a76390de709fb229");
+pub const TEST_CURVE_2_MAIN_SUBGROUP_ORDER: U384 = U384::from_hex("40a065fb5a76390de709fb229");
 
 // FPBLS12381
 #[derive(Clone, Debug)]
@@ -51,12 +51,12 @@ impl IsEllipticCurve for TestCurve2 {
     fn generator() -> Self::PointRepresentation {
         Self::PointRepresentation::new([
             FieldElement::new([
-                FieldElement::new(U384::from("21acedb641ca6d0f8b60148123a999801")),
-                FieldElement::new(U384::from("14d34d94f7de312859a8a0d9dbc67159d3")),
+                FieldElement::new(U384::from_hex("21acedb641ca6d0f8b60148123a999801")),
+                FieldElement::new(U384::from_hex("14d34d94f7de312859a8a0d9dbc67159d3")),
             ]),
             FieldElement::new([
-                FieldElement::new(U384::from("2ac53e77afe8d841c8eb660761c4b873a")),
-                FieldElement::new(U384::from("108a9e1c5514b0921cd5781a7f71130142")),
+                FieldElement::new(U384::from_hex("2ac53e77afe8d841c8eb660761c4b873a")),
+                FieldElement::new(U384::from_hex("108a9e1c5514b0921cd5781a7f71130142")),
             ]),
             FieldElement::one(),
         ])

--- a/math/src/errors.rs
+++ b/math/src/errors.rs
@@ -7,3 +7,9 @@ pub enum ByteConversionError {
     #[error("from_le_bytes failed")]
     FromLEBytesError,
 }
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum CreationError {
+    #[error("String is not an hexstring")]
+    InvalidHexString,
+}

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -461,7 +461,7 @@ where
 {
     #[allow(unused)]
     pub const fn from_hex(hex: &str) -> Self {
-        let integer = UnsignedInteger::<NUM_LIMBS>::from(hex);
+        let integer = UnsignedInteger::<NUM_LIMBS>::from_hex(hex);
         Self {
             value: MontgomeryAlgorithms::cios(
                 &integer,

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -460,7 +460,10 @@ impl<M, const NUM_LIMBS: usize> FieldElement<MontgomeryBackendPrimeField<M, NUM_
 where
     M: IsModulus<UnsignedInteger<NUM_LIMBS>> + Clone + Debug,
 {
-    #[allow(unused)]
+
+    /// Creates a `FieldElement` from a hexstring. It can contain `0x` or not. 
+    /// # Panics
+    /// Panics if value is not a hexstring
     pub const fn from_hex_unchecked(hex: &str) -> Self {
         let integer = UnsignedInteger::<NUM_LIMBS>::from_hex_unchecked(hex);
         Self {
@@ -473,7 +476,8 @@ where
         }
     }
 
-    #[allow(unused)]
+    /// Creates a `FieldElement` from a hexstring. It can contain `0x` or not. 
+    /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring
     pub fn from_hex(hex: &str) -> Result<Self, CreationError> {
         let integer = UnsignedInteger::<NUM_LIMBS>::from_hex(hex)?;
 

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -1,3 +1,4 @@
+use crate::errors::CreationError;
 use crate::field::traits::IsField;
 use crate::unsigned_integer::element::UnsignedInteger;
 use crate::unsigned_integer::montgomery::MontgomeryAlgorithms;
@@ -460,7 +461,7 @@ where
     M: IsModulus<UnsignedInteger<NUM_LIMBS>> + Clone + Debug,
 {
     #[allow(unused)]
-    pub const fn from_hex(hex: &str) -> Self {
+    pub const fn from_hex_unchecked(hex: &str) -> Self {
         let integer = UnsignedInteger::<NUM_LIMBS>::from_hex_unchecked(hex);
         Self {
             value: MontgomeryAlgorithms::cios(
@@ -470,6 +471,20 @@ where
                 &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::MU,
             ),
         }
+    }
+
+    #[allow(unused)]
+    pub fn from_hex(hex: &str) -> Result<Self,CreationError> {
+        let integer = UnsignedInteger::<NUM_LIMBS>::from_hex(hex)?;
+
+        Ok(Self {
+            value: MontgomeryAlgorithms::cios(
+                &integer,
+                &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::R2,
+                &M::MODULUS,
+                &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::MU,
+            ),
+        })
     }
 }
 

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -460,8 +460,7 @@ impl<M, const NUM_LIMBS: usize> FieldElement<MontgomeryBackendPrimeField<M, NUM_
 where
     M: IsModulus<UnsignedInteger<NUM_LIMBS>> + Clone + Debug,
 {
-
-    /// Creates a `FieldElement` from a hexstring. It can contain `0x` or not. 
+    /// Creates a `FieldElement` from a hexstring. It can contain `0x` or not.
     /// # Panics
     /// Panics if value is not a hexstring
     pub const fn from_hex_unchecked(hex: &str) -> Self {
@@ -476,7 +475,7 @@ where
         }
     }
 
-    /// Creates a `FieldElement` from a hexstring. It can contain `0x` or not. 
+    /// Creates a `FieldElement` from a hexstring. It can contain `0x` or not.
     /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring
     pub fn from_hex(hex: &str) -> Result<Self, CreationError> {
         let integer = UnsignedInteger::<NUM_LIMBS>::from_hex(hex)?;

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -461,7 +461,7 @@ where
 {
     #[allow(unused)]
     pub const fn from_hex(hex: &str) -> Self {
-        let integer = UnsignedInteger::<NUM_LIMBS>::from_hex(hex);
+        let integer = UnsignedInteger::<NUM_LIMBS>::from_hex_unchecked(hex);
         Self {
             value: MontgomeryAlgorithms::cios(
                 &integer,

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -474,7 +474,7 @@ where
     }
 
     #[allow(unused)]
-    pub fn from_hex(hex: &str) -> Result<Self,CreationError> {
+    pub fn from_hex(hex: &str) -> Result<Self, CreationError> {
         let integer = UnsignedInteger::<NUM_LIMBS>::from_hex(hex)?;
 
         Ok(Self {

--- a/math/src/field/fields/fft_friendly/stark_252_prime_field.rs
+++ b/math/src/field/fields/fft_friendly/stark_252_prime_field.rs
@@ -10,7 +10,7 @@ use crate::{
 pub struct MontgomeryConfigStark252PrimeField;
 impl IsModulus<U256> for MontgomeryConfigStark252PrimeField {
     const MODULUS: U256 =
-        U256::from("800000000000011000000000000000000000000000000000000000000000001");
+        U256::from_hex("800000000000011000000000000000000000000000000000000000000000001");
 }
 
 pub type Stark252PrimeField = U256PrimeField<MontgomeryConfigStark252PrimeField>;

--- a/math/src/field/fields/fft_friendly/stark_252_prime_field.rs
+++ b/math/src/field/fields/fft_friendly/stark_252_prime_field.rs
@@ -10,7 +10,7 @@ use crate::{
 pub struct MontgomeryConfigStark252PrimeField;
 impl IsModulus<U256> for MontgomeryConfigStark252PrimeField {
     const MODULUS: U256 =
-        U256::from_hex("800000000000011000000000000000000000000000000000000000000000001");
+        U256::from_hex_unchecked("800000000000011000000000000000000000000000000000000000000000001");
 }
 
 pub type Stark252PrimeField = U256PrimeField<MontgomeryConfigStark252PrimeField>;

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -424,13 +424,13 @@ mod tests_u384_prime_fields {
 
     #[test]
     fn montgomery_prime_field_addition_works_0() {
-        let x = U384FP1Element::new(UnsignedInteger::from(
+        let x = U384FP1Element::new(UnsignedInteger::from_hex(
             "05ed176deb0e80b4deb7718cdaa075165f149c",
         ));
-        let y = U384FP1Element::new(UnsignedInteger::from(
+        let y = U384FP1Element::new(UnsignedInteger::from_hex(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
-        let c = U384FP1Element::new(UnsignedInteger::from(
+        let c = U384FP1Element::new(UnsignedInteger::from_hex(
             "64fd5279bf47fe02d4185ce279d8aa55e00352",
         ));
         assert_eq!(x + y, c);
@@ -438,13 +438,13 @@ mod tests_u384_prime_fields {
 
     #[test]
     fn montgomery_prime_field_multiplication_works_0() {
-        let x = U384FP1Element::new(UnsignedInteger::from(
+        let x = U384FP1Element::new(UnsignedInteger::from_hex(
             "05ed176deb0e80b4deb7718cdaa075165f149c",
         ));
-        let y = U384FP1Element::new(UnsignedInteger::from(
+        let y = U384FP1Element::new(UnsignedInteger::from_hex(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
-        let c = U384FP1Element::new(UnsignedInteger::from(
+        let c = U384FP1Element::new(UnsignedInteger::from_hex(
             "73d23e8d462060dc23d5c15c00fc432d95621a3c",
         ));
         assert_eq!(x * y, c);
@@ -471,13 +471,13 @@ mod tests_u384_prime_fields {
 
     #[test]
     fn montgomery_prime_field_addition_works_1() {
-        let x = U384FP2Element::new(UnsignedInteger::from(
+        let x = U384FP2Element::new(UnsignedInteger::from_hex(
             "05ed176deb0e80b4deb7718cdaa075165f149c",
         ));
-        let y = U384FP2Element::new(UnsignedInteger::from(
+        let y = U384FP2Element::new(UnsignedInteger::from_hex(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
-        let c = U384FP2Element::new(UnsignedInteger::from(
+        let c = U384FP2Element::new(UnsignedInteger::from_hex(
             "64fd5279bf47fe02d4185ce279d8aa55e00352",
         ));
         assert_eq!(x + y, c);
@@ -486,7 +486,7 @@ mod tests_u384_prime_fields {
     #[test]
     fn montgomery_prime_field_multiplication_works_1() {
         let x = U384FP2Element::one();
-        let y = U384FP2Element::new(UnsignedInteger::from(
+        let y = U384FP2Element::new(UnsignedInteger::from_hex(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
         assert_eq!(&y * x, y);
@@ -494,7 +494,7 @@ mod tests_u384_prime_fields {
 
     #[test]
     fn to_bytes_from_bytes_be_is_the_identity() {
-        let x = U384FP2Element::new(UnsignedInteger::from(
+        let x = U384FP2Element::new(UnsignedInteger::from_hex(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
         assert_eq!(U384FP2Element::from_bytes_be(&x.to_bytes_be()).unwrap(), x);
@@ -514,7 +514,7 @@ mod tests_u384_prime_fields {
 
     #[test]
     fn to_bytes_from_bytes_le_is_the_identity() {
-        let x = U384FP2Element::new(UnsignedInteger::from(
+        let x = U384FP2Element::new(UnsignedInteger::from_hex(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
         assert_eq!(U384FP2Element::from_bytes_le(&x.to_bytes_le()).unwrap(), x);
@@ -750,13 +750,13 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn montgomery_prime_field_addition_works_0() {
-        let x = U256FP1Element::new(UnsignedInteger::from(
+        let x = U256FP1Element::new(UnsignedInteger::from_hex(
             "93e712950bf3fe589aa030562a44b1cec66b09192c4bcf705a5",
         ));
-        let y = U256FP1Element::new(UnsignedInteger::from(
+        let y = U256FP1Element::new(UnsignedInteger::from_hex(
             "10a712235c1f6b4172a1e35da6aef1a7ec6b09192c4bb88cfa5",
         ));
-        let c = U256FP1Element::new(UnsignedInteger::from(
+        let c = U256FP1Element::new(UnsignedInteger::from_hex(
             "a48e24b86813699a0d4213b3d0f3a376b2d61232589787fd54a",
         ));
         assert_eq!(x + y, c);
@@ -764,13 +764,13 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn montgomery_prime_field_multiplication_works_0() {
-        let x = U256FP1Element::new(UnsignedInteger::from(
+        let x = U256FP1Element::new(UnsignedInteger::from_hex(
             "93e712950bf3fe589aa030562a44b1cec66b09192c4bcf705a5",
         ));
-        let y = U256FP1Element::new(UnsignedInteger::from(
+        let y = U256FP1Element::new(UnsignedInteger::from_hex(
             "10a712235c1f6b4172a1e35da6aef1a7ec6b09192c4bb88cfa5",
         ));
-        let c = U256FP1Element::new(UnsignedInteger::from(
+        let c = U256FP1Element::new(UnsignedInteger::from_hex(
             "7808e74c3208d9a66791ef9cc15a46acc9951ee312102684021",
         ));
         assert_eq!(x * y, c);
@@ -795,13 +795,13 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn montgomery_prime_field_addition_works_1() {
-        let x = FP2Element::new(UnsignedInteger::from(
+        let x = FP2Element::new(UnsignedInteger::from_hex(
             "acbbb7ca01c65cfffffc72815b397fff9ab130ad53a5ffffffb8f21b207dfedf",
         ));
-        let y = FP2Element::new(UnsignedInteger::from(
+        let y = FP2Element::new(UnsignedInteger::from_hex(
             "d65ddbe509d3fffff21f494c588cbdbfe43e929b0543e3ffffffffffffffff43",
         ));
-        let c = FP2Element::new(UnsignedInteger::from(
+        let c = FP2Element::new(UnsignedInteger::from_hex(
             "831993af0b9a5cfff21bbbcdb3c63dbf7eefc34858e9e3ffffb8f21b207dfedf",
         ));
         assert_eq!(x + y, c);
@@ -809,13 +809,13 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn montgomery_prime_field_multiplication_works_1() {
-        let x = FP2Element::new(UnsignedInteger::from(
+        let x = FP2Element::new(UnsignedInteger::from_hex(
             "acbbb7ca01c65cfffffc72815b397fff9ab130ad53a5ffffffb8f21b207dfedf",
         ));
-        let y = FP2Element::new(UnsignedInteger::from(
+        let y = FP2Element::new(UnsignedInteger::from_hex(
             "d65ddbe509d3fffff21f494c588cbdbfe43e929b0543e3ffffffffffffffff43",
         ));
-        let c = FP2Element::new(UnsignedInteger::from(
+        let c = FP2Element::new(UnsignedInteger::from_hex(
             "2b1e80d553ecab2e4d41eb53c4c8ad89ebacac6cf6b91dcf2213f311093aa05d",
         ));
         assert_eq!(&y * x, c);
@@ -823,7 +823,7 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn to_bytes_from_bytes_be_is_the_identity() {
-        let x = FP2Element::new(UnsignedInteger::from(
+        let x = FP2Element::new(UnsignedInteger::from_hex(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
         assert_eq!(FP2Element::from_bytes_be(&x.to_bytes_be()).unwrap(), x);
@@ -843,7 +843,7 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn to_bytes_from_bytes_le_is_the_identity() {
-        let x = FP2Element::new(UnsignedInteger::from(
+        let x = FP2Element::new(UnsignedInteger::from_hex(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
         assert_eq!(FP2Element::from_bytes_le(&x.to_bytes_le()).unwrap(), x);

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -423,6 +423,11 @@ mod tests_u384_prime_fields {
     type U384FP1Element = FieldElement<U384FP1>;
 
     #[test]
+    fn montgomery_prime_field_from_bad_hex_errs() {
+        assert!(U384FP1Element::from_hex("0xTEST").is_err());
+    }
+
+    #[test]
     fn montgomery_prime_field_addition_works_0() {
         let x = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
             "05ed176deb0e80b4deb7718cdaa075165f149c",
@@ -879,7 +884,7 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn creating_a_field_element_from_hex_works_1() {
-        let a = U256FP1Element::from_hex("eb235f6144d9e91f4b14");
+        let a = U256FP1Element::from_hex_unchecked("eb235f6144d9e91f4b14");
         let b = U256FP1Element::new(U256 {
             limbs: [0, 0, 60195, 6872850209053821716],
         });
@@ -888,7 +893,7 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn creating_a_field_element_from_hex_works() {
-        let a = U256F29Element::from_hex("aa");
+        let a = U256F29Element::from_hex_unchecked("aa");
         let b = U256F29Element::from(25);
         assert_eq!(a, b);
     }

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -424,13 +424,13 @@ mod tests_u384_prime_fields {
 
     #[test]
     fn montgomery_prime_field_addition_works_0() {
-        let x = U384FP1Element::new(UnsignedInteger::from_hex(
+        let x = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
             "05ed176deb0e80b4deb7718cdaa075165f149c",
         ));
-        let y = U384FP1Element::new(UnsignedInteger::from_hex(
+        let y = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
-        let c = U384FP1Element::new(UnsignedInteger::from_hex(
+        let c = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
             "64fd5279bf47fe02d4185ce279d8aa55e00352",
         ));
         assert_eq!(x + y, c);
@@ -438,13 +438,13 @@ mod tests_u384_prime_fields {
 
     #[test]
     fn montgomery_prime_field_multiplication_works_0() {
-        let x = U384FP1Element::new(UnsignedInteger::from_hex(
+        let x = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
             "05ed176deb0e80b4deb7718cdaa075165f149c",
         ));
-        let y = U384FP1Element::new(UnsignedInteger::from_hex(
+        let y = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
-        let c = U384FP1Element::new(UnsignedInteger::from_hex(
+        let c = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
             "73d23e8d462060dc23d5c15c00fc432d95621a3c",
         ));
         assert_eq!(x * y, c);
@@ -471,13 +471,13 @@ mod tests_u384_prime_fields {
 
     #[test]
     fn montgomery_prime_field_addition_works_1() {
-        let x = U384FP2Element::new(UnsignedInteger::from_hex(
+        let x = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "05ed176deb0e80b4deb7718cdaa075165f149c",
         ));
-        let y = U384FP2Element::new(UnsignedInteger::from_hex(
+        let y = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
-        let c = U384FP2Element::new(UnsignedInteger::from_hex(
+        let c = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "64fd5279bf47fe02d4185ce279d8aa55e00352",
         ));
         assert_eq!(x + y, c);
@@ -486,7 +486,7 @@ mod tests_u384_prime_fields {
     #[test]
     fn montgomery_prime_field_multiplication_works_1() {
         let x = U384FP2Element::one();
-        let y = U384FP2Element::new(UnsignedInteger::from_hex(
+        let y = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
         assert_eq!(&y * x, y);
@@ -494,7 +494,7 @@ mod tests_u384_prime_fields {
 
     #[test]
     fn to_bytes_from_bytes_be_is_the_identity() {
-        let x = U384FP2Element::new(UnsignedInteger::from_hex(
+        let x = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
         assert_eq!(U384FP2Element::from_bytes_be(&x.to_bytes_be()).unwrap(), x);
@@ -514,7 +514,7 @@ mod tests_u384_prime_fields {
 
     #[test]
     fn to_bytes_from_bytes_le_is_the_identity() {
-        let x = U384FP2Element::new(UnsignedInteger::from_hex(
+        let x = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
         assert_eq!(U384FP2Element::from_bytes_le(&x.to_bytes_le()).unwrap(), x);
@@ -750,13 +750,13 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn montgomery_prime_field_addition_works_0() {
-        let x = U256FP1Element::new(UnsignedInteger::from_hex(
+        let x = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
             "93e712950bf3fe589aa030562a44b1cec66b09192c4bcf705a5",
         ));
-        let y = U256FP1Element::new(UnsignedInteger::from_hex(
+        let y = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
             "10a712235c1f6b4172a1e35da6aef1a7ec6b09192c4bb88cfa5",
         ));
-        let c = U256FP1Element::new(UnsignedInteger::from_hex(
+        let c = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
             "a48e24b86813699a0d4213b3d0f3a376b2d61232589787fd54a",
         ));
         assert_eq!(x + y, c);
@@ -764,13 +764,13 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn montgomery_prime_field_multiplication_works_0() {
-        let x = U256FP1Element::new(UnsignedInteger::from_hex(
+        let x = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
             "93e712950bf3fe589aa030562a44b1cec66b09192c4bcf705a5",
         ));
-        let y = U256FP1Element::new(UnsignedInteger::from_hex(
+        let y = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
             "10a712235c1f6b4172a1e35da6aef1a7ec6b09192c4bb88cfa5",
         ));
-        let c = U256FP1Element::new(UnsignedInteger::from_hex(
+        let c = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
             "7808e74c3208d9a66791ef9cc15a46acc9951ee312102684021",
         ));
         assert_eq!(x * y, c);
@@ -795,13 +795,13 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn montgomery_prime_field_addition_works_1() {
-        let x = FP2Element::new(UnsignedInteger::from_hex(
+        let x = FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "acbbb7ca01c65cfffffc72815b397fff9ab130ad53a5ffffffb8f21b207dfedf",
         ));
-        let y = FP2Element::new(UnsignedInteger::from_hex(
+        let y = FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "d65ddbe509d3fffff21f494c588cbdbfe43e929b0543e3ffffffffffffffff43",
         ));
-        let c = FP2Element::new(UnsignedInteger::from_hex(
+        let c = FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "831993af0b9a5cfff21bbbcdb3c63dbf7eefc34858e9e3ffffb8f21b207dfedf",
         ));
         assert_eq!(x + y, c);
@@ -809,13 +809,13 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn montgomery_prime_field_multiplication_works_1() {
-        let x = FP2Element::new(UnsignedInteger::from_hex(
+        let x = FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "acbbb7ca01c65cfffffc72815b397fff9ab130ad53a5ffffffb8f21b207dfedf",
         ));
-        let y = FP2Element::new(UnsignedInteger::from_hex(
+        let y = FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "d65ddbe509d3fffff21f494c588cbdbfe43e929b0543e3ffffffffffffffff43",
         ));
-        let c = FP2Element::new(UnsignedInteger::from_hex(
+        let c = FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "2b1e80d553ecab2e4d41eb53c4c8ad89ebacac6cf6b91dcf2213f311093aa05d",
         ));
         assert_eq!(&y * x, c);
@@ -823,7 +823,7 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn to_bytes_from_bytes_be_is_the_identity() {
-        let x = FP2Element::new(UnsignedInteger::from_hex(
+        let x = FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
         assert_eq!(FP2Element::from_bytes_be(&x.to_bytes_be()).unwrap(), x);
@@ -843,7 +843,7 @@ mod tests_u256_prime_fields {
 
     #[test]
     fn to_bytes_from_bytes_le_is_the_identity() {
-        let x = FP2Element::new(UnsignedInteger::from_hex(
+        let x = FP2Element::new(UnsignedInteger::from_hex_unchecked(
             "5f103b0bd4397d4df560eb559f38353f80eeb6",
         ));
         assert_eq!(FP2Element::from_bytes_le(&x.to_bytes_le()).unwrap(), x);

--- a/math/src/field/fields/p448_goldilocks_prime_field.rs
+++ b/math/src/field/fields/p448_goldilocks_prime_field.rs
@@ -7,7 +7,7 @@ pub type U448 = UnsignedInteger<7>;
 
 /// Goldilocks Prime p = 2^448 - 2^224 - 1
 pub const P448_GOLDILOCKS_PRIME_FIELD_ORDER: U448 =
-    U448::from("fffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    U448::from_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
 /// 448-bit unsigned integer represented as
 /// a size 8 `u64` array `limbs` of 56-bit words.

--- a/math/src/field/fields/p448_goldilocks_prime_field.rs
+++ b/math/src/field/fields/p448_goldilocks_prime_field.rs
@@ -7,7 +7,7 @@ pub type U448 = UnsignedInteger<7>;
 
 /// Goldilocks Prime p = 2^448 - 2^224 - 1
 pub const P448_GOLDILOCKS_PRIME_FIELD_ORDER: U448 =
-    U448::from_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    U448::from_hex_unchecked("fffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
 /// 448-bit unsigned integer represented as
 /// a size 8 `u64` array `limbs` of 56-bit words.

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -300,6 +300,8 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         true
     }
 
+    /// Creates an `UnsignedInteger` from a hexstring. It can contain `0x` or not. 
+    /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring
     pub fn from_hex(value: &str) -> Result<Self, CreationError> {
         let mut string = value;
 
@@ -319,6 +321,9 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         Ok(Self::from_hex_unchecked(string))
     }
 
+    /// Creates an `UnsignedInteger` from a hexstring. It can contain `0x` or not. 
+    /// # Panics
+    /// Panics if value is not a hexstring
     pub const fn from_hex_unchecked(value: &str) -> Self {
         let mut result = [0u64; NUM_LIMBS];
         let mut limb = 0;

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -321,9 +321,9 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         Ok(Self::from_hex_unchecked(string))
     }
 
-    /// Creates an `UnsignedInteger` from a hexstring. It can contain `0x` or not.
+    /// Creates an `UnsignedInteger` from a hexstring
     /// # Panics
-    /// Panics if value is not a hexstring
+    /// Panics if value is not a hexstring. Shouldn't start with `0x`
     pub const fn from_hex_unchecked(value: &str) -> Self {
         let mut result = [0u64; NUM_LIMBS];
         let mut limb = 0;

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -52,7 +52,7 @@ impl<const NUM_LIMBS: usize> From<u16> for UnsignedInteger<NUM_LIMBS> {
 
 impl<const NUM_LIMBS: usize> From<&str> for UnsignedInteger<NUM_LIMBS> {
     fn from(hex_str: &str) -> Self {
-        Self::from(hex_str)
+        Self::from_hex(hex_str)
     }
 }
 
@@ -282,7 +282,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         UnsignedInteger { limbs }
     }
 
-    pub const fn from(value: &str) -> Self {
+    pub const fn from_hex(value: &str) -> Self {
         let mut result = [0u64; NUM_LIMBS];
         let mut limb = 0;
         let mut limb_index = NUM_LIMBS - 1;
@@ -590,43 +590,43 @@ mod tests_u384 {
 
     #[test]
     fn construct_new_integer_from_hex_1() {
-        let a = U384::from("1");
+        let a = U384::from_hex("1");
         assert_eq!(a.limbs, [0, 0, 0, 0, 0, 1]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_2() {
-        let a = U384::from("f");
+        let a = U384::from_hex("f");
         assert_eq!(a.limbs, [0, 0, 0, 0, 0, 15]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_3() {
-        let a = U384::from("10000000000000000");
+        let a = U384::from_hex("10000000000000000");
         assert_eq!(a.limbs, [0, 0, 0, 0, 1, 0]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_4() {
-        let a = U384::from("a0000000000000000");
+        let a = U384::from_hex("a0000000000000000");
         assert_eq!(a.limbs, [0, 0, 0, 0, 10, 0]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_5() {
-        let a = U384::from("ffffffffffffffffff");
+        let a = U384::from_hex("ffffffffffffffffff");
         assert_eq!(a.limbs, [0, 0, 0, 0, 255, u64::MAX]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_6() {
-        let a = U384::from("eb235f6144d9e91f4b14");
+        let a = U384::from_hex("eb235f6144d9e91f4b14");
         assert_eq!(a.limbs, [0, 0, 0, 0, 60195, 6872850209053821716]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_7() {
-        let a = U384::from("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
+        let a = U384::from_hex("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
         assert_eq!(
             a.limbs,
             [
@@ -642,7 +642,7 @@ mod tests_u384 {
 
     #[test]
     fn construct_new_integer_from_hex_8() {
-        let a = U384::from("140f5177b90b4f96b61bb8ccb4f298ad2b20aaa5cf482b239e2897a787faf4660cc95597854beb235f6144d9e91f4b14");
+        let a = U384::from_hex("140f5177b90b4f96b61bb8ccb4f298ad2b20aaa5cf482b239e2897a787faf4660cc95597854beb235f6144d9e91f4b14");
         assert_eq!(
             a.limbs,
             [
@@ -658,7 +658,7 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_1() {
-        let a = U384::from("1");
+        let a = U384::from_hex("1");
         let b = U384 {
             limbs: [0, 0, 0, 0, 0, 1],
         };
@@ -666,7 +666,7 @@ mod tests_u384 {
     }
     #[test]
     fn equality_works_2() {
-        let a = U384::from("f");
+        let a = U384::from_hex("f");
         let b = U384 {
             limbs: [0, 0, 0, 0, 0, 15],
         };
@@ -675,7 +675,7 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_3() {
-        let a = U384::from("10000000000000000");
+        let a = U384::from_hex("10000000000000000");
         let b = U384 {
             limbs: [0, 0, 0, 0, 1, 0],
         };
@@ -684,7 +684,7 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_4() {
-        let a = U384::from("a0000000000000000");
+        let a = U384::from_hex("a0000000000000000");
         let b = U384 {
             limbs: [0, 0, 0, 0, 10, 0],
         };
@@ -693,7 +693,7 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_5() {
-        let a = U384::from("ffffffffffffffffff");
+        let a = U384::from_hex("ffffffffffffffffff");
         let b = U384 {
             limbs: [0, 0, 0, 0, u8::MAX as u64, u64::MAX],
         };
@@ -702,7 +702,7 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_6() {
-        let a = U384::from("eb235f6144d9e91f4b14");
+        let a = U384::from_hex("eb235f6144d9e91f4b14");
         let b = U384 {
             limbs: [0, 0, 0, 0, 60195, 6872850209053821716],
         };
@@ -711,7 +711,7 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_7() {
-        let a = U384::from("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
+        let a = U384::from_hex("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
         let b = U384 {
             limbs: [
                 0,
@@ -727,7 +727,7 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_8() {
-        let a = U384::from("140f5177b90b4f96b61bb8ccb4f298ad2b20aaa5cf482b239e2897a787faf4660cc95597854beb235f6144d9e91f4b14");
+        let a = U384::from_hex("140f5177b90b4f96b61bb8ccb4f298ad2b20aaa5cf482b239e2897a787faf4660cc95597854beb235f6144d9e91f4b14");
         let b = U384 {
             limbs: [
                 1445463580056702870,
@@ -743,28 +743,28 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_9() {
-        let a = U384::from("fffffff");
-        let b = U384::from("fefffff");
+        let a = U384::from_hex("fffffff");
+        let b = U384::from_hex("fefffff");
         assert_ne!(a, b);
     }
 
     #[test]
     fn equality_works_10() {
-        let a = U384::from("ffff000000000000");
-        let b = U384::from("ffff000000100000");
+        let a = U384::from_hex("ffff000000000000");
+        let b = U384::from_hex("ffff000000100000");
         assert_ne!(a, b);
     }
 
     #[test]
     fn const_ne_works_1() {
-        let a = U384::from("ffff000000000000");
-        let b = U384::from("ffff000000100000");
+        let a = U384::from_hex("ffff000000000000");
+        let b = U384::from_hex("ffff000000100000");
         assert!(U384::const_ne(&a, &b));
     }
 
     #[test]
     fn const_ne_works_2() {
-        let a = U384::from("140f5177b90b4f96b61bb8ccb4f298ad2b20aaa5cf482b239e2897a787faf4660cc95597854beb235f6144d9e91f4b14");
+        let a = U384::from_hex("140f5177b90b4f96b61bb8ccb4f298ad2b20aaa5cf482b239e2897a787faf4660cc95597854beb235f6144d9e91f4b14");
         let b = U384 {
             limbs: [
                 1445463580056702870,
@@ -796,45 +796,45 @@ mod tests_u384 {
 
     #[test]
     fn add_two_384_bit_integers_3() {
-        let a = U384::from("ffffffffffffffff");
-        let b = U384::from("1");
-        let c = U384::from("10000000000000000");
+        let a = U384::from_hex("ffffffffffffffff");
+        let b = U384::from_hex("1");
+        let c = U384::from_hex("10000000000000000");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_384_bit_integers_4() {
-        let a = U384::from("b58e1e0b66");
-        let b = U384::from("55469d9619");
-        let c = U384::from("10ad4bba17f");
+        let a = U384::from_hex("b58e1e0b66");
+        let b = U384::from_hex("55469d9619");
+        let c = U384::from_hex("10ad4bba17f");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_384_bit_integers_5() {
-        let a = U384::from("e8dff25cb6160f7705221da6f");
-        let b = U384::from("ab879169b5f80dc8a7969f0b0");
-        let c = U384::from("1946783c66c0e1d3facb8bcb1f");
+        let a = U384::from_hex("e8dff25cb6160f7705221da6f");
+        let b = U384::from_hex("ab879169b5f80dc8a7969f0b0");
+        let c = U384::from_hex("1946783c66c0e1d3facb8bcb1f");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_384_bit_integers_6() {
-        let a = U384::from("9adf291af3a64d59e14e7b440c850508014c551ed5");
-        let b = U384::from("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
-        let c = U384::from("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
+        let a = U384::from_hex("9adf291af3a64d59e14e7b440c850508014c551ed5");
+        let b = U384::from_hex("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
+        let c = U384::from_hex("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_384_bit_integers_7() {
-        let a = U384::from(
+        let a = U384::from_hex(
             "f866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9a03647cd3cc84",
         );
-        let b = U384::from(
+        let b = U384::from_hex(
             "9b4000dccf01a010e196154a1b998408f949d734389626ba97cb3331ee87e01dd5badc58f41b2",
         );
-        let c = U384::from(
+        let c = U384::from_hex(
             "193a6afd4d2cacc01101bdd44ec864f517b0f6f5a1d3020dd91594dc1de752cf775f1242630e36",
         );
         assert_eq!(a + b, c);
@@ -842,25 +842,25 @@ mod tests_u384 {
 
     #[test]
     fn add_two_384_bit_integers_8() {
-        let a = U384::from("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580eb36ae12ea59f90db5b1799d0970a42e");
-        let b = U384::from("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9cafff44a2c606877d46c49a3433cc85e");
-        let c = U384::from("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab636a25d16ba61858a1dc3404cad6c8c");
+        let a = U384::from_hex("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580eb36ae12ea59f90db5b1799d0970a42e");
+        let b = U384::from_hex("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9cafff44a2c606877d46c49a3433cc85e");
+        let c = U384::from_hex("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab636a25d16ba61858a1dc3404cad6c8c");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_384_bit_integers_9() {
-        let a = U384::from("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
-        let b = U384::from("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4622b8bd6fa68ef654796a183abde842");
-        let c = U384::from("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
+        let a = U384::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
+        let b = U384::from_hex("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4622b8bd6fa68ef654796a183abde842");
+        let c = U384::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_384_bit_integers_10() {
-        let a = U384::from("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580eb36ae12ea59f90db5b1799d0970a42e");
-        let b = U384::from("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9cafff44a2c606877d46c49a3433cc85e");
-        let c_expected = U384::from("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab636a25d16ba61858a1dc3404cad6c8c");
+        let a = U384::from_hex("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580eb36ae12ea59f90db5b1799d0970a42e");
+        let b = U384::from_hex("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9cafff44a2c606877d46c49a3433cc85e");
+        let c_expected = U384::from_hex("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab636a25d16ba61858a1dc3404cad6c8c");
         let (c, overflow) = U384::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(!overflow);
@@ -868,9 +868,9 @@ mod tests_u384 {
 
     #[test]
     fn add_two_384_bit_integers_11() {
-        let a = U384::from("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
-        let b = U384::from("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4622b8bd6fa68ef654796a183abde842");
-        let c_expected = U384::from("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
+        let a = U384::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
+        let b = U384::from_hex("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4622b8bd6fa68ef654796a183abde842");
+        let c_expected = U384::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
         let (c, overflow) = U384::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(!overflow);
@@ -878,9 +878,9 @@ mod tests_u384 {
 
     #[test]
     fn add_two_384_bit_integers_12_with_overflow() {
-        let a = U384::from("b07bc844363dd56467d9ebdd5929e9bb34a8e2577db77df6cf8f2ac45bd3d0bc2fc3078d265fe761af51d6aec5b59428");
-        let b = U384::from("cbbc474761bb7995ff54e25fa5d30295604fe3545d0cde405e72d8c0acebb119e9158131679b6c34483a3dafb49deeea");
-        let c_expected = U384::from("7c380f8b97f94efa672ece3cfefcec5094f8c5abdac45c372e02038508bf81d618d888be8dfb5395f78c145e7a538312");
+        let a = U384::from_hex("b07bc844363dd56467d9ebdd5929e9bb34a8e2577db77df6cf8f2ac45bd3d0bc2fc3078d265fe761af51d6aec5b59428");
+        let b = U384::from_hex("cbbc474761bb7995ff54e25fa5d30295604fe3545d0cde405e72d8c0acebb119e9158131679b6c34483a3dafb49deeea");
+        let c_expected = U384::from_hex("7c380f8b97f94efa672ece3cfefcec5094f8c5abdac45c372e02038508bf81d618d888be8dfb5395f78c145e7a538312");
         let (c, overflow) = U384::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(overflow);
@@ -904,45 +904,45 @@ mod tests_u384 {
 
     #[test]
     fn sub_two_384_bit_integers_3() {
-        let a = U384::from("ffffffffffffffff");
-        let b = U384::from("1");
-        let c = U384::from("10000000000000000");
+        let a = U384::from_hex("ffffffffffffffff");
+        let b = U384::from_hex("1");
+        let c = U384::from_hex("10000000000000000");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_384_bit_integers_4() {
-        let a = U384::from("b58e1e0b66");
-        let b = U384::from("55469d9619");
-        let c = U384::from("10ad4bba17f");
+        let a = U384::from_hex("b58e1e0b66");
+        let b = U384::from_hex("55469d9619");
+        let c = U384::from_hex("10ad4bba17f");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_384_bit_integers_5() {
-        let a = U384::from("e8dff25cb6160f7705221da6f");
-        let b = U384::from("ab879169b5f80dc8a7969f0b0");
-        let c = U384::from("1946783c66c0e1d3facb8bcb1f");
+        let a = U384::from_hex("e8dff25cb6160f7705221da6f");
+        let b = U384::from_hex("ab879169b5f80dc8a7969f0b0");
+        let c = U384::from_hex("1946783c66c0e1d3facb8bcb1f");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_384_bit_integers_6() {
-        let a = U384::from("9adf291af3a64d59e14e7b440c850508014c551ed5");
-        let b = U384::from("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
-        let c = U384::from("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
+        let a = U384::from_hex("9adf291af3a64d59e14e7b440c850508014c551ed5");
+        let b = U384::from_hex("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
+        let c = U384::from_hex("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_384_bit_integers_7() {
-        let a = U384::from(
+        let a = U384::from_hex(
             "f866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9a03647cd3cc84",
         );
-        let b = U384::from(
+        let b = U384::from_hex(
             "9b4000dccf01a010e196154a1b998408f949d734389626ba97cb3331ee87e01dd5badc58f41b2",
         );
-        let c = U384::from(
+        let c = U384::from_hex(
             "193a6afd4d2cacc01101bdd44ec864f517b0f6f5a1d3020dd91594dc1de752cf775f1242630e36",
         );
         assert_eq!(c - a, b);
@@ -950,17 +950,17 @@ mod tests_u384 {
 
     #[test]
     fn sub_two_384_bit_integers_8() {
-        let a = U384::from("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580eb36ae12ea59f90db5b1799d0970a42e");
-        let b = U384::from("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9cafff44a2c606877d46c49a3433cc85e");
-        let c = U384::from("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab636a25d16ba61858a1dc3404cad6c8c");
+        let a = U384::from_hex("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580eb36ae12ea59f90db5b1799d0970a42e");
+        let b = U384::from_hex("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9cafff44a2c606877d46c49a3433cc85e");
+        let c = U384::from_hex("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab636a25d16ba61858a1dc3404cad6c8c");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_384_bit_integers_9() {
-        let a = U384::from("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
-        let b = U384::from("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4622b8bd6fa68ef654796a183abde842");
-        let c = U384::from("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
+        let a = U384::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
+        let b = U384::from_hex("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4622b8bd6fa68ef654796a183abde842");
+        let c = U384::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
         assert_eq!(c - a, b);
     }
 
@@ -977,7 +977,7 @@ mod tests_u384 {
     #[test]
     fn sub_two_384_bit_integers_11_with_overflow() {
         let a = U384::from_u64(334);
-        let b_expected = U384::from("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd66");
+        let b_expected = U384::from_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd66");
         let c = U384::from_u64(1000);
         let (b, underflow) = U384::sub(&a, &c);
         assert!(underflow);
@@ -994,8 +994,8 @@ mod tests_u384 {
         assert!(U384::from_u64(2) > U384::from_u64(1));
         assert!(U384::from_u64(1) <= U384::from_u64(2));
 
-        let a = U384::from("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
-        let c = U384::from("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
+        let a = U384::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
+        let c = U384::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
 
         assert!(&a <= &a);
         assert!(&a >= &a);
@@ -1026,25 +1026,25 @@ mod tests_u384 {
 
     #[test]
     fn mul_two_384_bit_integers_works_2() {
-        let a = U384::from("6131d99f840b3b0");
-        let b = U384::from("6f5c466db398f43");
-        let c = U384::from("2a47a603a77f871dfbb937af7e5710");
+        let a = U384::from_hex("6131d99f840b3b0");
+        let b = U384::from_hex("6f5c466db398f43");
+        let c = U384::from_hex("2a47a603a77f871dfbb937af7e5710");
         assert_eq!(a * b, c);
     }
 
     #[test]
     fn mul_two_384_bit_integers_works_3() {
-        let a = U384::from("84a6add5db9e095b2e0f6b40eff8ee");
-        let b = U384::from("2347db918f725461bec2d5c57");
-        let c = U384::from("124805c476c9462adc0df6c88495d4253f5c38033afc18d78d920e2");
+        let a = U384::from_hex("84a6add5db9e095b2e0f6b40eff8ee");
+        let b = U384::from_hex("2347db918f725461bec2d5c57");
+        let c = U384::from_hex("124805c476c9462adc0df6c88495d4253f5c38033afc18d78d920e2");
         assert_eq!(a * b, c);
     }
 
     #[test]
     fn mul_two_384_bit_integers_works_4() {
-        let a = U384::from("04050753dd7c0b06c404633016f87040");
-        let b = U384::from("dc3830be041b3b4476445fcad3dac0f6f3a53e4ba12da");
-        let c = U384::from(
+        let a = U384::from_hex("04050753dd7c0b06c404633016f87040");
+        let b = U384::from_hex("dc3830be041b3b4476445fcad3dac0f6f3a53e4ba12da");
+        let c = U384::from_hex(
             "375342999dab7f52f4010c4abc2e18b55218015931a55d6053ac39e86e2a47d6b1cb95f41680",
         );
         assert_eq!(a * b, c);
@@ -1052,9 +1052,9 @@ mod tests_u384 {
 
     #[test]
     fn mul_two_384_bit_integers_works_5() {
-        let a = U384::from("7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8");
-        let b = U384::from("2");
-        let c_expected = U384::from(
+        let a = U384::from_hex("7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8");
+        let b = U384::from_hex("2");
+        let c_expected = U384::from_hex(
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0",
         );
         assert_eq!(a * b, c_expected);
@@ -1063,17 +1063,17 @@ mod tests_u384 {
     #[test]
     #[should_panic]
     fn mul_two_384_bit_integers_works_6() {
-        let a = U384::from("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
-        let b = U384::from("2");
+        let a = U384::from_hex("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+        let b = U384::from_hex("2");
         let _c = a * b;
     }
 
     #[test]
     fn mul_two_384_bit_integers_works_7_hi_lo() {
-        let a = U384::from("04050753dd7c0b06c404633016f87040");
-        let b = U384::from("dc3830be041b3b4476445fcad3dac0f6f3a53e4ba12da");
-        let hi_expected = U384::from("0");
-        let lo_expected = U384::from(
+        let a = U384::from_hex("04050753dd7c0b06c404633016f87040");
+        let b = U384::from_hex("dc3830be041b3b4476445fcad3dac0f6f3a53e4ba12da");
+        let hi_expected = U384::from_hex("0");
+        let lo_expected = U384::from_hex(
             "375342999dab7f52f4010c4abc2e18b55218015931a55d6053ac39e86e2a47d6b1cb95f41680",
         );
         let (hi, lo) = U384::mul(&a, &b);
@@ -1083,12 +1083,12 @@ mod tests_u384 {
 
     #[test]
     fn mul_two_384_bit_integers_works_8_hi_lo() {
-        let a = U384::from("5e2d939b602a50911232731d04fe6f40c05f97da0602307099fb991f9b414e2d52bef130349ec18db1a0215ea6caf76");
-        let b = U384::from("3f3ad1611ab58212f92a2484e9560935b9ac4615fe61cfed1a4861e193a74d20c94f9f88d8b2cc089543c3f699969d9");
-        let hi_expected = U384::from(
+        let a = U384::from_hex("5e2d939b602a50911232731d04fe6f40c05f97da0602307099fb991f9b414e2d52bef130349ec18db1a0215ea6caf76");
+        let b = U384::from_hex("3f3ad1611ab58212f92a2484e9560935b9ac4615fe61cfed1a4861e193a74d20c94f9f88d8b2cc089543c3f699969d9");
+        let hi_expected = U384::from_hex(
             "1742daad9c7861dd3499e7ece65467e337937b27e20d641b225bfe00323d33ed62715654eadc092b057a5f19f2ad6c",
         );
-        let lo_expected = U384::from("9969c0417b9304d9c16b046c860447d3533999e16710d2e90a44959a168816c015ffb44b987e8cbb82bd46b08d9e2106");
+        let lo_expected = U384::from_hex("9969c0417b9304d9c16b046c860447d3533999e16710d2e90a44959a168816c015ffb44b987e8cbb82bd46b08d9e2106");
         let (hi, lo) = U384::mul(&a, &b);
         assert_eq!(hi, hi_expected);
         assert_eq!(lo, lo_expected);
@@ -1096,10 +1096,10 @@ mod tests_u384 {
 
     #[test]
     fn mul_two_384_bit_integers_works_9_hi_lo() {
-        let a = U384::from("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
-        let b = U384::from("2");
-        let hi_expected = U384::from("1");
-        let lo_expected = U384::from("0");
+        let a = U384::from_hex("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+        let b = U384::from_hex("2");
+        let hi_expected = U384::from_hex("1");
+        let lo_expected = U384::from_hex("0");
         let (hi, lo) = U384::mul(&a, &b);
         assert_eq!(hi, hi_expected);
         assert_eq!(lo, lo_expected);
@@ -1107,8 +1107,8 @@ mod tests_u384 {
 
     #[test]
     fn shift_left_on_384_bit_integer_works_1() {
-        let a = U384::from("1");
-        let b = U384::from("10");
+        let a = U384::from_hex("1");
+        let b = U384::from_hex("10");
         assert_eq!(a << 4, b);
     }
 
@@ -1121,29 +1121,29 @@ mod tests_u384 {
 
     #[test]
     fn shift_left_on_384_bit_integer_works_3() {
-        let a = U384::from("10");
-        let b = U384::from("1000");
+        let a = U384::from_hex("10");
+        let b = U384::from_hex("1000");
         assert_eq!(&a << 8, b);
     }
 
     #[test]
     fn shift_left_on_384_bit_integer_works_4() {
-        let a = U384::from("e45542992b6844553f3cb1c5ac33e7fa5");
-        let b = U384::from("391550a64ada11154fcf2c716b0cf9fe940");
+        let a = U384::from_hex("e45542992b6844553f3cb1c5ac33e7fa5");
+        let b = U384::from_hex("391550a64ada11154fcf2c716b0cf9fe940");
         assert_eq!(a << 6, b);
     }
 
     #[test]
     fn shift_left_on_384_bit_integer_works_5() {
-        let a = U384::from("03303f4d6c2d1caf0c24a6b0239b679a8390aa99bead76bc0093b1bc1a8101f5ce");
-        let b = U384::from("6607e9ad85a395e18494d604736cf35072155337d5aed7801276378350203eb9c0000000000000000000000000000000");
+        let a = U384::from_hex("03303f4d6c2d1caf0c24a6b0239b679a8390aa99bead76bc0093b1bc1a8101f5ce");
+        let b = U384::from_hex("6607e9ad85a395e18494d604736cf35072155337d5aed7801276378350203eb9c0000000000000000000000000000000");
         assert_eq!(&a << 125, b);
     }
 
     #[test]
     fn shift_left_on_384_bit_integer_works_6() {
-        let a = U384::from("762e8968bc392ed786ab132f0b5b0cacd385dd51de3a");
-        let b = U384::from(
+        let a = U384::from_hex("762e8968bc392ed786ab132f0b5b0cacd385dd51de3a");
+        let b = U384::from_hex(
             "762e8968bc392ed786ab132f0b5b0cacd385dd51de3a00000000000000000000000000000000",
         );
         assert_eq!(&a << (64 * 2), b);
@@ -1151,65 +1151,65 @@ mod tests_u384 {
 
     #[test]
     fn shift_left_on_384_bit_integer_works_7() {
-        let a = U384::from("90823e0bd707f");
-        let b = U384::from("90823e0bd707f000000000000000000000000000000000000000000000000");
+        let a = U384::from_hex("90823e0bd707f");
+        let b = U384::from_hex("90823e0bd707f000000000000000000000000000000000000000000000000");
         assert_eq!(&a << (64 * 3), b);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_1() {
-        let a = U384::from("1");
-        let b = U384::from("10");
+        let a = U384::from_hex("1");
+        let b = U384::from_hex("10");
         assert_eq!(b >> 4, a);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_2() {
-        let a = U384::from("10");
-        let b = U384::from("1000");
+        let a = U384::from_hex("10");
+        let b = U384::from_hex("1000");
         assert_eq!(&b >> 8, a);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_3() {
-        let a = U384::from("e45542992b6844553f3cb1c5ac33e7fa5");
-        let b = U384::from("391550a64ada11154fcf2c716b0cf9fe940");
+        let a = U384::from_hex("e45542992b6844553f3cb1c5ac33e7fa5");
+        let b = U384::from_hex("391550a64ada11154fcf2c716b0cf9fe940");
         assert_eq!(b >> 6, a);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_4() {
-        let a = U384::from("03303f4d6c2d1caf0c24a6b0239b679a8390aa99bead76bc0093b1bc1a8101f5ce");
-        let b = U384::from("6607e9ad85a395e18494d604736cf35072155337d5aed7801276378350203eb9c0000000000000000000000000000000");
+        let a = U384::from_hex("03303f4d6c2d1caf0c24a6b0239b679a8390aa99bead76bc0093b1bc1a8101f5ce");
+        let b = U384::from_hex("6607e9ad85a395e18494d604736cf35072155337d5aed7801276378350203eb9c0000000000000000000000000000000");
         assert_eq!(&b >> 125, a);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_5() {
-        let a = U384::from("ba6ab46f9a9a2f20e4061b67ce4d8c3da98091cf990d7b14ef47ffe27370abbdeb6a3ce9f9cbf5df1b2430114c8558eb");
-        let b = U384::from("174d568df35345e41c80c36cf9c9b187b5301239f321af629de8fffc4e6");
+        let a = U384::from_hex("ba6ab46f9a9a2f20e4061b67ce4d8c3da98091cf990d7b14ef47ffe27370abbdeb6a3ce9f9cbf5df1b2430114c8558eb");
+        let b = U384::from_hex("174d568df35345e41c80c36cf9c9b187b5301239f321af629de8fffc4e6");
         assert_eq!(a >> 151, b);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_6() {
         let a =
-            U384::from("076c075d2f65e39b9ecdde8bf6f8c94241962ce0f557b7739673200c777152eb7e772ad35");
-        let b = U384::from("ed80eba5ecbc7373d9bbd17edf19284832c59c1eaaf6ee7");
+            U384::from_hex("076c075d2f65e39b9ecdde8bf6f8c94241962ce0f557b7739673200c777152eb7e772ad35");
+        let b = U384::from_hex("ed80eba5ecbc7373d9bbd17edf19284832c59c1eaaf6ee7");
         assert_eq!(&a >> 99, b);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_7() {
-        let a = U384::from("6a9ce35d8940a5ebd29604ce9a182ade76f03f7e9965760b84a8cfd1d3dd2e612669fe000e58b2af688fd90");
-        let b = U384::from("6a9ce35d8940a5ebd29604ce9a182ade76f03f7");
+        let a = U384::from_hex("6a9ce35d8940a5ebd29604ce9a182ade76f03f7e9965760b84a8cfd1d3dd2e612669fe000e58b2af688fd90");
+        let b = U384::from_hex("6a9ce35d8940a5ebd29604ce9a182ade76f03f7");
         assert_eq!(&a >> (64 * 3), b);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_8() {
-        let a = U384::from("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c5265bd7db75c90b2665a0826d17600f0e9");
-        let b = U384::from("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c52");
+        let a = U384::from_hex("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c5265bd7db75c90b2665a0826d17600f0e9");
+        let b = U384::from_hex("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c52");
         assert_eq!(&a >> (64 * 2), b);
     }
 
@@ -1333,43 +1333,43 @@ mod tests_u256 {
 
     #[test]
     fn construct_new_integer_from_hex_1() {
-        let a = U256::from("1");
+        let a = U256::from_hex("1");
         assert_eq!(a.limbs, [0, 0, 0, 1]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_2() {
-        let a = U256::from("f");
+        let a = U256::from_hex("f");
         assert_eq!(a.limbs, [0, 0, 0, 15]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_3() {
-        let a = U256::from("10000000000000000");
+        let a = U256::from_hex("10000000000000000");
         assert_eq!(a.limbs, [0, 0, 1, 0]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_4() {
-        let a = U256::from("a0000000000000000");
+        let a = U256::from_hex("a0000000000000000");
         assert_eq!(a.limbs, [0, 0, 10, 0]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_5() {
-        let a = U256::from("ffffffffffffffffff");
+        let a = U256::from_hex("ffffffffffffffffff");
         assert_eq!(a.limbs, [0, 0, 255, u64::MAX]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_6() {
-        let a = U256::from("eb235f6144d9e91f4b14");
+        let a = U256::from_hex("eb235f6144d9e91f4b14");
         assert_eq!(a.limbs, [0, 0, 60195, 6872850209053821716]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_7() {
-        let a = U256::from("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
+        let a = U256::from_hex("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
         assert_eq!(
             a.limbs,
             [
@@ -1383,7 +1383,7 @@ mod tests_u256 {
 
     #[test]
     fn construct_new_integer_from_hex_8() {
-        let a = U256::from("2B20AAA5CF482B239E2897A787FAF4660CC95597854BEB235F6144D9E91F4B14");
+        let a = U256::from_hex("2B20AAA5CF482B239E2897A787FAF4660CC95597854BEB235F6144D9E91F4B14");
         assert_eq!(
             a.limbs,
             [
@@ -1397,7 +1397,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_1() {
-        let a = U256::from("1");
+        let a = U256::from_hex("1");
         let b = U256 {
             limbs: [0, 0, 0, 1],
         };
@@ -1405,7 +1405,7 @@ mod tests_u256 {
     }
     #[test]
     fn equality_works_2() {
-        let a = U256::from("f");
+        let a = U256::from_hex("f");
         let b = U256 {
             limbs: [0, 0, 0, 15],
         };
@@ -1414,7 +1414,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_3() {
-        let a = U256::from("10000000000000000");
+        let a = U256::from_hex("10000000000000000");
         let b = U256 {
             limbs: [0, 0, 1, 0],
         };
@@ -1423,7 +1423,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_4() {
-        let a = U256::from("a0000000000000000");
+        let a = U256::from_hex("a0000000000000000");
         let b = U256 {
             limbs: [0, 0, 10, 0],
         };
@@ -1432,7 +1432,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_5() {
-        let a = U256::from("ffffffffffffffffff");
+        let a = U256::from_hex("ffffffffffffffffff");
         let b = U256 {
             limbs: [0, 0, u8::MAX as u64, u64::MAX],
         };
@@ -1441,7 +1441,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_6() {
-        let a = U256::from("eb235f6144d9e91f4b14");
+        let a = U256::from_hex("eb235f6144d9e91f4b14");
         let b = U256 {
             limbs: [0, 0, 60195, 6872850209053821716],
         };
@@ -1450,7 +1450,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_7() {
-        let a = U256::from("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
+        let a = U256::from_hex("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
         let b = U256 {
             limbs: [
                 0,
@@ -1464,7 +1464,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_8() {
-        let a = U256::from("2B20AAA5CF482B239E2897A787FAF4660CC95597854BEB235F6144D9E91F4B14");
+        let a = U256::from_hex("2B20AAA5CF482B239E2897A787FAF4660CC95597854BEB235F6144D9E91F4B14");
         let b = U256 {
             limbs: [
                 3107671372009581347,
@@ -1478,15 +1478,15 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_9() {
-        let a = U256::from("fffffff");
-        let b = U256::from("fefffff");
+        let a = U256::from_hex("fffffff");
+        let b = U256::from_hex("fefffff");
         assert_ne!(a, b);
     }
 
     #[test]
     fn equality_works_10() {
-        let a = U256::from("ffff000000000000");
-        let b = U256::from("ffff000000100000");
+        let a = U256::from_hex("ffff000000000000");
+        let b = U256::from_hex("ffff000000100000");
         assert_ne!(a, b);
     }
 
@@ -1508,66 +1508,66 @@ mod tests_u256 {
 
     #[test]
     fn add_two_256_bit_integers_3() {
-        let a = U256::from("ffffffffffffffff");
-        let b = U256::from("1");
-        let c = U256::from("10000000000000000");
+        let a = U256::from_hex("ffffffffffffffff");
+        let b = U256::from_hex("1");
+        let c = U256::from_hex("10000000000000000");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_4() {
-        let a = U256::from("b58e1e0b66");
-        let b = U256::from("55469d9619");
-        let c = U256::from("10ad4bba17f");
+        let a = U256::from_hex("b58e1e0b66");
+        let b = U256::from_hex("55469d9619");
+        let c = U256::from_hex("10ad4bba17f");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_5() {
-        let a = U256::from("e8dff25cb6160f7705221da6f");
-        let b = U256::from("ab879169b5f80dc8a7969f0b0");
-        let c = U256::from("1946783c66c0e1d3facb8bcb1f");
+        let a = U256::from_hex("e8dff25cb6160f7705221da6f");
+        let b = U256::from_hex("ab879169b5f80dc8a7969f0b0");
+        let c = U256::from_hex("1946783c66c0e1d3facb8bcb1f");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_6() {
-        let a = U256::from("9adf291af3a64d59e14e7b440c850508014c551ed5");
-        let b = U256::from("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
-        let c = U256::from("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
+        let a = U256::from_hex("9adf291af3a64d59e14e7b440c850508014c551ed5");
+        let b = U256::from_hex("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
+        let c = U256::from_hex("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_7() {
-        let a = U256::from("10d3bc05496380cfe27bf5d97ddb99ac95eb5ecfbd3907eadf877a4c2dfa05f6");
-        let b = U256::from("0866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9");
-        let c = U256::from("193a6afd4d2cacc01101bdd44ec864f517b0f6f5a1d3020dd91594dc1de752cf");
+        let a = U256::from_hex("10d3bc05496380cfe27bf5d97ddb99ac95eb5ecfbd3907eadf877a4c2dfa05f6");
+        let b = U256::from_hex("0866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9");
+        let c = U256::from_hex("193a6afd4d2cacc01101bdd44ec864f517b0f6f5a1d3020dd91594dc1de752cf");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_8() {
-        let a = U256::from("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580f");
-        let b = U256::from("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9c");
-        let c = U256::from("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
+        let a = U256::from_hex("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580f");
+        let b = U256::from_hex("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9c");
+        let c = U256::from_hex("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_9() {
-        let a = U256::from("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
-        let b = U256::from("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
-        let c = U256::from("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
+        let a = U256::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
+        let b = U256::from_hex("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
+        let c = U256::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_10() {
-        let a = U256::from("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580f");
-        let b = U256::from("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9c");
+        let a = U256::from_hex("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580f");
+        let b = U256::from_hex("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9c");
         let c_expected =
-            U256::from("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
+            U256::from_hex("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
         let (c, overflow) = U256::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(!overflow);
@@ -1575,10 +1575,10 @@ mod tests_u256 {
 
     #[test]
     fn add_two_256_bit_integers_11() {
-        let a = U256::from("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
-        let b = U256::from("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
+        let a = U256::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
+        let b = U256::from_hex("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
         let c_expected =
-            U256::from("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
+            U256::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
         let (c, overflow) = U256::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(!overflow);
@@ -1586,10 +1586,10 @@ mod tests_u256 {
 
     #[test]
     fn add_two_256_bit_integers_12_with_overflow() {
-        let a = U256::from("b07bc844363dd56467d9ebdd5929e9bb34a8e2577db77df6cf8f2ac45bd3d0bc");
-        let b = U256::from("cbbc474761bb7995ff54e25fa5d30295604fe3545d0cde405e72d8c0acebb119");
+        let a = U256::from_hex("b07bc844363dd56467d9ebdd5929e9bb34a8e2577db77df6cf8f2ac45bd3d0bc");
+        let b = U256::from_hex("cbbc474761bb7995ff54e25fa5d30295604fe3545d0cde405e72d8c0acebb119");
         let c_expected =
-            U256::from("7c380f8b97f94efa672ece3cfefcec5094f8c5abdac45c372e02038508bf81d5");
+            U256::from_hex("7c380f8b97f94efa672ece3cfefcec5094f8c5abdac45c372e02038508bf81d5");
         let (c, overflow) = U256::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(overflow);
@@ -1613,57 +1613,57 @@ mod tests_u256 {
 
     #[test]
     fn sub_two_256_bit_integers_3() {
-        let a = U256::from("ffffffffffffffff");
-        let b = U256::from("1");
-        let c = U256::from("10000000000000000");
+        let a = U256::from_hex("ffffffffffffffff");
+        let b = U256::from_hex("1");
+        let c = U256::from_hex("10000000000000000");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_4() {
-        let a = U256::from("b58e1e0b66");
-        let b = U256::from("55469d9619");
-        let c = U256::from("10ad4bba17f");
+        let a = U256::from_hex("b58e1e0b66");
+        let b = U256::from_hex("55469d9619");
+        let c = U256::from_hex("10ad4bba17f");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_5() {
-        let a = U256::from("e8dff25cb6160f7705221da6f");
-        let b = U256::from("ab879169b5f80dc8a7969f0b0");
-        let c = U256::from("1946783c66c0e1d3facb8bcb1f");
+        let a = U256::from_hex("e8dff25cb6160f7705221da6f");
+        let b = U256::from_hex("ab879169b5f80dc8a7969f0b0");
+        let c = U256::from_hex("1946783c66c0e1d3facb8bcb1f");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_6() {
-        let a = U256::from("9adf291af3a64d59e14e7b440c850508014c551ed5");
-        let b = U256::from("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
-        let c = U256::from("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
+        let a = U256::from_hex("9adf291af3a64d59e14e7b440c850508014c551ed5");
+        let b = U256::from_hex("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
+        let c = U256::from_hex("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_7() {
-        let a = U256::from("9b4000dccf01a010e196154a1b998408f949d734389626ba97cb3331ee87e01d");
-        let b = U256::from("5d26ae1b34c78bdf4cefb2b0b553473f887bc0f1ac03d36861c2e75e01656cbc");
-        let c = U256::from("f866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9");
+        let a = U256::from_hex("9b4000dccf01a010e196154a1b998408f949d734389626ba97cb3331ee87e01d");
+        let b = U256::from_hex("5d26ae1b34c78bdf4cefb2b0b553473f887bc0f1ac03d36861c2e75e01656cbc");
+        let c = U256::from_hex("f866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_8() {
-        let a = U256::from("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580e");
-        let b = U256::from("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9d");
-        let c = U256::from("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
+        let a = U256::from_hex("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580e");
+        let b = U256::from_hex("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9d");
+        let c = U256::from_hex("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_9() {
-        let a = U256::from("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
-        let b = U256::from("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
-        let c = U256::from("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
+        let a = U256::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
+        let b = U256::from_hex("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
+        let c = U256::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
         assert_eq!(c - a, b);
     }
 
@@ -1681,7 +1681,7 @@ mod tests_u256 {
     fn sub_two_256_bit_integers_11_with_overflow() {
         let a = U256::from_u64(334);
         let b_expected =
-            U256::from("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd66");
+            U256::from_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd66");
         let c = U256::from_u64(1000);
         let (b, overflow) = U256::sub(&a, &c);
         assert!(overflow);
@@ -1698,8 +1698,8 @@ mod tests_u256 {
         assert!(U256::from_u64(2) > U256::from_u64(1));
         assert!(U256::from_u64(1) <= U256::from_u64(2));
 
-        let a = U256::from("5d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
-        let c = U256::from("b99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
+        let a = U256::from_hex("5d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
+        let c = U256::from_hex("b99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
 
         assert!(&a <= &a);
         assert!(&a >= &a);
@@ -1730,37 +1730,37 @@ mod tests_u256 {
 
     #[test]
     fn mul_two_256_bit_integers_works_2() {
-        let a = U256::from("6131d99f840b3b0");
-        let b = U256::from("6f5c466db398f43");
-        let c = U256::from("2a47a603a77f871dfbb937af7e5710");
+        let a = U256::from_hex("6131d99f840b3b0");
+        let b = U256::from_hex("6f5c466db398f43");
+        let c = U256::from_hex("2a47a603a77f871dfbb937af7e5710");
         assert_eq!(a * b, c);
     }
 
     #[test]
     fn mul_two_256_bit_integers_works_3() {
-        let a = U256::from("84a6add5db9e095b2e0f6b40eff8ee");
-        let b = U256::from("2347db918f725461bec2d5c57");
-        let c = U256::from("124805c476c9462adc0df6c88495d4253f5c38033afc18d78d920e2");
+        let a = U256::from_hex("84a6add5db9e095b2e0f6b40eff8ee");
+        let b = U256::from_hex("2347db918f725461bec2d5c57");
+        let c = U256::from_hex("124805c476c9462adc0df6c88495d4253f5c38033afc18d78d920e2");
         assert_eq!(a * b, c);
     }
 
     #[test]
     fn mul_two_256_bit_integers_works_4() {
-        let a = U256::from("15bf61fcf53a3f0ae1e8e555d");
-        let b = U256::from("cbbc474761bb7995ff54e25fa5d5d0cde405e9f");
+        let a = U256::from_hex("15bf61fcf53a3f0ae1e8e555d");
+        let b = U256::from_hex("cbbc474761bb7995ff54e25fa5d5d0cde405e9f");
         let c_expected =
-            U256::from("114ec14db0c80d30b7dcb9c45948ef04cc149e612cb544f447b146553aff2ac3");
+            U256::from_hex("114ec14db0c80d30b7dcb9c45948ef04cc149e612cb544f447b146553aff2ac3");
         assert_eq!(a * b, c_expected);
     }
 
     #[test]
     fn mul_two_256_bit_integers_works_5_hi_lo() {
-        let a = U256::from("8e2d939b602a50911232731d04fe6f40c05f97da0602307099fb991f9b414e2d");
-        let b = U256::from("7f3ad1611ab58212f92a2484e9560935b9ac4615fe61cfed1a4861e193a74d20");
+        let a = U256::from_hex("8e2d939b602a50911232731d04fe6f40c05f97da0602307099fb991f9b414e2d");
+        let b = U256::from_hex("7f3ad1611ab58212f92a2484e9560935b9ac4615fe61cfed1a4861e193a74d20");
         let hi_expected =
-            U256::from("46A946D6A984FE6507DE6B8D1354256D7A7BAE4283404733BDC876A264BCE5EE");
+            U256::from_hex("46A946D6A984FE6507DE6B8D1354256D7A7BAE4283404733BDC876A264BCE5EE");
         let lo_expected =
-            U256::from("43F24263F10930EBE3EA0307466C19B13B9C7DBA6B3F7604B7F32FB0E3084EA0");
+            U256::from_hex("43F24263F10930EBE3EA0307466C19B13B9C7DBA6B3F7604B7F32FB0E3084EA0");
         let (hi, lo) = U256::mul(&a, &b);
         assert_eq!(hi, hi_expected);
         assert_eq!(lo, lo_expected);
@@ -1768,8 +1768,8 @@ mod tests_u256 {
 
     #[test]
     fn shift_left_on_256_bit_integer_works_1() {
-        let a = U256::from("1");
-        let b = U256::from("10");
+        let a = U256::from_hex("1");
+        let b = U256::from_hex("10");
         assert_eq!(a << 4, b);
     }
 
@@ -1782,92 +1782,92 @@ mod tests_u256 {
 
     #[test]
     fn shift_left_on_256_bit_integer_works_3() {
-        let a = U256::from("10");
-        let b = U256::from("1000");
+        let a = U256::from_hex("10");
+        let b = U256::from_hex("1000");
         assert_eq!(&a << 8, b);
     }
 
     #[test]
     fn shift_left_on_256_bit_integer_works_4() {
-        let a = U256::from("e45542992b6844553f3cb1c5ac33e7fa5");
-        let b = U256::from("391550a64ada11154fcf2c716b0cf9fe940");
+        let a = U256::from_hex("e45542992b6844553f3cb1c5ac33e7fa5");
+        let b = U256::from_hex("391550a64ada11154fcf2c716b0cf9fe940");
         assert_eq!(a << 6, b);
     }
 
     #[test]
     fn shift_left_on_256_bit_integer_works_5() {
-        let a = U256::from("a8390aa99bead76bc0093b1bc1a8101f5ce");
-        let b = U256::from("72155337d5aed7801276378350203eb9c0000000000000000000000000000000");
+        let a = U256::from_hex("a8390aa99bead76bc0093b1bc1a8101f5ce");
+        let b = U256::from_hex("72155337d5aed7801276378350203eb9c0000000000000000000000000000000");
         assert_eq!(&a << 125, b);
     }
 
     #[test]
     fn shift_left_on_256_bit_integer_works_6() {
-        let a = U256::from("2ed786ab132f0b5b0cacd385dd51de3a");
-        let b = U256::from("2ed786ab132f0b5b0cacd385dd51de3a00000000000000000000000000000000");
+        let a = U256::from_hex("2ed786ab132f0b5b0cacd385dd51de3a");
+        let b = U256::from_hex("2ed786ab132f0b5b0cacd385dd51de3a00000000000000000000000000000000");
         assert_eq!(&a << (64 * 2), b);
     }
 
     #[test]
     fn shift_left_on_256_bit_integer_works_7() {
-        let a = U256::from("90823e0bd707f");
-        let b = U256::from("90823e0bd707f000000000000000000000000000000000000000000000000");
+        let a = U256::from_hex("90823e0bd707f");
+        let b = U256::from_hex("90823e0bd707f000000000000000000000000000000000000000000000000");
         assert_eq!(&a << (64 * 3), b);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_1() {
-        let a = U256::from("1");
-        let b = U256::from("10");
+        let a = U256::from_hex("1");
+        let b = U256::from_hex("10");
         assert_eq!(b >> 4, a);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_2() {
-        let a = U256::from("10");
-        let b = U256::from("1000");
+        let a = U256::from_hex("10");
+        let b = U256::from_hex("1000");
         assert_eq!(&b >> 8, a);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_3() {
-        let a = U256::from("e45542992b6844553f3cb1c5ac33e7fa5");
-        let b = U256::from("391550a64ada11154fcf2c716b0cf9fe940");
+        let a = U256::from_hex("e45542992b6844553f3cb1c5ac33e7fa5");
+        let b = U256::from_hex("391550a64ada11154fcf2c716b0cf9fe940");
         assert_eq!(b >> 6, a);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_4() {
-        let a = U256::from("390aa99bead76bc0093b1bc1a8101f5ce");
-        let b = U256::from("72155337d5aed7801276378350203eb9c0000000000000000000000000000000");
+        let a = U256::from_hex("390aa99bead76bc0093b1bc1a8101f5ce");
+        let b = U256::from_hex("72155337d5aed7801276378350203eb9c0000000000000000000000000000000");
         assert_eq!(&b >> 125, a);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_5() {
-        let a = U256::from("ba6ab46f9a9a2f20e4061b67ce4d8c3da98091cf990d7b14ef47ffe27370abbd");
-        let b = U256::from("174d568df35345e41c80c36cf9c");
+        let a = U256::from_hex("ba6ab46f9a9a2f20e4061b67ce4d8c3da98091cf990d7b14ef47ffe27370abbd");
+        let b = U256::from_hex("174d568df35345e41c80c36cf9c");
         assert_eq!(a >> 151, b);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_6() {
-        let a = U256::from("076c075d2f65e39b9ecdde8bf6f8c94241962ce0f557b7739673200c777152eb");
-        let b = U256::from("ed80eba5ecbc7373d9bbd17edf19284832c59c");
+        let a = U256::from_hex("076c075d2f65e39b9ecdde8bf6f8c94241962ce0f557b7739673200c777152eb");
+        let b = U256::from_hex("ed80eba5ecbc7373d9bbd17edf19284832c59c");
         assert_eq!(&a >> 99, b);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_7() {
-        let a = U256::from("6a9ce35d8940a5ebd29604ce9a182ade76f03f7e9965760b84a8cfd1d3dd2e61");
-        let b = U256::from("6a9ce35d8940a5eb");
+        let a = U256::from_hex("6a9ce35d8940a5ebd29604ce9a182ade76f03f7e9965760b84a8cfd1d3dd2e61");
+        let b = U256::from_hex("6a9ce35d8940a5eb");
         assert_eq!(&a >> (64 * 3), b);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_8() {
-        let a = U256::from("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c5265bd7");
-        let b = U256::from("5322c128ec84081b6c376c108ebd7fd3");
+        let a = U256::from_hex("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c5265bd7");
+        let b = U256::from_hex("5322c128ec84081b6c376c108ebd7fd3");
         assert_eq!(&a >> (64 * 2), b);
     }
 

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -283,18 +283,17 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
     }
 
     const fn is_hex_string(string: &str) -> bool {
-
         let len: usize = string.len();
         let bytes = string.as_bytes();
         let mut i = 0;
 
-        while i < (len-1) {
+        while i < (len - 1) {
             i += 1;
             match bytes[i] {
                 b'0'..=b'9' => (),
                 b'a'..=b'f' => (),
                 b'A'..=b'F' => (),
-                _ => return false
+                _ => return false,
             }
         }
 
@@ -305,17 +304,19 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         let mut string = value;
 
         // Remove 0x if it's on the string
-        if string.len() > 2 
-            && value.chars().nth(0).unwrap() == '0' 
-            && value.chars().nth(1).unwrap() == 'x'  {
+        let mut char_iterator = value.chars();
+        if string.len() > 2
+            && char_iterator.next().unwrap() == '0'
+            && char_iterator.next().unwrap() == 'x'
+        {
             string = &string[2..];
         }
-    
+
         if !Self::is_hex_string(string) {
-            return Err(CreationError::InvalidHexString)
+            return Err(CreationError::InvalidHexString);
         }
 
-        Ok(Self::from_hex_unchecked(&string))
+        Ok(Self::from_hex_unchecked(string))
     }
 
     pub const fn from_hex_unchecked(value: &str) -> Self {
@@ -744,8 +745,6 @@ mod tests_u384 {
             ]
         );
     }
-
-    
 
     #[test]
     fn equality_works_1() {
@@ -1226,7 +1225,9 @@ mod tests_u384 {
 
     #[test]
     fn shift_left_on_384_bit_integer_works_5() {
-        let a = U384::from_hex_unchecked("03303f4d6c2d1caf0c24a6b0239b679a8390aa99bead76bc0093b1bc1a8101f5ce");
+        let a = U384::from_hex_unchecked(
+            "03303f4d6c2d1caf0c24a6b0239b679a8390aa99bead76bc0093b1bc1a8101f5ce",
+        );
         let b = U384::from_hex_unchecked("6607e9ad85a395e18494d604736cf35072155337d5aed7801276378350203eb9c0000000000000000000000000000000");
         assert_eq!(&a << 125, b);
     }
@@ -1243,7 +1244,9 @@ mod tests_u384 {
     #[test]
     fn shift_left_on_384_bit_integer_works_7() {
         let a = U384::from_hex_unchecked("90823e0bd707f");
-        let b = U384::from_hex_unchecked("90823e0bd707f000000000000000000000000000000000000000000000000");
+        let b = U384::from_hex_unchecked(
+            "90823e0bd707f000000000000000000000000000000000000000000000000",
+        );
         assert_eq!(&a << (64 * 3), b);
     }
 
@@ -1270,7 +1273,9 @@ mod tests_u384 {
 
     #[test]
     fn shift_right_on_384_bit_integer_works_4() {
-        let a = U384::from_hex_unchecked("03303f4d6c2d1caf0c24a6b0239b679a8390aa99bead76bc0093b1bc1a8101f5ce");
+        let a = U384::from_hex_unchecked(
+            "03303f4d6c2d1caf0c24a6b0239b679a8390aa99bead76bc0093b1bc1a8101f5ce",
+        );
         let b = U384::from_hex_unchecked("6607e9ad85a395e18494d604736cf35072155337d5aed7801276378350203eb9c0000000000000000000000000000000");
         assert_eq!(&b >> 125, a);
     }
@@ -1278,14 +1283,16 @@ mod tests_u384 {
     #[test]
     fn shift_right_on_384_bit_integer_works_5() {
         let a = U384::from_hex_unchecked("ba6ab46f9a9a2f20e4061b67ce4d8c3da98091cf990d7b14ef47ffe27370abbdeb6a3ce9f9cbf5df1b2430114c8558eb");
-        let b = U384::from_hex_unchecked("174d568df35345e41c80c36cf9c9b187b5301239f321af629de8fffc4e6");
+        let b =
+            U384::from_hex_unchecked("174d568df35345e41c80c36cf9c9b187b5301239f321af629de8fffc4e6");
         assert_eq!(a >> 151, b);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_6() {
-        let a =
-            U384::from_hex_unchecked("076c075d2f65e39b9ecdde8bf6f8c94241962ce0f557b7739673200c777152eb7e772ad35");
+        let a = U384::from_hex_unchecked(
+            "076c075d2f65e39b9ecdde8bf6f8c94241962ce0f557b7739673200c777152eb7e772ad35",
+        );
         let b = U384::from_hex_unchecked("ed80eba5ecbc7373d9bbd17edf19284832c59c1eaaf6ee7");
         assert_eq!(&a >> 99, b);
     }
@@ -1300,7 +1307,8 @@ mod tests_u384 {
     #[test]
     fn shift_right_on_384_bit_integer_works_8() {
         let a = U384::from_hex_unchecked("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c5265bd7db75c90b2665a0826d17600f0e9");
-        let b = U384::from_hex_unchecked("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c52");
+        let b =
+            U384::from_hex_unchecked("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c52");
         assert_eq!(&a >> (64 * 2), b);
     }
 
@@ -1474,7 +1482,9 @@ mod tests_u256 {
 
     #[test]
     fn construct_new_integer_from_hex_8() {
-        let a = U256::from_hex_unchecked("2B20AAA5CF482B239E2897A787FAF4660CC95597854BEB235F6144D9E91F4B14");
+        let a = U256::from_hex_unchecked(
+            "2B20AAA5CF482B239E2897A787FAF4660CC95597854BEB235F6144D9E91F4B14",
+        );
         assert_eq!(
             a.limbs,
             [
@@ -1555,7 +1565,9 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_8() {
-        let a = U256::from_hex_unchecked("2B20AAA5CF482B239E2897A787FAF4660CC95597854BEB235F6144D9E91F4B14");
+        let a = U256::from_hex_unchecked(
+            "2B20AAA5CF482B239E2897A787FAF4660CC95597854BEB235F6144D9E91F4B14",
+        );
         let b = U256 {
             limbs: [
                 3107671372009581347,
@@ -1631,34 +1643,57 @@ mod tests_u256 {
 
     #[test]
     fn add_two_256_bit_integers_7() {
-        let a = U256::from_hex_unchecked("10d3bc05496380cfe27bf5d97ddb99ac95eb5ecfbd3907eadf877a4c2dfa05f6");
-        let b = U256::from_hex_unchecked("0866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9");
-        let c = U256::from_hex_unchecked("193a6afd4d2cacc01101bdd44ec864f517b0f6f5a1d3020dd91594dc1de752cf");
+        let a = U256::from_hex_unchecked(
+            "10d3bc05496380cfe27bf5d97ddb99ac95eb5ecfbd3907eadf877a4c2dfa05f6",
+        );
+        let b = U256::from_hex_unchecked(
+            "0866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9",
+        );
+        let c = U256::from_hex_unchecked(
+            "193a6afd4d2cacc01101bdd44ec864f517b0f6f5a1d3020dd91594dc1de752cf",
+        );
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_8() {
-        let a = U256::from_hex_unchecked("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580f");
-        let b = U256::from_hex_unchecked("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9c");
-        let c = U256::from_hex_unchecked("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
+        let a = U256::from_hex_unchecked(
+            "07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580f",
+        );
+        let b = U256::from_hex_unchecked(
+            "d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9c",
+        );
+        let c = U256::from_hex_unchecked(
+            "dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab",
+        );
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_9() {
-        let a = U256::from_hex_unchecked("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
-        let b = U256::from_hex_unchecked("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
-        let c = U256::from_hex_unchecked("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
+        let a = U256::from_hex_unchecked(
+            "92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2",
+        );
+        let b = U256::from_hex_unchecked(
+            "46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4",
+        );
+        let c = U256::from_hex_unchecked(
+            "d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6",
+        );
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_10() {
-        let a = U256::from_hex_unchecked("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580f");
-        let b = U256::from_hex_unchecked("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9c");
-        let c_expected =
-            U256::from_hex_unchecked("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
+        let a = U256::from_hex_unchecked(
+            "07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580f",
+        );
+        let b = U256::from_hex_unchecked(
+            "d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9c",
+        );
+        let c_expected = U256::from_hex_unchecked(
+            "dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab",
+        );
         let (c, overflow) = U256::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(!overflow);
@@ -1666,10 +1701,15 @@ mod tests_u256 {
 
     #[test]
     fn add_two_256_bit_integers_11() {
-        let a = U256::from_hex_unchecked("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
-        let b = U256::from_hex_unchecked("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
-        let c_expected =
-            U256::from_hex_unchecked("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
+        let a = U256::from_hex_unchecked(
+            "92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2",
+        );
+        let b = U256::from_hex_unchecked(
+            "46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4",
+        );
+        let c_expected = U256::from_hex_unchecked(
+            "d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6",
+        );
         let (c, overflow) = U256::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(!overflow);
@@ -1677,10 +1717,15 @@ mod tests_u256 {
 
     #[test]
     fn add_two_256_bit_integers_12_with_overflow() {
-        let a = U256::from_hex_unchecked("b07bc844363dd56467d9ebdd5929e9bb34a8e2577db77df6cf8f2ac45bd3d0bc");
-        let b = U256::from_hex_unchecked("cbbc474761bb7995ff54e25fa5d30295604fe3545d0cde405e72d8c0acebb119");
-        let c_expected =
-            U256::from_hex_unchecked("7c380f8b97f94efa672ece3cfefcec5094f8c5abdac45c372e02038508bf81d5");
+        let a = U256::from_hex_unchecked(
+            "b07bc844363dd56467d9ebdd5929e9bb34a8e2577db77df6cf8f2ac45bd3d0bc",
+        );
+        let b = U256::from_hex_unchecked(
+            "cbbc474761bb7995ff54e25fa5d30295604fe3545d0cde405e72d8c0acebb119",
+        );
+        let c_expected = U256::from_hex_unchecked(
+            "7c380f8b97f94efa672ece3cfefcec5094f8c5abdac45c372e02038508bf81d5",
+        );
         let (c, overflow) = U256::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(overflow);
@@ -1736,25 +1781,43 @@ mod tests_u256 {
 
     #[test]
     fn sub_two_256_bit_integers_7() {
-        let a = U256::from_hex_unchecked("9b4000dccf01a010e196154a1b998408f949d734389626ba97cb3331ee87e01d");
-        let b = U256::from_hex_unchecked("5d26ae1b34c78bdf4cefb2b0b553473f887bc0f1ac03d36861c2e75e01656cbc");
-        let c = U256::from_hex_unchecked("f866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9");
+        let a = U256::from_hex_unchecked(
+            "9b4000dccf01a010e196154a1b998408f949d734389626ba97cb3331ee87e01d",
+        );
+        let b = U256::from_hex_unchecked(
+            "5d26ae1b34c78bdf4cefb2b0b553473f887bc0f1ac03d36861c2e75e01656cbc",
+        );
+        let c = U256::from_hex_unchecked(
+            "f866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9",
+        );
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_8() {
-        let a = U256::from_hex_unchecked("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580e");
-        let b = U256::from_hex_unchecked("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9d");
-        let c = U256::from_hex_unchecked("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
+        let a = U256::from_hex_unchecked(
+            "07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580e",
+        );
+        let b = U256::from_hex_unchecked(
+            "d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9d",
+        );
+        let c = U256::from_hex_unchecked(
+            "dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab",
+        );
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_9() {
-        let a = U256::from_hex_unchecked("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
-        let b = U256::from_hex_unchecked("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
-        let c = U256::from_hex_unchecked("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
+        let a = U256::from_hex_unchecked(
+            "92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2",
+        );
+        let b = U256::from_hex_unchecked(
+            "46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4",
+        );
+        let c = U256::from_hex_unchecked(
+            "d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6",
+        );
         assert_eq!(c - a, b);
     }
 
@@ -1771,8 +1834,9 @@ mod tests_u256 {
     #[test]
     fn sub_two_256_bit_integers_11_with_overflow() {
         let a = U256::from_u64(334);
-        let b_expected =
-            U256::from_hex_unchecked("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd66");
+        let b_expected = U256::from_hex_unchecked(
+            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd66",
+        );
         let c = U256::from_u64(1000);
         let (b, overflow) = U256::sub(&a, &c);
         assert!(overflow);
@@ -1789,8 +1853,12 @@ mod tests_u256 {
         assert!(U256::from_u64(2) > U256::from_u64(1));
         assert!(U256::from_u64(1) <= U256::from_u64(2));
 
-        let a = U256::from_hex_unchecked("5d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
-        let c = U256::from_hex_unchecked("b99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
+        let a = U256::from_hex_unchecked(
+            "5d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233",
+        );
+        let c = U256::from_hex_unchecked(
+            "b99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75",
+        );
 
         assert!(&a <= &a);
         assert!(&a >= &a);
@@ -1839,19 +1907,26 @@ mod tests_u256 {
     fn mul_two_256_bit_integers_works_4() {
         let a = U256::from_hex_unchecked("15bf61fcf53a3f0ae1e8e555d");
         let b = U256::from_hex_unchecked("cbbc474761bb7995ff54e25fa5d5d0cde405e9f");
-        let c_expected =
-            U256::from_hex_unchecked("114ec14db0c80d30b7dcb9c45948ef04cc149e612cb544f447b146553aff2ac3");
+        let c_expected = U256::from_hex_unchecked(
+            "114ec14db0c80d30b7dcb9c45948ef04cc149e612cb544f447b146553aff2ac3",
+        );
         assert_eq!(a * b, c_expected);
     }
 
     #[test]
     fn mul_two_256_bit_integers_works_5_hi_lo() {
-        let a = U256::from_hex_unchecked("8e2d939b602a50911232731d04fe6f40c05f97da0602307099fb991f9b414e2d");
-        let b = U256::from_hex_unchecked("7f3ad1611ab58212f92a2484e9560935b9ac4615fe61cfed1a4861e193a74d20");
-        let hi_expected =
-            U256::from_hex_unchecked("46A946D6A984FE6507DE6B8D1354256D7A7BAE4283404733BDC876A264BCE5EE");
-        let lo_expected =
-            U256::from_hex_unchecked("43F24263F10930EBE3EA0307466C19B13B9C7DBA6B3F7604B7F32FB0E3084EA0");
+        let a = U256::from_hex_unchecked(
+            "8e2d939b602a50911232731d04fe6f40c05f97da0602307099fb991f9b414e2d",
+        );
+        let b = U256::from_hex_unchecked(
+            "7f3ad1611ab58212f92a2484e9560935b9ac4615fe61cfed1a4861e193a74d20",
+        );
+        let hi_expected = U256::from_hex_unchecked(
+            "46A946D6A984FE6507DE6B8D1354256D7A7BAE4283404733BDC876A264BCE5EE",
+        );
+        let lo_expected = U256::from_hex_unchecked(
+            "43F24263F10930EBE3EA0307466C19B13B9C7DBA6B3F7604B7F32FB0E3084EA0",
+        );
         let (hi, lo) = U256::mul(&a, &b);
         assert_eq!(hi, hi_expected);
         assert_eq!(lo, lo_expected);
@@ -1888,21 +1963,27 @@ mod tests_u256 {
     #[test]
     fn shift_left_on_256_bit_integer_works_5() {
         let a = U256::from_hex_unchecked("a8390aa99bead76bc0093b1bc1a8101f5ce");
-        let b = U256::from_hex_unchecked("72155337d5aed7801276378350203eb9c0000000000000000000000000000000");
+        let b = U256::from_hex_unchecked(
+            "72155337d5aed7801276378350203eb9c0000000000000000000000000000000",
+        );
         assert_eq!(&a << 125, b);
     }
 
     #[test]
     fn shift_left_on_256_bit_integer_works_6() {
         let a = U256::from_hex_unchecked("2ed786ab132f0b5b0cacd385dd51de3a");
-        let b = U256::from_hex_unchecked("2ed786ab132f0b5b0cacd385dd51de3a00000000000000000000000000000000");
+        let b = U256::from_hex_unchecked(
+            "2ed786ab132f0b5b0cacd385dd51de3a00000000000000000000000000000000",
+        );
         assert_eq!(&a << (64 * 2), b);
     }
 
     #[test]
     fn shift_left_on_256_bit_integer_works_7() {
         let a = U256::from_hex_unchecked("90823e0bd707f");
-        let b = U256::from_hex_unchecked("90823e0bd707f000000000000000000000000000000000000000000000000");
+        let b = U256::from_hex_unchecked(
+            "90823e0bd707f000000000000000000000000000000000000000000000000",
+        );
         assert_eq!(&a << (64 * 3), b);
     }
 
@@ -1930,34 +2011,44 @@ mod tests_u256 {
     #[test]
     fn shift_right_on_256_bit_integer_works_4() {
         let a = U256::from_hex_unchecked("390aa99bead76bc0093b1bc1a8101f5ce");
-        let b = U256::from_hex_unchecked("72155337d5aed7801276378350203eb9c0000000000000000000000000000000");
+        let b = U256::from_hex_unchecked(
+            "72155337d5aed7801276378350203eb9c0000000000000000000000000000000",
+        );
         assert_eq!(&b >> 125, a);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_5() {
-        let a = U256::from_hex_unchecked("ba6ab46f9a9a2f20e4061b67ce4d8c3da98091cf990d7b14ef47ffe27370abbd");
+        let a = U256::from_hex_unchecked(
+            "ba6ab46f9a9a2f20e4061b67ce4d8c3da98091cf990d7b14ef47ffe27370abbd",
+        );
         let b = U256::from_hex_unchecked("174d568df35345e41c80c36cf9c");
         assert_eq!(a >> 151, b);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_6() {
-        let a = U256::from_hex_unchecked("076c075d2f65e39b9ecdde8bf6f8c94241962ce0f557b7739673200c777152eb");
+        let a = U256::from_hex_unchecked(
+            "076c075d2f65e39b9ecdde8bf6f8c94241962ce0f557b7739673200c777152eb",
+        );
         let b = U256::from_hex_unchecked("ed80eba5ecbc7373d9bbd17edf19284832c59c");
         assert_eq!(&a >> 99, b);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_7() {
-        let a = U256::from_hex_unchecked("6a9ce35d8940a5ebd29604ce9a182ade76f03f7e9965760b84a8cfd1d3dd2e61");
+        let a = U256::from_hex_unchecked(
+            "6a9ce35d8940a5ebd29604ce9a182ade76f03f7e9965760b84a8cfd1d3dd2e61",
+        );
         let b = U256::from_hex_unchecked("6a9ce35d8940a5eb");
         assert_eq!(&a >> (64 * 3), b);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_8() {
-        let a = U256::from_hex_unchecked("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c5265bd7");
+        let a = U256::from_hex_unchecked(
+            "5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c5265bd7",
+        );
         let b = U256::from_hex_unchecked("5322c128ec84081b6c376c108ebd7fd3");
         assert_eq!(&a >> (64 * 2), b);
     }

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -709,9 +709,24 @@ mod tests_u384 {
     }
 
     #[test]
-    #[should_panic]
     fn construct_new_integer_from_non_hex_errs() {
-        U384::from_hex("0xTEST").unwrap();
+        assert!(U384::from_hex("0xTEST").is_err());
+    }
+
+    #[test]
+    fn construct_new_integer_from_hex_checked_8() {
+        let a = U384::from_hex("140f5177b90b4f96b61bb8ccb4f298ad2b20aaa5cf482b239e2897a787faf4660cc95597854beb235f6144d9e91f4b14").unwrap();
+        assert_eq!(
+            a.limbs,
+            [
+                1445463580056702870,
+                13122285128622708909,
+                3107671372009581347,
+                11396525602857743462,
+                921361708038744867,
+                6872850209053821716
+            ]
+        );
     }
 
     #[test]

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -1,7 +1,7 @@
 use std::convert::From;
 use std::ops::{Add, BitAnd, Mul, Shl, Shr, Sub};
 
-use crate::errors::ByteConversionError;
+use crate::errors::{ByteConversionError, CreationError};
 use crate::traits::ByteConversion;
 use crate::unsigned_integer::traits::IsUnsignedInteger;
 
@@ -52,7 +52,7 @@ impl<const NUM_LIMBS: usize> From<u16> for UnsignedInteger<NUM_LIMBS> {
 
 impl<const NUM_LIMBS: usize> From<&str> for UnsignedInteger<NUM_LIMBS> {
     fn from(hex_str: &str) -> Self {
-        Self::from_hex(hex_str)
+        Self::from_hex_unchecked(hex_str)
     }
 }
 
@@ -282,7 +282,43 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         UnsignedInteger { limbs }
     }
 
-    pub const fn from_hex(value: &str) -> Self {
+    const fn is_hex_string(string: &str) -> bool {
+
+        let len: usize = string.len();
+        let bytes = string.as_bytes();
+        let mut i = 0;
+
+        while i < (len-1) {
+            i += 1;
+            match bytes[i] {
+                b'0'..=b'9' => (),
+                b'a'..=b'f' => (),
+                b'A'..=b'F' => (),
+                _ => return false
+            }
+        }
+
+        true
+    }
+
+    pub fn from_hex(value: &str) -> Result<Self, CreationError> {
+        let mut string = value;
+
+        // Remove 0x if it's on the string
+        if string.len() > 2 
+            && value.chars().nth(0).unwrap() == '0' 
+            && value.chars().nth(1).unwrap() == 'x'  {
+            string = &string[2..];
+        }
+    
+        if !Self::is_hex_string(string) {
+            return Err(CreationError::InvalidHexString)
+        }
+
+        Ok(Self::from_hex_unchecked(&string))
+    }
+
+    pub const fn from_hex_unchecked(value: &str) -> Self {
         let mut result = [0u64; NUM_LIMBS];
         let mut limb = 0;
         let mut limb_index = NUM_LIMBS - 1;
@@ -590,43 +626,43 @@ mod tests_u384 {
 
     #[test]
     fn construct_new_integer_from_hex_1() {
-        let a = U384::from_hex("1");
+        let a = U384::from_hex_unchecked("1");
         assert_eq!(a.limbs, [0, 0, 0, 0, 0, 1]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_2() {
-        let a = U384::from_hex("f");
+        let a = U384::from_hex_unchecked("f");
         assert_eq!(a.limbs, [0, 0, 0, 0, 0, 15]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_3() {
-        let a = U384::from_hex("10000000000000000");
+        let a = U384::from_hex_unchecked("10000000000000000");
         assert_eq!(a.limbs, [0, 0, 0, 0, 1, 0]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_4() {
-        let a = U384::from_hex("a0000000000000000");
+        let a = U384::from_hex_unchecked("a0000000000000000");
         assert_eq!(a.limbs, [0, 0, 0, 0, 10, 0]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_5() {
-        let a = U384::from_hex("ffffffffffffffffff");
+        let a = U384::from_hex_unchecked("ffffffffffffffffff");
         assert_eq!(a.limbs, [0, 0, 0, 0, 255, u64::MAX]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_6() {
-        let a = U384::from_hex("eb235f6144d9e91f4b14");
+        let a = U384::from_hex_unchecked("eb235f6144d9e91f4b14");
         assert_eq!(a.limbs, [0, 0, 0, 0, 60195, 6872850209053821716]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_7() {
-        let a = U384::from_hex("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
+        let a = U384::from_hex_unchecked("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
         assert_eq!(
             a.limbs,
             [
@@ -641,8 +677,46 @@ mod tests_u384 {
     }
 
     #[test]
+    fn construct_new_integer_from_hex_checked_7() {
+        let a = U384::from_hex("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2").unwrap();
+        assert_eq!(
+            a.limbs,
+            [
+                0,
+                0,
+                0,
+                194229460750598834,
+                4171047363999149894,
+                6975114134393503410
+            ]
+        );
+    }
+
+    #[test]
+    fn construct_new_integer_from_hex_checked_7_with_zero_x() {
+        let a = U384::from_hex("0x2b20aaa5cf482b239e2897a787faf4660cc95597854beb2").unwrap();
+        assert_eq!(
+            a.limbs,
+            [
+                0,
+                0,
+                0,
+                194229460750598834,
+                4171047363999149894,
+                6975114134393503410
+            ]
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn construct_new_integer_from_non_hex_errs() {
+        U384::from_hex("0xTEST").unwrap();
+    }
+
+    #[test]
     fn construct_new_integer_from_hex_8() {
-        let a = U384::from_hex("140f5177b90b4f96b61bb8ccb4f298ad2b20aaa5cf482b239e2897a787faf4660cc95597854beb235f6144d9e91f4b14");
+        let a = U384::from_hex_unchecked("140f5177b90b4f96b61bb8ccb4f298ad2b20aaa5cf482b239e2897a787faf4660cc95597854beb235f6144d9e91f4b14");
         assert_eq!(
             a.limbs,
             [
@@ -656,9 +730,11 @@ mod tests_u384 {
         );
     }
 
+    
+
     #[test]
     fn equality_works_1() {
-        let a = U384::from_hex("1");
+        let a = U384::from_hex_unchecked("1");
         let b = U384 {
             limbs: [0, 0, 0, 0, 0, 1],
         };
@@ -666,7 +742,7 @@ mod tests_u384 {
     }
     #[test]
     fn equality_works_2() {
-        let a = U384::from_hex("f");
+        let a = U384::from_hex_unchecked("f");
         let b = U384 {
             limbs: [0, 0, 0, 0, 0, 15],
         };
@@ -675,7 +751,7 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_3() {
-        let a = U384::from_hex("10000000000000000");
+        let a = U384::from_hex_unchecked("10000000000000000");
         let b = U384 {
             limbs: [0, 0, 0, 0, 1, 0],
         };
@@ -684,7 +760,7 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_4() {
-        let a = U384::from_hex("a0000000000000000");
+        let a = U384::from_hex_unchecked("a0000000000000000");
         let b = U384 {
             limbs: [0, 0, 0, 0, 10, 0],
         };
@@ -693,7 +769,7 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_5() {
-        let a = U384::from_hex("ffffffffffffffffff");
+        let a = U384::from_hex_unchecked("ffffffffffffffffff");
         let b = U384 {
             limbs: [0, 0, 0, 0, u8::MAX as u64, u64::MAX],
         };
@@ -702,7 +778,7 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_6() {
-        let a = U384::from_hex("eb235f6144d9e91f4b14");
+        let a = U384::from_hex_unchecked("eb235f6144d9e91f4b14");
         let b = U384 {
             limbs: [0, 0, 0, 0, 60195, 6872850209053821716],
         };
@@ -711,7 +787,7 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_7() {
-        let a = U384::from_hex("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
+        let a = U384::from_hex_unchecked("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
         let b = U384 {
             limbs: [
                 0,
@@ -727,7 +803,7 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_8() {
-        let a = U384::from_hex("140f5177b90b4f96b61bb8ccb4f298ad2b20aaa5cf482b239e2897a787faf4660cc95597854beb235f6144d9e91f4b14");
+        let a = U384::from_hex_unchecked("140f5177b90b4f96b61bb8ccb4f298ad2b20aaa5cf482b239e2897a787faf4660cc95597854beb235f6144d9e91f4b14");
         let b = U384 {
             limbs: [
                 1445463580056702870,
@@ -743,28 +819,28 @@ mod tests_u384 {
 
     #[test]
     fn equality_works_9() {
-        let a = U384::from_hex("fffffff");
-        let b = U384::from_hex("fefffff");
+        let a = U384::from_hex_unchecked("fffffff");
+        let b = U384::from_hex_unchecked("fefffff");
         assert_ne!(a, b);
     }
 
     #[test]
     fn equality_works_10() {
-        let a = U384::from_hex("ffff000000000000");
-        let b = U384::from_hex("ffff000000100000");
+        let a = U384::from_hex_unchecked("ffff000000000000");
+        let b = U384::from_hex_unchecked("ffff000000100000");
         assert_ne!(a, b);
     }
 
     #[test]
     fn const_ne_works_1() {
-        let a = U384::from_hex("ffff000000000000");
-        let b = U384::from_hex("ffff000000100000");
+        let a = U384::from_hex_unchecked("ffff000000000000");
+        let b = U384::from_hex_unchecked("ffff000000100000");
         assert!(U384::const_ne(&a, &b));
     }
 
     #[test]
     fn const_ne_works_2() {
-        let a = U384::from_hex("140f5177b90b4f96b61bb8ccb4f298ad2b20aaa5cf482b239e2897a787faf4660cc95597854beb235f6144d9e91f4b14");
+        let a = U384::from_hex_unchecked("140f5177b90b4f96b61bb8ccb4f298ad2b20aaa5cf482b239e2897a787faf4660cc95597854beb235f6144d9e91f4b14");
         let b = U384 {
             limbs: [
                 1445463580056702870,
@@ -796,45 +872,45 @@ mod tests_u384 {
 
     #[test]
     fn add_two_384_bit_integers_3() {
-        let a = U384::from_hex("ffffffffffffffff");
-        let b = U384::from_hex("1");
-        let c = U384::from_hex("10000000000000000");
+        let a = U384::from_hex_unchecked("ffffffffffffffff");
+        let b = U384::from_hex_unchecked("1");
+        let c = U384::from_hex_unchecked("10000000000000000");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_384_bit_integers_4() {
-        let a = U384::from_hex("b58e1e0b66");
-        let b = U384::from_hex("55469d9619");
-        let c = U384::from_hex("10ad4bba17f");
+        let a = U384::from_hex_unchecked("b58e1e0b66");
+        let b = U384::from_hex_unchecked("55469d9619");
+        let c = U384::from_hex_unchecked("10ad4bba17f");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_384_bit_integers_5() {
-        let a = U384::from_hex("e8dff25cb6160f7705221da6f");
-        let b = U384::from_hex("ab879169b5f80dc8a7969f0b0");
-        let c = U384::from_hex("1946783c66c0e1d3facb8bcb1f");
+        let a = U384::from_hex_unchecked("e8dff25cb6160f7705221da6f");
+        let b = U384::from_hex_unchecked("ab879169b5f80dc8a7969f0b0");
+        let c = U384::from_hex_unchecked("1946783c66c0e1d3facb8bcb1f");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_384_bit_integers_6() {
-        let a = U384::from_hex("9adf291af3a64d59e14e7b440c850508014c551ed5");
-        let b = U384::from_hex("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
-        let c = U384::from_hex("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
+        let a = U384::from_hex_unchecked("9adf291af3a64d59e14e7b440c850508014c551ed5");
+        let b = U384::from_hex_unchecked("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
+        let c = U384::from_hex_unchecked("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_384_bit_integers_7() {
-        let a = U384::from_hex(
+        let a = U384::from_hex_unchecked(
             "f866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9a03647cd3cc84",
         );
-        let b = U384::from_hex(
+        let b = U384::from_hex_unchecked(
             "9b4000dccf01a010e196154a1b998408f949d734389626ba97cb3331ee87e01dd5badc58f41b2",
         );
-        let c = U384::from_hex(
+        let c = U384::from_hex_unchecked(
             "193a6afd4d2cacc01101bdd44ec864f517b0f6f5a1d3020dd91594dc1de752cf775f1242630e36",
         );
         assert_eq!(a + b, c);
@@ -842,25 +918,25 @@ mod tests_u384 {
 
     #[test]
     fn add_two_384_bit_integers_8() {
-        let a = U384::from_hex("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580eb36ae12ea59f90db5b1799d0970a42e");
-        let b = U384::from_hex("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9cafff44a2c606877d46c49a3433cc85e");
-        let c = U384::from_hex("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab636a25d16ba61858a1dc3404cad6c8c");
+        let a = U384::from_hex_unchecked("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580eb36ae12ea59f90db5b1799d0970a42e");
+        let b = U384::from_hex_unchecked("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9cafff44a2c606877d46c49a3433cc85e");
+        let c = U384::from_hex_unchecked("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab636a25d16ba61858a1dc3404cad6c8c");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_384_bit_integers_9() {
-        let a = U384::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
-        let b = U384::from_hex("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4622b8bd6fa68ef654796a183abde842");
-        let c = U384::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
+        let a = U384::from_hex_unchecked("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
+        let b = U384::from_hex_unchecked("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4622b8bd6fa68ef654796a183abde842");
+        let c = U384::from_hex_unchecked("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_384_bit_integers_10() {
-        let a = U384::from_hex("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580eb36ae12ea59f90db5b1799d0970a42e");
-        let b = U384::from_hex("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9cafff44a2c606877d46c49a3433cc85e");
-        let c_expected = U384::from_hex("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab636a25d16ba61858a1dc3404cad6c8c");
+        let a = U384::from_hex_unchecked("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580eb36ae12ea59f90db5b1799d0970a42e");
+        let b = U384::from_hex_unchecked("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9cafff44a2c606877d46c49a3433cc85e");
+        let c_expected = U384::from_hex_unchecked("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab636a25d16ba61858a1dc3404cad6c8c");
         let (c, overflow) = U384::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(!overflow);
@@ -868,9 +944,9 @@ mod tests_u384 {
 
     #[test]
     fn add_two_384_bit_integers_11() {
-        let a = U384::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
-        let b = U384::from_hex("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4622b8bd6fa68ef654796a183abde842");
-        let c_expected = U384::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
+        let a = U384::from_hex_unchecked("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
+        let b = U384::from_hex_unchecked("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4622b8bd6fa68ef654796a183abde842");
+        let c_expected = U384::from_hex_unchecked("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
         let (c, overflow) = U384::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(!overflow);
@@ -878,9 +954,9 @@ mod tests_u384 {
 
     #[test]
     fn add_two_384_bit_integers_12_with_overflow() {
-        let a = U384::from_hex("b07bc844363dd56467d9ebdd5929e9bb34a8e2577db77df6cf8f2ac45bd3d0bc2fc3078d265fe761af51d6aec5b59428");
-        let b = U384::from_hex("cbbc474761bb7995ff54e25fa5d30295604fe3545d0cde405e72d8c0acebb119e9158131679b6c34483a3dafb49deeea");
-        let c_expected = U384::from_hex("7c380f8b97f94efa672ece3cfefcec5094f8c5abdac45c372e02038508bf81d618d888be8dfb5395f78c145e7a538312");
+        let a = U384::from_hex_unchecked("b07bc844363dd56467d9ebdd5929e9bb34a8e2577db77df6cf8f2ac45bd3d0bc2fc3078d265fe761af51d6aec5b59428");
+        let b = U384::from_hex_unchecked("cbbc474761bb7995ff54e25fa5d30295604fe3545d0cde405e72d8c0acebb119e9158131679b6c34483a3dafb49deeea");
+        let c_expected = U384::from_hex_unchecked("7c380f8b97f94efa672ece3cfefcec5094f8c5abdac45c372e02038508bf81d618d888be8dfb5395f78c145e7a538312");
         let (c, overflow) = U384::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(overflow);
@@ -904,45 +980,45 @@ mod tests_u384 {
 
     #[test]
     fn sub_two_384_bit_integers_3() {
-        let a = U384::from_hex("ffffffffffffffff");
-        let b = U384::from_hex("1");
-        let c = U384::from_hex("10000000000000000");
+        let a = U384::from_hex_unchecked("ffffffffffffffff");
+        let b = U384::from_hex_unchecked("1");
+        let c = U384::from_hex_unchecked("10000000000000000");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_384_bit_integers_4() {
-        let a = U384::from_hex("b58e1e0b66");
-        let b = U384::from_hex("55469d9619");
-        let c = U384::from_hex("10ad4bba17f");
+        let a = U384::from_hex_unchecked("b58e1e0b66");
+        let b = U384::from_hex_unchecked("55469d9619");
+        let c = U384::from_hex_unchecked("10ad4bba17f");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_384_bit_integers_5() {
-        let a = U384::from_hex("e8dff25cb6160f7705221da6f");
-        let b = U384::from_hex("ab879169b5f80dc8a7969f0b0");
-        let c = U384::from_hex("1946783c66c0e1d3facb8bcb1f");
+        let a = U384::from_hex_unchecked("e8dff25cb6160f7705221da6f");
+        let b = U384::from_hex_unchecked("ab879169b5f80dc8a7969f0b0");
+        let c = U384::from_hex_unchecked("1946783c66c0e1d3facb8bcb1f");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_384_bit_integers_6() {
-        let a = U384::from_hex("9adf291af3a64d59e14e7b440c850508014c551ed5");
-        let b = U384::from_hex("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
-        let c = U384::from_hex("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
+        let a = U384::from_hex_unchecked("9adf291af3a64d59e14e7b440c850508014c551ed5");
+        let b = U384::from_hex_unchecked("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
+        let c = U384::from_hex_unchecked("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_384_bit_integers_7() {
-        let a = U384::from_hex(
+        let a = U384::from_hex_unchecked(
             "f866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9a03647cd3cc84",
         );
-        let b = U384::from_hex(
+        let b = U384::from_hex_unchecked(
             "9b4000dccf01a010e196154a1b998408f949d734389626ba97cb3331ee87e01dd5badc58f41b2",
         );
-        let c = U384::from_hex(
+        let c = U384::from_hex_unchecked(
             "193a6afd4d2cacc01101bdd44ec864f517b0f6f5a1d3020dd91594dc1de752cf775f1242630e36",
         );
         assert_eq!(c - a, b);
@@ -950,17 +1026,17 @@ mod tests_u384 {
 
     #[test]
     fn sub_two_384_bit_integers_8() {
-        let a = U384::from_hex("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580eb36ae12ea59f90db5b1799d0970a42e");
-        let b = U384::from_hex("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9cafff44a2c606877d46c49a3433cc85e");
-        let c = U384::from_hex("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab636a25d16ba61858a1dc3404cad6c8c");
+        let a = U384::from_hex_unchecked("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580eb36ae12ea59f90db5b1799d0970a42e");
+        let b = U384::from_hex_unchecked("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9cafff44a2c606877d46c49a3433cc85e");
+        let c = U384::from_hex_unchecked("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab636a25d16ba61858a1dc3404cad6c8c");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_384_bit_integers_9() {
-        let a = U384::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
-        let b = U384::from_hex("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4622b8bd6fa68ef654796a183abde842");
-        let c = U384::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
+        let a = U384::from_hex_unchecked("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
+        let b = U384::from_hex_unchecked("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4622b8bd6fa68ef654796a183abde842");
+        let c = U384::from_hex_unchecked("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
         assert_eq!(c - a, b);
     }
 
@@ -977,7 +1053,7 @@ mod tests_u384 {
     #[test]
     fn sub_two_384_bit_integers_11_with_overflow() {
         let a = U384::from_u64(334);
-        let b_expected = U384::from_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd66");
+        let b_expected = U384::from_hex_unchecked("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd66");
         let c = U384::from_u64(1000);
         let (b, underflow) = U384::sub(&a, &c);
         assert!(underflow);
@@ -994,8 +1070,8 @@ mod tests_u384 {
         assert!(U384::from_u64(2) > U384::from_u64(1));
         assert!(U384::from_u64(1) <= U384::from_u64(2));
 
-        let a = U384::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
-        let c = U384::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
+        let a = U384::from_hex_unchecked("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
+        let c = U384::from_hex_unchecked("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
 
         assert!(&a <= &a);
         assert!(&a >= &a);
@@ -1026,25 +1102,25 @@ mod tests_u384 {
 
     #[test]
     fn mul_two_384_bit_integers_works_2() {
-        let a = U384::from_hex("6131d99f840b3b0");
-        let b = U384::from_hex("6f5c466db398f43");
-        let c = U384::from_hex("2a47a603a77f871dfbb937af7e5710");
+        let a = U384::from_hex_unchecked("6131d99f840b3b0");
+        let b = U384::from_hex_unchecked("6f5c466db398f43");
+        let c = U384::from_hex_unchecked("2a47a603a77f871dfbb937af7e5710");
         assert_eq!(a * b, c);
     }
 
     #[test]
     fn mul_two_384_bit_integers_works_3() {
-        let a = U384::from_hex("84a6add5db9e095b2e0f6b40eff8ee");
-        let b = U384::from_hex("2347db918f725461bec2d5c57");
-        let c = U384::from_hex("124805c476c9462adc0df6c88495d4253f5c38033afc18d78d920e2");
+        let a = U384::from_hex_unchecked("84a6add5db9e095b2e0f6b40eff8ee");
+        let b = U384::from_hex_unchecked("2347db918f725461bec2d5c57");
+        let c = U384::from_hex_unchecked("124805c476c9462adc0df6c88495d4253f5c38033afc18d78d920e2");
         assert_eq!(a * b, c);
     }
 
     #[test]
     fn mul_two_384_bit_integers_works_4() {
-        let a = U384::from_hex("04050753dd7c0b06c404633016f87040");
-        let b = U384::from_hex("dc3830be041b3b4476445fcad3dac0f6f3a53e4ba12da");
-        let c = U384::from_hex(
+        let a = U384::from_hex_unchecked("04050753dd7c0b06c404633016f87040");
+        let b = U384::from_hex_unchecked("dc3830be041b3b4476445fcad3dac0f6f3a53e4ba12da");
+        let c = U384::from_hex_unchecked(
             "375342999dab7f52f4010c4abc2e18b55218015931a55d6053ac39e86e2a47d6b1cb95f41680",
         );
         assert_eq!(a * b, c);
@@ -1052,9 +1128,9 @@ mod tests_u384 {
 
     #[test]
     fn mul_two_384_bit_integers_works_5() {
-        let a = U384::from_hex("7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8");
-        let b = U384::from_hex("2");
-        let c_expected = U384::from_hex(
+        let a = U384::from_hex_unchecked("7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8");
+        let b = U384::from_hex_unchecked("2");
+        let c_expected = U384::from_hex_unchecked(
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0",
         );
         assert_eq!(a * b, c_expected);
@@ -1063,17 +1139,17 @@ mod tests_u384 {
     #[test]
     #[should_panic]
     fn mul_two_384_bit_integers_works_6() {
-        let a = U384::from_hex("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
-        let b = U384::from_hex("2");
+        let a = U384::from_hex_unchecked("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+        let b = U384::from_hex_unchecked("2");
         let _c = a * b;
     }
 
     #[test]
     fn mul_two_384_bit_integers_works_7_hi_lo() {
-        let a = U384::from_hex("04050753dd7c0b06c404633016f87040");
-        let b = U384::from_hex("dc3830be041b3b4476445fcad3dac0f6f3a53e4ba12da");
-        let hi_expected = U384::from_hex("0");
-        let lo_expected = U384::from_hex(
+        let a = U384::from_hex_unchecked("04050753dd7c0b06c404633016f87040");
+        let b = U384::from_hex_unchecked("dc3830be041b3b4476445fcad3dac0f6f3a53e4ba12da");
+        let hi_expected = U384::from_hex_unchecked("0");
+        let lo_expected = U384::from_hex_unchecked(
             "375342999dab7f52f4010c4abc2e18b55218015931a55d6053ac39e86e2a47d6b1cb95f41680",
         );
         let (hi, lo) = U384::mul(&a, &b);
@@ -1083,12 +1159,12 @@ mod tests_u384 {
 
     #[test]
     fn mul_two_384_bit_integers_works_8_hi_lo() {
-        let a = U384::from_hex("5e2d939b602a50911232731d04fe6f40c05f97da0602307099fb991f9b414e2d52bef130349ec18db1a0215ea6caf76");
-        let b = U384::from_hex("3f3ad1611ab58212f92a2484e9560935b9ac4615fe61cfed1a4861e193a74d20c94f9f88d8b2cc089543c3f699969d9");
-        let hi_expected = U384::from_hex(
+        let a = U384::from_hex_unchecked("5e2d939b602a50911232731d04fe6f40c05f97da0602307099fb991f9b414e2d52bef130349ec18db1a0215ea6caf76");
+        let b = U384::from_hex_unchecked("3f3ad1611ab58212f92a2484e9560935b9ac4615fe61cfed1a4861e193a74d20c94f9f88d8b2cc089543c3f699969d9");
+        let hi_expected = U384::from_hex_unchecked(
             "1742daad9c7861dd3499e7ece65467e337937b27e20d641b225bfe00323d33ed62715654eadc092b057a5f19f2ad6c",
         );
-        let lo_expected = U384::from_hex("9969c0417b9304d9c16b046c860447d3533999e16710d2e90a44959a168816c015ffb44b987e8cbb82bd46b08d9e2106");
+        let lo_expected = U384::from_hex_unchecked("9969c0417b9304d9c16b046c860447d3533999e16710d2e90a44959a168816c015ffb44b987e8cbb82bd46b08d9e2106");
         let (hi, lo) = U384::mul(&a, &b);
         assert_eq!(hi, hi_expected);
         assert_eq!(lo, lo_expected);
@@ -1096,10 +1172,10 @@ mod tests_u384 {
 
     #[test]
     fn mul_two_384_bit_integers_works_9_hi_lo() {
-        let a = U384::from_hex("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
-        let b = U384::from_hex("2");
-        let hi_expected = U384::from_hex("1");
-        let lo_expected = U384::from_hex("0");
+        let a = U384::from_hex_unchecked("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+        let b = U384::from_hex_unchecked("2");
+        let hi_expected = U384::from_hex_unchecked("1");
+        let lo_expected = U384::from_hex_unchecked("0");
         let (hi, lo) = U384::mul(&a, &b);
         assert_eq!(hi, hi_expected);
         assert_eq!(lo, lo_expected);
@@ -1107,8 +1183,8 @@ mod tests_u384 {
 
     #[test]
     fn shift_left_on_384_bit_integer_works_1() {
-        let a = U384::from_hex("1");
-        let b = U384::from_hex("10");
+        let a = U384::from_hex_unchecked("1");
+        let b = U384::from_hex_unchecked("10");
         assert_eq!(a << 4, b);
     }
 
@@ -1121,29 +1197,29 @@ mod tests_u384 {
 
     #[test]
     fn shift_left_on_384_bit_integer_works_3() {
-        let a = U384::from_hex("10");
-        let b = U384::from_hex("1000");
+        let a = U384::from_hex_unchecked("10");
+        let b = U384::from_hex_unchecked("1000");
         assert_eq!(&a << 8, b);
     }
 
     #[test]
     fn shift_left_on_384_bit_integer_works_4() {
-        let a = U384::from_hex("e45542992b6844553f3cb1c5ac33e7fa5");
-        let b = U384::from_hex("391550a64ada11154fcf2c716b0cf9fe940");
+        let a = U384::from_hex_unchecked("e45542992b6844553f3cb1c5ac33e7fa5");
+        let b = U384::from_hex_unchecked("391550a64ada11154fcf2c716b0cf9fe940");
         assert_eq!(a << 6, b);
     }
 
     #[test]
     fn shift_left_on_384_bit_integer_works_5() {
-        let a = U384::from_hex("03303f4d6c2d1caf0c24a6b0239b679a8390aa99bead76bc0093b1bc1a8101f5ce");
-        let b = U384::from_hex("6607e9ad85a395e18494d604736cf35072155337d5aed7801276378350203eb9c0000000000000000000000000000000");
+        let a = U384::from_hex_unchecked("03303f4d6c2d1caf0c24a6b0239b679a8390aa99bead76bc0093b1bc1a8101f5ce");
+        let b = U384::from_hex_unchecked("6607e9ad85a395e18494d604736cf35072155337d5aed7801276378350203eb9c0000000000000000000000000000000");
         assert_eq!(&a << 125, b);
     }
 
     #[test]
     fn shift_left_on_384_bit_integer_works_6() {
-        let a = U384::from_hex("762e8968bc392ed786ab132f0b5b0cacd385dd51de3a");
-        let b = U384::from_hex(
+        let a = U384::from_hex_unchecked("762e8968bc392ed786ab132f0b5b0cacd385dd51de3a");
+        let b = U384::from_hex_unchecked(
             "762e8968bc392ed786ab132f0b5b0cacd385dd51de3a00000000000000000000000000000000",
         );
         assert_eq!(&a << (64 * 2), b);
@@ -1151,65 +1227,65 @@ mod tests_u384 {
 
     #[test]
     fn shift_left_on_384_bit_integer_works_7() {
-        let a = U384::from_hex("90823e0bd707f");
-        let b = U384::from_hex("90823e0bd707f000000000000000000000000000000000000000000000000");
+        let a = U384::from_hex_unchecked("90823e0bd707f");
+        let b = U384::from_hex_unchecked("90823e0bd707f000000000000000000000000000000000000000000000000");
         assert_eq!(&a << (64 * 3), b);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_1() {
-        let a = U384::from_hex("1");
-        let b = U384::from_hex("10");
+        let a = U384::from_hex_unchecked("1");
+        let b = U384::from_hex_unchecked("10");
         assert_eq!(b >> 4, a);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_2() {
-        let a = U384::from_hex("10");
-        let b = U384::from_hex("1000");
+        let a = U384::from_hex_unchecked("10");
+        let b = U384::from_hex_unchecked("1000");
         assert_eq!(&b >> 8, a);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_3() {
-        let a = U384::from_hex("e45542992b6844553f3cb1c5ac33e7fa5");
-        let b = U384::from_hex("391550a64ada11154fcf2c716b0cf9fe940");
+        let a = U384::from_hex_unchecked("e45542992b6844553f3cb1c5ac33e7fa5");
+        let b = U384::from_hex_unchecked("391550a64ada11154fcf2c716b0cf9fe940");
         assert_eq!(b >> 6, a);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_4() {
-        let a = U384::from_hex("03303f4d6c2d1caf0c24a6b0239b679a8390aa99bead76bc0093b1bc1a8101f5ce");
-        let b = U384::from_hex("6607e9ad85a395e18494d604736cf35072155337d5aed7801276378350203eb9c0000000000000000000000000000000");
+        let a = U384::from_hex_unchecked("03303f4d6c2d1caf0c24a6b0239b679a8390aa99bead76bc0093b1bc1a8101f5ce");
+        let b = U384::from_hex_unchecked("6607e9ad85a395e18494d604736cf35072155337d5aed7801276378350203eb9c0000000000000000000000000000000");
         assert_eq!(&b >> 125, a);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_5() {
-        let a = U384::from_hex("ba6ab46f9a9a2f20e4061b67ce4d8c3da98091cf990d7b14ef47ffe27370abbdeb6a3ce9f9cbf5df1b2430114c8558eb");
-        let b = U384::from_hex("174d568df35345e41c80c36cf9c9b187b5301239f321af629de8fffc4e6");
+        let a = U384::from_hex_unchecked("ba6ab46f9a9a2f20e4061b67ce4d8c3da98091cf990d7b14ef47ffe27370abbdeb6a3ce9f9cbf5df1b2430114c8558eb");
+        let b = U384::from_hex_unchecked("174d568df35345e41c80c36cf9c9b187b5301239f321af629de8fffc4e6");
         assert_eq!(a >> 151, b);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_6() {
         let a =
-            U384::from_hex("076c075d2f65e39b9ecdde8bf6f8c94241962ce0f557b7739673200c777152eb7e772ad35");
-        let b = U384::from_hex("ed80eba5ecbc7373d9bbd17edf19284832c59c1eaaf6ee7");
+            U384::from_hex_unchecked("076c075d2f65e39b9ecdde8bf6f8c94241962ce0f557b7739673200c777152eb7e772ad35");
+        let b = U384::from_hex_unchecked("ed80eba5ecbc7373d9bbd17edf19284832c59c1eaaf6ee7");
         assert_eq!(&a >> 99, b);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_7() {
-        let a = U384::from_hex("6a9ce35d8940a5ebd29604ce9a182ade76f03f7e9965760b84a8cfd1d3dd2e612669fe000e58b2af688fd90");
-        let b = U384::from_hex("6a9ce35d8940a5ebd29604ce9a182ade76f03f7");
+        let a = U384::from_hex_unchecked("6a9ce35d8940a5ebd29604ce9a182ade76f03f7e9965760b84a8cfd1d3dd2e612669fe000e58b2af688fd90");
+        let b = U384::from_hex_unchecked("6a9ce35d8940a5ebd29604ce9a182ade76f03f7");
         assert_eq!(&a >> (64 * 3), b);
     }
 
     #[test]
     fn shift_right_on_384_bit_integer_works_8() {
-        let a = U384::from_hex("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c5265bd7db75c90b2665a0826d17600f0e9");
-        let b = U384::from_hex("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c52");
+        let a = U384::from_hex_unchecked("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c5265bd7db75c90b2665a0826d17600f0e9");
+        let b = U384::from_hex_unchecked("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c52");
         assert_eq!(&a >> (64 * 2), b);
     }
 
@@ -1333,43 +1409,43 @@ mod tests_u256 {
 
     #[test]
     fn construct_new_integer_from_hex_1() {
-        let a = U256::from_hex("1");
+        let a = U256::from_hex_unchecked("1");
         assert_eq!(a.limbs, [0, 0, 0, 1]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_2() {
-        let a = U256::from_hex("f");
+        let a = U256::from_hex_unchecked("f");
         assert_eq!(a.limbs, [0, 0, 0, 15]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_3() {
-        let a = U256::from_hex("10000000000000000");
+        let a = U256::from_hex_unchecked("10000000000000000");
         assert_eq!(a.limbs, [0, 0, 1, 0]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_4() {
-        let a = U256::from_hex("a0000000000000000");
+        let a = U256::from_hex_unchecked("a0000000000000000");
         assert_eq!(a.limbs, [0, 0, 10, 0]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_5() {
-        let a = U256::from_hex("ffffffffffffffffff");
+        let a = U256::from_hex_unchecked("ffffffffffffffffff");
         assert_eq!(a.limbs, [0, 0, 255, u64::MAX]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_6() {
-        let a = U256::from_hex("eb235f6144d9e91f4b14");
+        let a = U256::from_hex_unchecked("eb235f6144d9e91f4b14");
         assert_eq!(a.limbs, [0, 0, 60195, 6872850209053821716]);
     }
 
     #[test]
     fn construct_new_integer_from_hex_7() {
-        let a = U256::from_hex("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
+        let a = U256::from_hex_unchecked("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
         assert_eq!(
             a.limbs,
             [
@@ -1383,7 +1459,7 @@ mod tests_u256 {
 
     #[test]
     fn construct_new_integer_from_hex_8() {
-        let a = U256::from_hex("2B20AAA5CF482B239E2897A787FAF4660CC95597854BEB235F6144D9E91F4B14");
+        let a = U256::from_hex_unchecked("2B20AAA5CF482B239E2897A787FAF4660CC95597854BEB235F6144D9E91F4B14");
         assert_eq!(
             a.limbs,
             [
@@ -1397,7 +1473,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_1() {
-        let a = U256::from_hex("1");
+        let a = U256::from_hex_unchecked("1");
         let b = U256 {
             limbs: [0, 0, 0, 1],
         };
@@ -1405,7 +1481,7 @@ mod tests_u256 {
     }
     #[test]
     fn equality_works_2() {
-        let a = U256::from_hex("f");
+        let a = U256::from_hex_unchecked("f");
         let b = U256 {
             limbs: [0, 0, 0, 15],
         };
@@ -1414,7 +1490,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_3() {
-        let a = U256::from_hex("10000000000000000");
+        let a = U256::from_hex_unchecked("10000000000000000");
         let b = U256 {
             limbs: [0, 0, 1, 0],
         };
@@ -1423,7 +1499,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_4() {
-        let a = U256::from_hex("a0000000000000000");
+        let a = U256::from_hex_unchecked("a0000000000000000");
         let b = U256 {
             limbs: [0, 0, 10, 0],
         };
@@ -1432,7 +1508,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_5() {
-        let a = U256::from_hex("ffffffffffffffffff");
+        let a = U256::from_hex_unchecked("ffffffffffffffffff");
         let b = U256 {
             limbs: [0, 0, u8::MAX as u64, u64::MAX],
         };
@@ -1441,7 +1517,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_6() {
-        let a = U256::from_hex("eb235f6144d9e91f4b14");
+        let a = U256::from_hex_unchecked("eb235f6144d9e91f4b14");
         let b = U256 {
             limbs: [0, 0, 60195, 6872850209053821716],
         };
@@ -1450,7 +1526,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_7() {
-        let a = U256::from_hex("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
+        let a = U256::from_hex_unchecked("2b20aaa5cf482b239e2897a787faf4660cc95597854beb2");
         let b = U256 {
             limbs: [
                 0,
@@ -1464,7 +1540,7 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_8() {
-        let a = U256::from_hex("2B20AAA5CF482B239E2897A787FAF4660CC95597854BEB235F6144D9E91F4B14");
+        let a = U256::from_hex_unchecked("2B20AAA5CF482B239E2897A787FAF4660CC95597854BEB235F6144D9E91F4B14");
         let b = U256 {
             limbs: [
                 3107671372009581347,
@@ -1478,15 +1554,15 @@ mod tests_u256 {
 
     #[test]
     fn equality_works_9() {
-        let a = U256::from_hex("fffffff");
-        let b = U256::from_hex("fefffff");
+        let a = U256::from_hex_unchecked("fffffff");
+        let b = U256::from_hex_unchecked("fefffff");
         assert_ne!(a, b);
     }
 
     #[test]
     fn equality_works_10() {
-        let a = U256::from_hex("ffff000000000000");
-        let b = U256::from_hex("ffff000000100000");
+        let a = U256::from_hex_unchecked("ffff000000000000");
+        let b = U256::from_hex_unchecked("ffff000000100000");
         assert_ne!(a, b);
     }
 
@@ -1508,66 +1584,66 @@ mod tests_u256 {
 
     #[test]
     fn add_two_256_bit_integers_3() {
-        let a = U256::from_hex("ffffffffffffffff");
-        let b = U256::from_hex("1");
-        let c = U256::from_hex("10000000000000000");
+        let a = U256::from_hex_unchecked("ffffffffffffffff");
+        let b = U256::from_hex_unchecked("1");
+        let c = U256::from_hex_unchecked("10000000000000000");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_4() {
-        let a = U256::from_hex("b58e1e0b66");
-        let b = U256::from_hex("55469d9619");
-        let c = U256::from_hex("10ad4bba17f");
+        let a = U256::from_hex_unchecked("b58e1e0b66");
+        let b = U256::from_hex_unchecked("55469d9619");
+        let c = U256::from_hex_unchecked("10ad4bba17f");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_5() {
-        let a = U256::from_hex("e8dff25cb6160f7705221da6f");
-        let b = U256::from_hex("ab879169b5f80dc8a7969f0b0");
-        let c = U256::from_hex("1946783c66c0e1d3facb8bcb1f");
+        let a = U256::from_hex_unchecked("e8dff25cb6160f7705221da6f");
+        let b = U256::from_hex_unchecked("ab879169b5f80dc8a7969f0b0");
+        let c = U256::from_hex_unchecked("1946783c66c0e1d3facb8bcb1f");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_6() {
-        let a = U256::from_hex("9adf291af3a64d59e14e7b440c850508014c551ed5");
-        let b = U256::from_hex("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
-        let c = U256::from_hex("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
+        let a = U256::from_hex_unchecked("9adf291af3a64d59e14e7b440c850508014c551ed5");
+        let b = U256::from_hex_unchecked("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
+        let c = U256::from_hex_unchecked("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_7() {
-        let a = U256::from_hex("10d3bc05496380cfe27bf5d97ddb99ac95eb5ecfbd3907eadf877a4c2dfa05f6");
-        let b = U256::from_hex("0866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9");
-        let c = U256::from_hex("193a6afd4d2cacc01101bdd44ec864f517b0f6f5a1d3020dd91594dc1de752cf");
+        let a = U256::from_hex_unchecked("10d3bc05496380cfe27bf5d97ddb99ac95eb5ecfbd3907eadf877a4c2dfa05f6");
+        let b = U256::from_hex_unchecked("0866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9");
+        let c = U256::from_hex_unchecked("193a6afd4d2cacc01101bdd44ec864f517b0f6f5a1d3020dd91594dc1de752cf");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_8() {
-        let a = U256::from_hex("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580f");
-        let b = U256::from_hex("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9c");
-        let c = U256::from_hex("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
+        let a = U256::from_hex_unchecked("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580f");
+        let b = U256::from_hex_unchecked("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9c");
+        let c = U256::from_hex_unchecked("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_9() {
-        let a = U256::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
-        let b = U256::from_hex("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
-        let c = U256::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
+        let a = U256::from_hex_unchecked("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
+        let b = U256::from_hex_unchecked("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
+        let c = U256::from_hex_unchecked("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn add_two_256_bit_integers_10() {
-        let a = U256::from_hex("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580f");
-        let b = U256::from_hex("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9c");
+        let a = U256::from_hex_unchecked("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580f");
+        let b = U256::from_hex_unchecked("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9c");
         let c_expected =
-            U256::from_hex("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
+            U256::from_hex_unchecked("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
         let (c, overflow) = U256::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(!overflow);
@@ -1575,10 +1651,10 @@ mod tests_u256 {
 
     #[test]
     fn add_two_256_bit_integers_11() {
-        let a = U256::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
-        let b = U256::from_hex("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
+        let a = U256::from_hex_unchecked("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
+        let b = U256::from_hex_unchecked("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
         let c_expected =
-            U256::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
+            U256::from_hex_unchecked("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
         let (c, overflow) = U256::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(!overflow);
@@ -1586,10 +1662,10 @@ mod tests_u256 {
 
     #[test]
     fn add_two_256_bit_integers_12_with_overflow() {
-        let a = U256::from_hex("b07bc844363dd56467d9ebdd5929e9bb34a8e2577db77df6cf8f2ac45bd3d0bc");
-        let b = U256::from_hex("cbbc474761bb7995ff54e25fa5d30295604fe3545d0cde405e72d8c0acebb119");
+        let a = U256::from_hex_unchecked("b07bc844363dd56467d9ebdd5929e9bb34a8e2577db77df6cf8f2ac45bd3d0bc");
+        let b = U256::from_hex_unchecked("cbbc474761bb7995ff54e25fa5d30295604fe3545d0cde405e72d8c0acebb119");
         let c_expected =
-            U256::from_hex("7c380f8b97f94efa672ece3cfefcec5094f8c5abdac45c372e02038508bf81d5");
+            U256::from_hex_unchecked("7c380f8b97f94efa672ece3cfefcec5094f8c5abdac45c372e02038508bf81d5");
         let (c, overflow) = U256::add(&a, &b);
         assert_eq!(c, c_expected);
         assert!(overflow);
@@ -1613,57 +1689,57 @@ mod tests_u256 {
 
     #[test]
     fn sub_two_256_bit_integers_3() {
-        let a = U256::from_hex("ffffffffffffffff");
-        let b = U256::from_hex("1");
-        let c = U256::from_hex("10000000000000000");
+        let a = U256::from_hex_unchecked("ffffffffffffffff");
+        let b = U256::from_hex_unchecked("1");
+        let c = U256::from_hex_unchecked("10000000000000000");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_4() {
-        let a = U256::from_hex("b58e1e0b66");
-        let b = U256::from_hex("55469d9619");
-        let c = U256::from_hex("10ad4bba17f");
+        let a = U256::from_hex_unchecked("b58e1e0b66");
+        let b = U256::from_hex_unchecked("55469d9619");
+        let c = U256::from_hex_unchecked("10ad4bba17f");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_5() {
-        let a = U256::from_hex("e8dff25cb6160f7705221da6f");
-        let b = U256::from_hex("ab879169b5f80dc8a7969f0b0");
-        let c = U256::from_hex("1946783c66c0e1d3facb8bcb1f");
+        let a = U256::from_hex_unchecked("e8dff25cb6160f7705221da6f");
+        let b = U256::from_hex_unchecked("ab879169b5f80dc8a7969f0b0");
+        let c = U256::from_hex_unchecked("1946783c66c0e1d3facb8bcb1f");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_6() {
-        let a = U256::from_hex("9adf291af3a64d59e14e7b440c850508014c551ed5");
-        let b = U256::from_hex("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
-        let c = U256::from_hex("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
+        let a = U256::from_hex_unchecked("9adf291af3a64d59e14e7b440c850508014c551ed5");
+        let b = U256::from_hex_unchecked("e7948474bce907f0feaf7e5d741a8cd2f6d1fb9448");
+        let c = U256::from_hex_unchecked("18273ad8fb08f554adffdf9a1809f91daf81e50b31d");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_7() {
-        let a = U256::from_hex("9b4000dccf01a010e196154a1b998408f949d734389626ba97cb3331ee87e01d");
-        let b = U256::from_hex("5d26ae1b34c78bdf4cefb2b0b553473f887bc0f1ac03d36861c2e75e01656cbc");
-        let c = U256::from_hex("f866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9");
+        let a = U256::from_hex_unchecked("9b4000dccf01a010e196154a1b998408f949d734389626ba97cb3331ee87e01d");
+        let b = U256::from_hex_unchecked("5d26ae1b34c78bdf4cefb2b0b553473f887bc0f1ac03d36861c2e75e01656cbc");
+        let c = U256::from_hex_unchecked("f866aef803c92bf02e85c7fad0eccb4881c59825e499fa22f98e1a8fefed4cd9");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_8() {
-        let a = U256::from_hex("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580e");
-        let b = U256::from_hex("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9d");
-        let c = U256::from_hex("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
+        let a = U256::from_hex_unchecked("07df9c74fa9d5aafa74a87dbbf93215659d8a3e1706d4b06de9512284802580e");
+        let b = U256::from_hex_unchecked("d515e54973f0643a6a9957579c1f84020a6a91d5d5f27b75401c7538d2c9ea9d");
+        let c = U256::from_hex_unchecked("dcf581be6e8dbeea11e3df335bb2a558644335b7465fc67c1eb187611acc42ab");
         assert_eq!(c - a, b);
     }
 
     #[test]
     fn sub_two_256_bit_integers_9() {
-        let a = U256::from_hex("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
-        let b = U256::from_hex("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
-        let c = U256::from_hex("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
+        let a = U256::from_hex_unchecked("92977527a0f8ba00d18c1b2f1900d965d4a70e5f5f54468ffb2d4d41519385f2");
+        let b = U256::from_hex_unchecked("46facf9953a9494822bf18836ffd7e55c48b30aa81e17fa1ace0b473015307e4");
+        let c = U256::from_hex_unchecked("d99244c0f4a20348f44b33b288fe57bb99323f09e135c631a80e01b452e68dd6");
         assert_eq!(c - a, b);
     }
 
@@ -1681,7 +1757,7 @@ mod tests_u256 {
     fn sub_two_256_bit_integers_11_with_overflow() {
         let a = U256::from_u64(334);
         let b_expected =
-            U256::from_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd66");
+            U256::from_hex_unchecked("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd66");
         let c = U256::from_u64(1000);
         let (b, overflow) = U256::sub(&a, &c);
         assert!(overflow);
@@ -1698,8 +1774,8 @@ mod tests_u256 {
         assert!(U256::from_u64(2) > U256::from_u64(1));
         assert!(U256::from_u64(1) <= U256::from_u64(2));
 
-        let a = U256::from_hex("5d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
-        let c = U256::from_hex("b99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
+        let a = U256::from_hex_unchecked("5d4a70e5f5f54468ffb2d4d41519385f24b078a0e7d0281d5ad0c36724dc4233");
+        let c = U256::from_hex_unchecked("b99323f09e135c631a80e01b452e68dd6ad3315e5776b713af4a2d7f5f9a2a75");
 
         assert!(&a <= &a);
         assert!(&a >= &a);
@@ -1730,37 +1806,37 @@ mod tests_u256 {
 
     #[test]
     fn mul_two_256_bit_integers_works_2() {
-        let a = U256::from_hex("6131d99f840b3b0");
-        let b = U256::from_hex("6f5c466db398f43");
-        let c = U256::from_hex("2a47a603a77f871dfbb937af7e5710");
+        let a = U256::from_hex_unchecked("6131d99f840b3b0");
+        let b = U256::from_hex_unchecked("6f5c466db398f43");
+        let c = U256::from_hex_unchecked("2a47a603a77f871dfbb937af7e5710");
         assert_eq!(a * b, c);
     }
 
     #[test]
     fn mul_two_256_bit_integers_works_3() {
-        let a = U256::from_hex("84a6add5db9e095b2e0f6b40eff8ee");
-        let b = U256::from_hex("2347db918f725461bec2d5c57");
-        let c = U256::from_hex("124805c476c9462adc0df6c88495d4253f5c38033afc18d78d920e2");
+        let a = U256::from_hex_unchecked("84a6add5db9e095b2e0f6b40eff8ee");
+        let b = U256::from_hex_unchecked("2347db918f725461bec2d5c57");
+        let c = U256::from_hex_unchecked("124805c476c9462adc0df6c88495d4253f5c38033afc18d78d920e2");
         assert_eq!(a * b, c);
     }
 
     #[test]
     fn mul_two_256_bit_integers_works_4() {
-        let a = U256::from_hex("15bf61fcf53a3f0ae1e8e555d");
-        let b = U256::from_hex("cbbc474761bb7995ff54e25fa5d5d0cde405e9f");
+        let a = U256::from_hex_unchecked("15bf61fcf53a3f0ae1e8e555d");
+        let b = U256::from_hex_unchecked("cbbc474761bb7995ff54e25fa5d5d0cde405e9f");
         let c_expected =
-            U256::from_hex("114ec14db0c80d30b7dcb9c45948ef04cc149e612cb544f447b146553aff2ac3");
+            U256::from_hex_unchecked("114ec14db0c80d30b7dcb9c45948ef04cc149e612cb544f447b146553aff2ac3");
         assert_eq!(a * b, c_expected);
     }
 
     #[test]
     fn mul_two_256_bit_integers_works_5_hi_lo() {
-        let a = U256::from_hex("8e2d939b602a50911232731d04fe6f40c05f97da0602307099fb991f9b414e2d");
-        let b = U256::from_hex("7f3ad1611ab58212f92a2484e9560935b9ac4615fe61cfed1a4861e193a74d20");
+        let a = U256::from_hex_unchecked("8e2d939b602a50911232731d04fe6f40c05f97da0602307099fb991f9b414e2d");
+        let b = U256::from_hex_unchecked("7f3ad1611ab58212f92a2484e9560935b9ac4615fe61cfed1a4861e193a74d20");
         let hi_expected =
-            U256::from_hex("46A946D6A984FE6507DE6B8D1354256D7A7BAE4283404733BDC876A264BCE5EE");
+            U256::from_hex_unchecked("46A946D6A984FE6507DE6B8D1354256D7A7BAE4283404733BDC876A264BCE5EE");
         let lo_expected =
-            U256::from_hex("43F24263F10930EBE3EA0307466C19B13B9C7DBA6B3F7604B7F32FB0E3084EA0");
+            U256::from_hex_unchecked("43F24263F10930EBE3EA0307466C19B13B9C7DBA6B3F7604B7F32FB0E3084EA0");
         let (hi, lo) = U256::mul(&a, &b);
         assert_eq!(hi, hi_expected);
         assert_eq!(lo, lo_expected);
@@ -1768,8 +1844,8 @@ mod tests_u256 {
 
     #[test]
     fn shift_left_on_256_bit_integer_works_1() {
-        let a = U256::from_hex("1");
-        let b = U256::from_hex("10");
+        let a = U256::from_hex_unchecked("1");
+        let b = U256::from_hex_unchecked("10");
         assert_eq!(a << 4, b);
     }
 
@@ -1782,92 +1858,92 @@ mod tests_u256 {
 
     #[test]
     fn shift_left_on_256_bit_integer_works_3() {
-        let a = U256::from_hex("10");
-        let b = U256::from_hex("1000");
+        let a = U256::from_hex_unchecked("10");
+        let b = U256::from_hex_unchecked("1000");
         assert_eq!(&a << 8, b);
     }
 
     #[test]
     fn shift_left_on_256_bit_integer_works_4() {
-        let a = U256::from_hex("e45542992b6844553f3cb1c5ac33e7fa5");
-        let b = U256::from_hex("391550a64ada11154fcf2c716b0cf9fe940");
+        let a = U256::from_hex_unchecked("e45542992b6844553f3cb1c5ac33e7fa5");
+        let b = U256::from_hex_unchecked("391550a64ada11154fcf2c716b0cf9fe940");
         assert_eq!(a << 6, b);
     }
 
     #[test]
     fn shift_left_on_256_bit_integer_works_5() {
-        let a = U256::from_hex("a8390aa99bead76bc0093b1bc1a8101f5ce");
-        let b = U256::from_hex("72155337d5aed7801276378350203eb9c0000000000000000000000000000000");
+        let a = U256::from_hex_unchecked("a8390aa99bead76bc0093b1bc1a8101f5ce");
+        let b = U256::from_hex_unchecked("72155337d5aed7801276378350203eb9c0000000000000000000000000000000");
         assert_eq!(&a << 125, b);
     }
 
     #[test]
     fn shift_left_on_256_bit_integer_works_6() {
-        let a = U256::from_hex("2ed786ab132f0b5b0cacd385dd51de3a");
-        let b = U256::from_hex("2ed786ab132f0b5b0cacd385dd51de3a00000000000000000000000000000000");
+        let a = U256::from_hex_unchecked("2ed786ab132f0b5b0cacd385dd51de3a");
+        let b = U256::from_hex_unchecked("2ed786ab132f0b5b0cacd385dd51de3a00000000000000000000000000000000");
         assert_eq!(&a << (64 * 2), b);
     }
 
     #[test]
     fn shift_left_on_256_bit_integer_works_7() {
-        let a = U256::from_hex("90823e0bd707f");
-        let b = U256::from_hex("90823e0bd707f000000000000000000000000000000000000000000000000");
+        let a = U256::from_hex_unchecked("90823e0bd707f");
+        let b = U256::from_hex_unchecked("90823e0bd707f000000000000000000000000000000000000000000000000");
         assert_eq!(&a << (64 * 3), b);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_1() {
-        let a = U256::from_hex("1");
-        let b = U256::from_hex("10");
+        let a = U256::from_hex_unchecked("1");
+        let b = U256::from_hex_unchecked("10");
         assert_eq!(b >> 4, a);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_2() {
-        let a = U256::from_hex("10");
-        let b = U256::from_hex("1000");
+        let a = U256::from_hex_unchecked("10");
+        let b = U256::from_hex_unchecked("1000");
         assert_eq!(&b >> 8, a);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_3() {
-        let a = U256::from_hex("e45542992b6844553f3cb1c5ac33e7fa5");
-        let b = U256::from_hex("391550a64ada11154fcf2c716b0cf9fe940");
+        let a = U256::from_hex_unchecked("e45542992b6844553f3cb1c5ac33e7fa5");
+        let b = U256::from_hex_unchecked("391550a64ada11154fcf2c716b0cf9fe940");
         assert_eq!(b >> 6, a);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_4() {
-        let a = U256::from_hex("390aa99bead76bc0093b1bc1a8101f5ce");
-        let b = U256::from_hex("72155337d5aed7801276378350203eb9c0000000000000000000000000000000");
+        let a = U256::from_hex_unchecked("390aa99bead76bc0093b1bc1a8101f5ce");
+        let b = U256::from_hex_unchecked("72155337d5aed7801276378350203eb9c0000000000000000000000000000000");
         assert_eq!(&b >> 125, a);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_5() {
-        let a = U256::from_hex("ba6ab46f9a9a2f20e4061b67ce4d8c3da98091cf990d7b14ef47ffe27370abbd");
-        let b = U256::from_hex("174d568df35345e41c80c36cf9c");
+        let a = U256::from_hex_unchecked("ba6ab46f9a9a2f20e4061b67ce4d8c3da98091cf990d7b14ef47ffe27370abbd");
+        let b = U256::from_hex_unchecked("174d568df35345e41c80c36cf9c");
         assert_eq!(a >> 151, b);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_6() {
-        let a = U256::from_hex("076c075d2f65e39b9ecdde8bf6f8c94241962ce0f557b7739673200c777152eb");
-        let b = U256::from_hex("ed80eba5ecbc7373d9bbd17edf19284832c59c");
+        let a = U256::from_hex_unchecked("076c075d2f65e39b9ecdde8bf6f8c94241962ce0f557b7739673200c777152eb");
+        let b = U256::from_hex_unchecked("ed80eba5ecbc7373d9bbd17edf19284832c59c");
         assert_eq!(&a >> 99, b);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_7() {
-        let a = U256::from_hex("6a9ce35d8940a5ebd29604ce9a182ade76f03f7e9965760b84a8cfd1d3dd2e61");
-        let b = U256::from_hex("6a9ce35d8940a5eb");
+        let a = U256::from_hex_unchecked("6a9ce35d8940a5ebd29604ce9a182ade76f03f7e9965760b84a8cfd1d3dd2e61");
+        let b = U256::from_hex_unchecked("6a9ce35d8940a5eb");
         assert_eq!(&a >> (64 * 3), b);
     }
 
     #[test]
     fn shift_right_on_256_bit_integer_works_8() {
-        let a = U256::from_hex("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c5265bd7");
-        let b = U256::from_hex("5322c128ec84081b6c376c108ebd7fd3");
+        let a = U256::from_hex_unchecked("5322c128ec84081b6c376c108ebd7fd36bbd44f71ee5e6ad6bcb3dd1c5265bd7");
+        let b = U256::from_hex_unchecked("5322c128ec84081b6c376c108ebd7fd3");
         assert_eq!(&a >> (64 * 2), b);
     }
 

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -300,7 +300,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         true
     }
 
-    /// Creates an `UnsignedInteger` from a hexstring. It can contain `0x` or not. 
+    /// Creates an `UnsignedInteger` from a hexstring. It can contain `0x` or not.
     /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring
     pub fn from_hex(value: &str) -> Result<Self, CreationError> {
         let mut string = value;
@@ -321,7 +321,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         Ok(Self::from_hex_unchecked(string))
     }
 
-    /// Creates an `UnsignedInteger` from a hexstring. It can contain `0x` or not. 
+    /// Creates an `UnsignedInteger` from a hexstring. It can contain `0x` or not.
     /// # Panics
     /// Panics if value is not a hexstring
     pub const fn from_hex_unchecked(value: &str) -> Self {

--- a/math/src/unsigned_integer/montgomery.rs
+++ b/math/src/unsigned_integer/montgomery.rs
@@ -93,21 +93,21 @@ mod tests {
 
     #[test]
     fn montgomery_multiplication_works_1() {
-        let x = U384::from("05ed176deb0e80b4deb7718cdaa075165f149c");
-        let y = U384::from("5f103b0bd4397d4df560eb559f38353f80eeb6");
-        let m = U384::from("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
+        let x = U384::from_hex("05ed176deb0e80b4deb7718cdaa075165f149c");
+        let y = U384::from_hex("5f103b0bd4397d4df560eb559f38353f80eeb6");
+        let m = U384::from_hex("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
         let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
-        let c = U384::from("8d65cdee621682815d59f465d2641eea8a1274dc"); // x * y * (r^{-1}) % m, where r = 2^{64 * 6}
+        let c = U384::from_hex("8d65cdee621682815d59f465d2641eea8a1274dc"); // x * y * (r^{-1}) % m, where r = 2^{64 * 6}
         assert_eq!(MontgomeryAlgorithms::cios(&x, &y, &m, &mu), c);
     }
 
     #[test]
     fn montgomery_multiplication_works_3() {
-        let x = U384::from("8d65cdee621682815d59f465d2641eea8a1274dc");
-        let m = U384::from("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
-        let r_mod_m = U384::from("58dfb0e1b3dd5e674bdcde4f42eb5533b8759d33");
+        let x = U384::from_hex("8d65cdee621682815d59f465d2641eea8a1274dc");
+        let m = U384::from_hex("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
+        let r_mod_m = U384::from_hex("58dfb0e1b3dd5e674bdcde4f42eb5533b8759d33");
         let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
-        let c = U384::from("8d65cdee621682815d59f465d2641eea8a1274dc");
+        let c = U384::from_hex("8d65cdee621682815d59f465d2641eea8a1274dc");
         assert_eq!(MontgomeryAlgorithms::cios(&x, &r_mod_m, &m, &mu), c);
     }
 }

--- a/math/src/unsigned_integer/montgomery.rs
+++ b/math/src/unsigned_integer/montgomery.rs
@@ -93,21 +93,21 @@ mod tests {
 
     #[test]
     fn montgomery_multiplication_works_1() {
-        let x = U384::from_hex("05ed176deb0e80b4deb7718cdaa075165f149c");
-        let y = U384::from_hex("5f103b0bd4397d4df560eb559f38353f80eeb6");
-        let m = U384::from_hex("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
+        let x = U384::from_hex_unchecked("05ed176deb0e80b4deb7718cdaa075165f149c");
+        let y = U384::from_hex_unchecked("5f103b0bd4397d4df560eb559f38353f80eeb6");
+        let m = U384::from_hex_unchecked("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
         let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
-        let c = U384::from_hex("8d65cdee621682815d59f465d2641eea8a1274dc"); // x * y * (r^{-1}) % m, where r = 2^{64 * 6}
+        let c = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc"); // x * y * (r^{-1}) % m, where r = 2^{64 * 6}
         assert_eq!(MontgomeryAlgorithms::cios(&x, &y, &m, &mu), c);
     }
 
     #[test]
     fn montgomery_multiplication_works_3() {
-        let x = U384::from_hex("8d65cdee621682815d59f465d2641eea8a1274dc");
-        let m = U384::from_hex("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
-        let r_mod_m = U384::from_hex("58dfb0e1b3dd5e674bdcde4f42eb5533b8759d33");
+        let x = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc");
+        let m = U384::from_hex_unchecked("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
+        let r_mod_m = U384::from_hex_unchecked("58dfb0e1b3dd5e674bdcde4f42eb5533b8759d33");
         let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
-        let c = U384::from_hex("8d65cdee621682815d59f465d2641eea8a1274dc");
+        let c = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc");
         assert_eq!(MontgomeryAlgorithms::cios(&x, &r_mod_m, &m, &mu), c);
     }
 }

--- a/proving_system/plonk/src/prover.rs
+++ b/proving_system/plonk/src/prover.rs
@@ -493,23 +493,33 @@ mod tests {
     use super::*;
 
     fn alpha() -> FrElement {
-        FrElement::from_hex_unchecked("583cfb0df2ef98f2131d717bc6aadd571c5302597c135cab7c00435817bf6e50")
+        FrElement::from_hex_unchecked(
+            "583cfb0df2ef98f2131d717bc6aadd571c5302597c135cab7c00435817bf6e50",
+        )
     }
 
     fn beta() -> FrElement {
-        FrElement::from_hex_unchecked("bdda7414bdf5bf42b77cbb3af4a82f32ec7622dd6c71575bede021e6e4609d4")
+        FrElement::from_hex_unchecked(
+            "bdda7414bdf5bf42b77cbb3af4a82f32ec7622dd6c71575bede021e6e4609d4",
+        )
     }
 
     fn gamma() -> FrElement {
-        FrElement::from_hex_unchecked("58f6690d9b36e62e4a0aef27612819288df2a3ff5bf01597cf06779503f51583")
+        FrElement::from_hex_unchecked(
+            "58f6690d9b36e62e4a0aef27612819288df2a3ff5bf01597cf06779503f51583",
+        )
     }
 
     fn zeta() -> FrElement {
-        FrElement::from_hex_unchecked("2a4040abb941ee5e2a42602a7a60d282a430a4cf099fa3bb0ba8f4da628ec59a")
+        FrElement::from_hex_unchecked(
+            "2a4040abb941ee5e2a42602a7a60d282a430a4cf099fa3bb0ba8f4da628ec59a",
+        )
     }
 
     fn upsilon() -> FrElement {
-        FrElement::from_hex_unchecked("2d15959489a2a8e44693221ca7cbdcab15253d6bae9fd7fe0664cff02fe4f1cf")
+        FrElement::from_hex_unchecked(
+            "2d15959489a2a8e44693221ca7cbdcab15253d6bae9fd7fe0664cff02fe4f1cf",
+        )
     }
 
     #[test]
@@ -603,18 +613,24 @@ mod tests {
         let round_2 = prover.round_2(&witness, &common_preprocessed_input, beta(), gamma());
 
         let round_4 = prover.round_4(&common_preprocessed_input, &round_1, &round_2, zeta());
-        let expected_a_value =
-            FrElement::from_hex_unchecked("2c090a95b57f1f493b7b747bba34fef7772fd72f97d718ed69549641a823eb2e");
-        let expected_b_value =
-            FrElement::from_hex_unchecked("5975959d91369ba4e7a03c6ae94b7fe98e8b61b7bf9af63c8ae0759e17ac0c7e");
-        let expected_c_value =
-            FrElement::from_hex_unchecked("6bf31edeb4344b7d2df2cb1bd40b4d13e182d9cb09f89591fa043c1a34b4a93");
-        let expected_z_value =
-            FrElement::from_hex_unchecked("38e2ec8e7c3dab29e2b8e9c8ea152914b8fe4612e91f2902c80238efcf21f4ee");
-        let expected_s1_value =
-            FrElement::from_hex_unchecked("472f66db4fb6947d9ed9808241fe82324bc08aa2a54be93179db8e564e1137d4");
-        let expected_s2_value =
-            FrElement::from_hex_unchecked("5588f1239c24efe0538868d0f716984e69c6980e586864f615e4b0621fdc6f81");
+        let expected_a_value = FrElement::from_hex_unchecked(
+            "2c090a95b57f1f493b7b747bba34fef7772fd72f97d718ed69549641a823eb2e",
+        );
+        let expected_b_value = FrElement::from_hex_unchecked(
+            "5975959d91369ba4e7a03c6ae94b7fe98e8b61b7bf9af63c8ae0759e17ac0c7e",
+        );
+        let expected_c_value = FrElement::from_hex_unchecked(
+            "6bf31edeb4344b7d2df2cb1bd40b4d13e182d9cb09f89591fa043c1a34b4a93",
+        );
+        let expected_z_value = FrElement::from_hex_unchecked(
+            "38e2ec8e7c3dab29e2b8e9c8ea152914b8fe4612e91f2902c80238efcf21f4ee",
+        );
+        let expected_s1_value = FrElement::from_hex_unchecked(
+            "472f66db4fb6947d9ed9808241fe82324bc08aa2a54be93179db8e564e1137d4",
+        );
+        let expected_s2_value = FrElement::from_hex_unchecked(
+            "5588f1239c24efe0538868d0f716984e69c6980e586864f615e4b0621fdc6f81",
+        );
 
         assert_eq!(round_4.a_zeta, expected_a_value);
         assert_eq!(round_4.b_zeta, expected_b_value);

--- a/proving_system/plonk/src/prover.rs
+++ b/proving_system/plonk/src/prover.rs
@@ -493,23 +493,23 @@ mod tests {
     use super::*;
 
     fn alpha() -> FrElement {
-        FrElement::from_hex("583cfb0df2ef98f2131d717bc6aadd571c5302597c135cab7c00435817bf6e50")
+        FrElement::from_hex_unchecked("583cfb0df2ef98f2131d717bc6aadd571c5302597c135cab7c00435817bf6e50")
     }
 
     fn beta() -> FrElement {
-        FrElement::from_hex("bdda7414bdf5bf42b77cbb3af4a82f32ec7622dd6c71575bede021e6e4609d4")
+        FrElement::from_hex_unchecked("bdda7414bdf5bf42b77cbb3af4a82f32ec7622dd6c71575bede021e6e4609d4")
     }
 
     fn gamma() -> FrElement {
-        FrElement::from_hex("58f6690d9b36e62e4a0aef27612819288df2a3ff5bf01597cf06779503f51583")
+        FrElement::from_hex_unchecked("58f6690d9b36e62e4a0aef27612819288df2a3ff5bf01597cf06779503f51583")
     }
 
     fn zeta() -> FrElement {
-        FrElement::from_hex("2a4040abb941ee5e2a42602a7a60d282a430a4cf099fa3bb0ba8f4da628ec59a")
+        FrElement::from_hex_unchecked("2a4040abb941ee5e2a42602a7a60d282a430a4cf099fa3bb0ba8f4da628ec59a")
     }
 
     fn upsilon() -> FrElement {
-        FrElement::from_hex("2d15959489a2a8e44693221ca7cbdcab15253d6bae9fd7fe0664cff02fe4f1cf")
+        FrElement::from_hex_unchecked("2d15959489a2a8e44693221ca7cbdcab15253d6bae9fd7fe0664cff02fe4f1cf")
     }
 
     #[test]
@@ -523,16 +523,16 @@ mod tests {
         let prover = Prover::new(kzg, random_generator);
         let round_1 = prover.round_1(&witness, &common_preprocessed_input);
         let a_1_expected = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"),
-            FpElement::from_hex("114d1d6855d545a8aa7d76c8cf2e21f267816aef1db507c96655b9d5caac42364e6f38ba0ecb751bad54dcd6b939c2ca"),
+            FpElement::from_hex_unchecked("17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"),
+            FpElement::from_hex_unchecked("114d1d6855d545a8aa7d76c8cf2e21f267816aef1db507c96655b9d5caac42364e6f38ba0ecb751bad54dcd6b939c2ca"),
         ).unwrap();
         let b_1_expected = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("44ed7c3ed015c6a39c350cd06d03b48d3e1f5eaf7a256c5b6203886e6e78cd9b76623d163da4dfb0f2491e7cc06408"),
-            FpElement::from_hex("14c4464d2556fdfdc8e31068ef8d953608e511569a236c825f2ddab4fe04af03aba29e38b9b2b6221243124d235f4c67"),
+            FpElement::from_hex_unchecked("44ed7c3ed015c6a39c350cd06d03b48d3e1f5eaf7a256c5b6203886e6e78cd9b76623d163da4dfb0f2491e7cc06408"),
+            FpElement::from_hex_unchecked("14c4464d2556fdfdc8e31068ef8d953608e511569a236c825f2ddab4fe04af03aba29e38b9b2b6221243124d235f4c67"),
         ).unwrap();
         let c_1_expected = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("7726dc031bd26122395153ca428d5e6dea0a64c1f9b3b1bb2f2508a5eb6ea0ea0363294fad3160858bc87e46d3422fd"),
-            FpElement::from_hex("8db0c15bfd77df7fe66284c3b04e6043eaba99ef6a845d4f7255fd0da95f2fb8e474df2e7f8e1a38829f7a9612a9b87"),
+            FpElement::from_hex_unchecked("7726dc031bd26122395153ca428d5e6dea0a64c1f9b3b1bb2f2508a5eb6ea0ea0363294fad3160858bc87e46d3422fd"),
+            FpElement::from_hex_unchecked("8db0c15bfd77df7fe66284c3b04e6043eaba99ef6a845d4f7255fd0da95f2fb8e474df2e7f8e1a38829f7a9612a9b87"),
         ).unwrap();
         assert_eq!(round_1.a_1, a_1_expected);
         assert_eq!(round_1.b_1, b_1_expected);
@@ -550,8 +550,8 @@ mod tests {
 
         let result_2 = prover.round_2(&witness, &common_preprocessed_input, beta(), gamma());
         let z_1_expected = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("3e8322968c3496cf1b5786d4d71d158a646ec90c14edf04e758038e1f88dcdfe8443fcecbb75f3074a872a380391742"),
-            FpElement::from_hex("11eac40d09796ff150004e7b858d83ddd9fe995dced0b3fbd7535d6e361729b25d488799da61fdf1d7b5022684053327"),
+            FpElement::from_hex_unchecked("3e8322968c3496cf1b5786d4d71d158a646ec90c14edf04e758038e1f88dcdfe8443fcecbb75f3074a872a380391742"),
+            FpElement::from_hex_unchecked("11eac40d09796ff150004e7b858d83ddd9fe995dced0b3fbd7535d6e361729b25d488799da61fdf1d7b5022684053327"),
         ).unwrap();
         assert_eq!(result_2.z_1, z_1_expected);
     }
@@ -576,12 +576,12 @@ mod tests {
         );
 
         let t_lo_1_expected = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("9f511a769e77e87537b0749d65f467532fbf0f9dc1bcc912c333741be9d0a613f61e5fe595996964646ce30794701e5"),
-            FpElement::from_hex("89fd6bb571323912210517237d6121144fc01ba2756f47c12c9cc94fc9197313867d68530f152dc8d447f10fcf75a6c"),
+            FpElement::from_hex_unchecked("9f511a769e77e87537b0749d65f467532fbf0f9dc1bcc912c333741be9d0a613f61e5fe595996964646ce30794701e5"),
+            FpElement::from_hex_unchecked("89fd6bb571323912210517237d6121144fc01ba2756f47c12c9cc94fc9197313867d68530f152dc8d447f10fcf75a6c"),
         ).unwrap();
         let t_mid_1_expected = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("f96d8a93f3f5be2ab2819891f41c9f883cacea63da423e6ed1701765fcd659fc11e056a48c554f5df3a9c6603d48ca8"),
-            FpElement::from_hex("14fa74fa049b7276007b739f3b8cfeac09e8cfabd4f858b6b99798c81124c34851960bebda90133cb03c981c08c8b6d3"),
+            FpElement::from_hex_unchecked("f96d8a93f3f5be2ab2819891f41c9f883cacea63da423e6ed1701765fcd659fc11e056a48c554f5df3a9c6603d48ca8"),
+            FpElement::from_hex_unchecked("14fa74fa049b7276007b739f3b8cfeac09e8cfabd4f858b6b99798c81124c34851960bebda90133cb03c981c08c8b6d3"),
         ).unwrap();
         let t_hi_1_expected = ShortWeierstrassProjectivePoint::<BLS12381Curve>::neutral_element();
 
@@ -604,17 +604,17 @@ mod tests {
 
         let round_4 = prover.round_4(&common_preprocessed_input, &round_1, &round_2, zeta());
         let expected_a_value =
-            FrElement::from_hex("2c090a95b57f1f493b7b747bba34fef7772fd72f97d718ed69549641a823eb2e");
+            FrElement::from_hex_unchecked("2c090a95b57f1f493b7b747bba34fef7772fd72f97d718ed69549641a823eb2e");
         let expected_b_value =
-            FrElement::from_hex("5975959d91369ba4e7a03c6ae94b7fe98e8b61b7bf9af63c8ae0759e17ac0c7e");
+            FrElement::from_hex_unchecked("5975959d91369ba4e7a03c6ae94b7fe98e8b61b7bf9af63c8ae0759e17ac0c7e");
         let expected_c_value =
-            FrElement::from_hex("6bf31edeb4344b7d2df2cb1bd40b4d13e182d9cb09f89591fa043c1a34b4a93");
+            FrElement::from_hex_unchecked("6bf31edeb4344b7d2df2cb1bd40b4d13e182d9cb09f89591fa043c1a34b4a93");
         let expected_z_value =
-            FrElement::from_hex("38e2ec8e7c3dab29e2b8e9c8ea152914b8fe4612e91f2902c80238efcf21f4ee");
+            FrElement::from_hex_unchecked("38e2ec8e7c3dab29e2b8e9c8ea152914b8fe4612e91f2902c80238efcf21f4ee");
         let expected_s1_value =
-            FrElement::from_hex("472f66db4fb6947d9ed9808241fe82324bc08aa2a54be93179db8e564e1137d4");
+            FrElement::from_hex_unchecked("472f66db4fb6947d9ed9808241fe82324bc08aa2a54be93179db8e564e1137d4");
         let expected_s2_value =
-            FrElement::from_hex("5588f1239c24efe0538868d0f716984e69c6980e586864f615e4b0621fdc6f81");
+            FrElement::from_hex_unchecked("5588f1239c24efe0538868d0f716984e69c6980e586864f615e4b0621fdc6f81");
 
         assert_eq!(round_4.a_zeta, expected_a_value);
         assert_eq!(round_4.b_zeta, expected_b_value);
@@ -648,12 +648,12 @@ mod tests {
         let round_4 = prover.round_4(&common_preprocessed_input, &round_1, &round_2, zeta());
 
         let expected_w_zeta_1 = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("fa6250b80a418f0548b132ac264ff9915b2076c0c2548da9316ae19ffa35bbcf905d9f02f9274739608045ef83a4757"),
-            FpElement::from_hex("17713ade2dbd66e923d4092a5d2da98202959dd65a15e9f7791fab3c0dd08788aa9b4a1cb21d04e0c43bd29225472145"),
+            FpElement::from_hex_unchecked("fa6250b80a418f0548b132ac264ff9915b2076c0c2548da9316ae19ffa35bbcf905d9f02f9274739608045ef83a4757"),
+            FpElement::from_hex_unchecked("17713ade2dbd66e923d4092a5d2da98202959dd65a15e9f7791fab3c0dd08788aa9b4a1cb21d04e0c43bd29225472145"),
         ).unwrap();
         let expected_w_zeta_omega_1 = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("4484f08f8eaccf28bab8ee9539e6e7f4059cb1ce77b9b18e9e452f387163dc0b845f4874bf6445399e650d362799ff5"),
-            FpElement::from_hex("1254347a0fa2ac856917825a5cff5f9583d39a52edbc2be5bb10fabd0c04d23019bcb963404345743120310fd734a61a"),
+            FpElement::from_hex_unchecked("4484f08f8eaccf28bab8ee9539e6e7f4059cb1ce77b9b18e9e452f387163dc0b845f4874bf6445399e650d362799ff5"),
+            FpElement::from_hex_unchecked("1254347a0fa2ac856917825a5cff5f9583d39a52edbc2be5bb10fabd0c04d23019bcb963404345743120310fd734a61a"),
         ).unwrap();
 
         let round_5 = prover.round_5(

--- a/proving_system/plonk/src/setup.rs
+++ b/proving_system/plonk/src/setup.rs
@@ -113,33 +113,33 @@ mod tests {
         let vk = setup::<FrField, KZG>(&common_input, &kzg);
 
         let expected_ql = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("1492341357755e31a6306abf3237f84f707ded7cb526b8ffd40901746234ef27f12bc91ef638e4977563db208b765f12"),
-            FpElement::from_hex("ec3ff8288ea339010658334f494a614f7470c19a08d53a9cf5718e0613bb65d2cdbc1df374057d9b45c35cf1f1b5b72"),
+            FpElement::from_hex_unchecked("1492341357755e31a6306abf3237f84f707ded7cb526b8ffd40901746234ef27f12bc91ef638e4977563db208b765f12"),
+            FpElement::from_hex_unchecked("ec3ff8288ea339010658334f494a614f7470c19a08d53a9cf5718e0613bb65d2cdbc1df374057d9b45c35cf1f1b5b72"),
         ).unwrap();
         let expected_qr = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("107ab09b6b8c6fc55087aeb8045e17a6d016bdacbc64476264328e71f3e85a4eacaee34ee963e9c9249b6b1bc9653674"),
-            FpElement::from_hex("f98e3fe5a53545b67a51da7e7a6cedc51af467abdefd644113fb97edf339aeaa5e2f6a5713725ec76754510b76a10be"),
+            FpElement::from_hex_unchecked("107ab09b6b8c6fc55087aeb8045e17a6d016bdacbc64476264328e71f3e85a4eacaee34ee963e9c9249b6b1bc9653674"),
+            FpElement::from_hex_unchecked("f98e3fe5a53545b67a51da7e7a6cedc51af467abdefd644113fb97edf339aeaa5e2f6a5713725ec76754510b76a10be"),
         ).unwrap();
         let expected_qo = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("9fd00baa112a0064ce5c3c2d243e657b25df8a2f237b91eec27e83157f6ca896a2401d07ec7d7d097d2f2a344e2018f"),
-            FpElement::from_hex("15922cfa65972d80823c6bb9aeb0637c864b636267bfee2818413e9cdc5f7948575c4ce097bb8b9db8087c4ed5056592"),
+            FpElement::from_hex_unchecked("9fd00baa112a0064ce5c3c2d243e657b25df8a2f237b91eec27e83157f6ca896a2401d07ec7d7d097d2f2a344e2018f"),
+            FpElement::from_hex_unchecked("15922cfa65972d80823c6bb9aeb0637c864b636267bfee2818413e9cdc5f7948575c4ce097bb8b9db8087c4ed5056592"),
         ).unwrap();
         let expected_qm = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("9fd00baa112a0064ce5c3c2d243e657b25df8a2f237b91eec27e83157f6ca896a2401d07ec7d7d097d2f2a344e2018f"),
-            FpElement::from_hex("46ee4efd3e8b919c8df3bfc949b495ade2be8228bc524974eef94041a517cdbc74fb31e1998746201f683b12afa4519"),
+            FpElement::from_hex_unchecked("9fd00baa112a0064ce5c3c2d243e657b25df8a2f237b91eec27e83157f6ca896a2401d07ec7d7d097d2f2a344e2018f"),
+            FpElement::from_hex_unchecked("46ee4efd3e8b919c8df3bfc949b495ade2be8228bc524974eef94041a517cdbc74fb31e1998746201f683b12afa4519"),
         ).unwrap();
 
         let expected_s1 = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("187ee12de08728650d18912aa9fe54863922a9eeb37e34ff43041f1d039f00028ad2cdf23705e6f6ab7ea9406535c1b0"),
-            FpElement::from_hex("4f29051990de0d12b38493992845d9abcb48ef18239eca8b8228618c78ec371d39917bc0d45cf6dc4f79bd64baa9ae2")
+            FpElement::from_hex_unchecked("187ee12de08728650d18912aa9fe54863922a9eeb37e34ff43041f1d039f00028ad2cdf23705e6f6ab7ea9406535c1b0"),
+            FpElement::from_hex_unchecked("4f29051990de0d12b38493992845d9abcb48ef18239eca8b8228618c78ec371d39917bc0d45cf6dc4f79bd64baa9ae2")
         ).unwrap();
         let expected_s2 = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("167c0384025887c01ea704234e813842a4acef7d765c3a94a5442ca685b4fc1d1b425ba7786a7413bd4a7d6a1eb5a35a"),
-            FpElement::from_hex("12b644100c5d00af27c121806c4779f88e840ff3fdac44124b8175a303d586c4d910486f909b37dda1505c485f053da1")
+            FpElement::from_hex_unchecked("167c0384025887c01ea704234e813842a4acef7d765c3a94a5442ca685b4fc1d1b425ba7786a7413bd4a7d6a1eb5a35a"),
+            FpElement::from_hex_unchecked("12b644100c5d00af27c121806c4779f88e840ff3fdac44124b8175a303d586c4d910486f909b37dda1505c485f053da1")
         ).unwrap();
         let expected_s3 = BLS12381Curve::create_point_from_affine(
-            FpElement::from_hex("188fb6dba3cf5af8a7f6a44d935bb3dd2083a5beb4c020f581739ebc40659c824a4ca8279cf7d852decfbca572e4fa0e"),
-            FpElement::from_hex("d84d52582fd95bfa7672f7cef9dd4d0b1b4a54d33f244fdb97df71c7d45fd5c5329296b633c9ed23b8475ee47b9d99")
+            FpElement::from_hex_unchecked("188fb6dba3cf5af8a7f6a44d935bb3dd2083a5beb4c020f581739ebc40659c824a4ca8279cf7d852decfbca572e4fa0e"),
+            FpElement::from_hex_unchecked("d84d52582fd95bfa7672f7cef9dd4d0b1b4a54d33f244fdb97df71c7d45fd5c5329296b633c9ed23b8475ee47b9d99")
         ).unwrap();
 
         assert_eq!(vk.ql_1, expected_ql);

--- a/proving_system/plonk/src/test_utils/circuit_1.rs
+++ b/proving_system/plonk/src/test_utils/circuit_1.rs
@@ -9,7 +9,7 @@ use lambdaworks_math::{
 };
 
 pub const ORDER_4_ROOT_UNITY: FrElement =
-    FrElement::from_hex("8d51ccce760304d0ec030002760300000001000000000000"); // order 4
+    FrElement::from_hex_unchecked("8d51ccce760304d0ec030002760300000001000000000000"); // order 4
 
 /*  Test circuit for the program:
     public input x

--- a/proving_system/plonk/src/test_utils/circuit_2.rs
+++ b/proving_system/plonk/src/test_utils/circuit_2.rs
@@ -9,7 +9,7 @@ use lambdaworks_math::{
 };
 
 pub const ORDER_8_ROOT_UNITY: FrElement =
-    FrElement::from_hex("345766f603fa66e78c0625cd70d77ce2b38b21c28713b7007228fd3397743f7a"); // order 8
+    FrElement::from_hex_unchecked("345766f603fa66e78c0625cd70d77ce2b38b21c28713b7007228fd3397743f7a"); // order 8
 
 /*  Test circuit for the program:
     public input x

--- a/proving_system/plonk/src/test_utils/circuit_2.rs
+++ b/proving_system/plonk/src/test_utils/circuit_2.rs
@@ -8,8 +8,9 @@ use lambdaworks_math::{
     polynomial::Polynomial,
 };
 
-pub const ORDER_8_ROOT_UNITY: FrElement =
-    FrElement::from_hex_unchecked("345766f603fa66e78c0625cd70d77ce2b38b21c28713b7007228fd3397743f7a"); // order 8
+pub const ORDER_8_ROOT_UNITY: FrElement = FrElement::from_hex_unchecked(
+    "345766f603fa66e78c0625cd70d77ce2b38b21c28713b7007228fd3397743f7a",
+); // order 8
 
 /*  Test circuit for the program:
     public input x

--- a/proving_system/plonk/src/test_utils/circuit_json.rs
+++ b/proving_system/plonk/src/test_utils/circuit_json.rs
@@ -36,11 +36,11 @@ pub fn common_preprocessed_input_from_json(
 ) {
     let json_input: JsonPlonkCircuit = serde_json::from_str(json_string).unwrap();
     let n = json_input.N_padded;
-    let omega = FrElement::from_hex(&json_input.Omega);
+    let omega = FrElement::from_hex_unchecked(&json_input.Omega);
     let domain = generate_domain(&omega, n);
     let permuted = generate_permutation_coefficients(&omega, n, &json_input.Permutation);
 
-    let pad = FrElement::from_hex(&json_input.Input[0]);
+    let pad = FrElement::from_hex_unchecked(&json_input.Input[0]);
 
     let s1_lagrange: Vec<FrElement> = permuted[..n].to_vec();
     let s2_lagrange: Vec<FrElement> = permuted[n..2 * n].to_vec();
@@ -97,7 +97,7 @@ pub fn pad_vector<'a>(
 }
 
 fn convert_str_vec_to_frelement_vec(ss: Vec<String>) -> Vec<FrElement> {
-    ss.iter().map(|s| FrElement::from_hex(s)).collect()
+    ss.iter().map(|s| FrElement::from_hex_unchecked(s)).collect()
 }
 
 fn process_vector(vector: Vec<String>, pad: &FrElement, n: usize) -> Vec<FrElement> {

--- a/proving_system/plonk/src/test_utils/circuit_json.rs
+++ b/proving_system/plonk/src/test_utils/circuit_json.rs
@@ -97,7 +97,9 @@ pub fn pad_vector<'a>(
 }
 
 fn convert_str_vec_to_frelement_vec(ss: Vec<String>) -> Vec<FrElement> {
-    ss.iter().map(|s| FrElement::from_hex_unchecked(s)).collect()
+    ss.iter()
+        .map(|s| FrElement::from_hex_unchecked(s))
+        .collect()
 }
 
 fn process_vector(vector: Vec<String>, pad: &FrElement, n: usize) -> Vec<FrElement> {

--- a/proving_system/plonk/src/test_utils/utils.rs
+++ b/proving_system/plonk/src/test_utils/utils.rs
@@ -21,7 +21,7 @@ pub type FpField = BLS12381PrimeField;
 pub type FpElement = FieldElement<FpField>;
 pub type Pairing = BLS12381AtePairing;
 pub type KZG = KateZaveruchaGoldberg<FrField, Pairing>;
-pub const ORDER_R_MINUS_1_ROOT_UNITY: FrElement = FrElement::from_hex("7");
+pub const ORDER_R_MINUS_1_ROOT_UNITY: FrElement = FrElement::from_hex_unchecked("7");
 
 type G1Point = <BLS12381Curve as IsEllipticCurve>::PointRepresentation;
 type G2Point = <BLS12381TwistCurve as IsEllipticCurve>::PointRepresentation;

--- a/proving_system/stark/src/cairo_vm/execution_trace.rs
+++ b/proving_system/stark/src/cairo_vm/execution_trace.rs
@@ -689,7 +689,9 @@ mod test {
             vec![
                 FE::from(2),
                 FE::from(3),
-                FE::from_hex_unchecked("0800000000000010fffffffffffffffffffffffffffffffffffffffffffffffb"),
+                FE::from_hex_unchecked(
+                    "0800000000000010fffffffffffffffffffffffffffffffffffffffffffffffb",
+                ),
                 FE::from(6),
                 FE::from(9),
                 FE::from(6),
@@ -799,7 +801,9 @@ mod test {
             vec![
                 FE::from(2),
                 FE::from(3),
-                FE::from_hex_unchecked("0800000000000010fffffffffffffffffffffffffffffffffffffffffffffffb"),
+                FE::from_hex_unchecked(
+                    "0800000000000010fffffffffffffffffffffffffffffffffffffffffffffffb",
+                ),
                 FE::from(3),
                 FE::from(9),
                 FE::from(6),
@@ -865,7 +869,9 @@ mod test {
             vec![
                 FE::from(38),
                 FE::from(57),
-                FE::from_hex_unchecked("0800000000000010ffffffffffffffffffffffffffffffffffffffffffffffcb"),
+                FE::from_hex_unchecked(
+                    "0800000000000010ffffffffffffffffffffffffffffffffffffffffffffffcb",
+                ),
                 FE::from(6),
                 FE::from(81),
                 FE::from(114),

--- a/proving_system/stark/src/cairo_vm/execution_trace.rs
+++ b/proving_system/stark/src/cairo_vm/execution_trace.rs
@@ -689,7 +689,7 @@ mod test {
             vec![
                 FE::from(2),
                 FE::from(3),
-                FE::from_hex("0800000000000010fffffffffffffffffffffffffffffffffffffffffffffffb"),
+                FE::from_hex_unchecked("0800000000000010fffffffffffffffffffffffffffffffffffffffffffffffb"),
                 FE::from(6),
                 FE::from(9),
                 FE::from(6),
@@ -799,7 +799,7 @@ mod test {
             vec![
                 FE::from(2),
                 FE::from(3),
-                FE::from_hex("0800000000000010fffffffffffffffffffffffffffffffffffffffffffffffb"),
+                FE::from_hex_unchecked("0800000000000010fffffffffffffffffffffffffffffffffffffffffffffffb"),
                 FE::from(3),
                 FE::from(9),
                 FE::from(6),
@@ -865,7 +865,7 @@ mod test {
             vec![
                 FE::from(38),
                 FE::from(57),
-                FE::from_hex("0800000000000010ffffffffffffffffffffffffffffffffffffffffffffffcb"),
+                FE::from_hex_unchecked("0800000000000010ffffffffffffffffffffffffffffffffffffffffffffffcb"),
                 FE::from(6),
                 FE::from(81),
                 FE::from(114),


### PR DESCRIPTION
# Add checked and unchecked from hex

## Description

Add checked and unchecked from hex to avoid unwanted panics. Most of the prs is the change of calls from `from` to `from_hex_unchecked`. I've also added tests for the checked versions for `UnsignedIntegers` and `FieldElements`through their montgomery backend.

Functions are splitted since we need const calls, but we can't use results there, so we leave the unchecked for creating values in compile time, and checked for runtime.
 
## Type of change

Please delete options that are not relevant.

- [ x ] New feature
