### PR TITLE
perf: optimize polynomial division

### DIFF
--- a/math/src/polynomial.rs
+++ b/math/src/polynomial.rs
@@ -119,8 +119,9 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
         } else {
             let mut n = self;
             let mut q: Vec<FieldElement<F>> = vec![FieldElement::zero(); n.degree() + 1];
+            let denominator = dividend.leading_coefficient().inv();
             while n != Polynomial::zero() && n.degree() >= dividend.degree() {
-                let new_coefficient = n.leading_coefficient() / dividend.leading_coefficient();
+                let new_coefficient = n.leading_coefficient() * &denominator;
                 q[n.degree() - dividend.degree()] = new_coefficient.clone();
                 let d = dividend.mul_with_ref(&Polynomial::new_monomial(
                     new_coefficient,


### PR DESCRIPTION
Computing a the inverse in `Fp` is the most expensive step in `Fp` division, which in turn takes most of the time in the polynomial division itself.
Extracting this out of the hot loop and replacing the call site with a product gives a huge boost (70-90% measured in polynomial benchmarks and almost 10% in STARK proving benchmarks).

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks run
