### PR TITLE
Add mixed addition optimization for the miller loop of the BLS 12 381 curve

### DIFF
--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -1,15 +1,13 @@
-use crate::unsigned_integer::element::U384;
-use crate::{
-    field::{
-        element::FieldElement,
-        extensions::{
-            cubic::{CubicExtensionField, HasCubicNonResidue},
-            quadratic::{HasQuadraticNonResidue, QuadraticExtensionField},
-        },
-        fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+use crate::{field::{
+    element::FieldElement,
+    extensions::{
+        cubic::{CubicExtensionField, HasCubicNonResidue},
+        quadratic::{HasQuadraticNonResidue, QuadraticExtensionField},
     },
-    traits::ByteConversion,
-};
+    fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+    traits::IsField,
+}, traits::ByteConversion};
+use crate::unsigned_integer::element::U384;
 
 pub const BLS12381_PRIME_FIELD_ORDER: U384 = U384::from_hex_unchecked("1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab");
 
@@ -22,63 +20,90 @@ impl IsModulus<U384> for BLS12381FieldModulus {
 
 pub type BLS12381PrimeField = MontgomeryBackendPrimeField<BLS12381FieldModulus, 6>;
 
-#[derive(Debug, Clone)]
-pub struct LevelOneResidue;
-impl HasQuadraticNonResidue for LevelOneResidue {
-    type BaseField = BLS12381PrimeField;
+//////////////////
+#[derive(Clone, Debug)]
+pub struct Degree2ExtensionField;
 
-    fn residue() -> FieldElement<BLS12381PrimeField> {
-        -FieldElement::one()
+impl IsField for Degree2ExtensionField {
+    type BaseType = [FieldElement<BLS12381PrimeField>; 2];
+
+    /// Returns the component wise addition of `a` and `b`
+    fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        [&a[0] + &b[0], &a[1] + &b[1]]
     }
-}
 
-pub type Degree2ExtensionField = QuadraticExtensionField<LevelOneResidue>;
-
-#[derive(Debug, Clone)]
-pub struct LevelTwoResidue;
-impl HasCubicNonResidue for LevelTwoResidue {
-    type BaseField = Degree2ExtensionField;
-
-    fn residue() -> FieldElement<Degree2ExtensionField> {
-        FieldElement::new([
-            FieldElement::new(U384::from_hex_unchecked("d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd556")),
-            FieldElement::new(U384::from_hex_unchecked("d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd555"))
-        ])
+    /// Returns the multiplication of `a` and `b` using the following
+    /// equation:
+    /// (a0 + a1 * t) * (b0 + b1 * t) = a0 * b0 + a1 * b1 * Self::residue() + (a0 * b1 + a1 * b0) * t
+    /// where `t.pow(2)` equals `Q::residue()`.
+    fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        let a0b0 = &a[0] * &b[0];
+        let a1b1 = &a[1] * &b[1];
+        let z = (&a[0] + &a[1]) * (&b[0] + &b[1]);
+        [&a0b0 - &a1b1, z - a0b0 - a1b1]
     }
-}
 
-pub type Degree6ExtensionField = CubicExtensionField<LevelTwoResidue>;
-
-#[derive(Debug, Clone)]
-pub struct LevelThreeResidue;
-impl HasQuadraticNonResidue for LevelThreeResidue {
-    type BaseField = Degree6ExtensionField;
-
-    fn residue() -> FieldElement<Degree6ExtensionField> {
-        FieldElement::new([
-            FieldElement::zero(),
-            FieldElement::one(),
-            FieldElement::zero(),
-        ])
+    /// Returns the component wise subtraction of `a` and `b`
+    fn sub(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        [&a[0] - &b[0], &a[1] - &b[1]]
     }
-}
 
-pub type Degree12ExtensionField = QuadraticExtensionField<LevelThreeResidue>;
+    /// Returns the component wise negation of `a`
+    fn neg(a: &Self::BaseType) -> Self::BaseType {
+        [-&a[0], -&a[1]]
+    }
 
-impl FieldElement<BLS12381PrimeField> {
-    pub fn new_base(a_hex: &str) -> Self {
-        Self::new(U384::from_hex_unchecked(a_hex))
+    /// Returns the multiplicative inverse of `a`
+    /// This uses the equality `(a0 + a1 * t) * (a0 - a1 * t) = a0.pow(2) - a1.pow(2) * Q::residue()`
+    fn inv(a: &Self::BaseType) -> Self::BaseType {
+        let inv_norm = (a[0].pow(2_u64) + a[1].pow(2_u64)).inv();
+        [&a[0] * &inv_norm, -&a[1] * inv_norm]
+    }
+
+    /// Returns the division of `a` and `b`
+    fn div(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        Self::mul(a, &Self::inv(b))
+    }
+
+    /// Returns a boolean indicating whether `a` and `b` are equal component wise.
+    fn eq(a: &Self::BaseType, b: &Self::BaseType) -> bool {
+        a[0] == b[0] && a[1] == b[1]
+    }
+
+    /// Returns the additive neutral element of the field extension.
+    fn zero() -> Self::BaseType {
+        [FieldElement::zero(), FieldElement::zero()]
+    }
+
+    /// Returns the multiplicative neutral element of the field extension.
+    fn one() -> Self::BaseType {
+        [FieldElement::one(), FieldElement::zero()]
+    }
+
+    /// Returns the element `x * 1` where 1 is the multiplicative neutral element.
+    fn from_u64(x: u64) -> Self::BaseType {
+        [FieldElement::from(x), FieldElement::zero()]
+    }
+
+    /// Takes as input an element of BaseType and returns the internal representation
+    /// of that element in the field.
+    /// Note: for this case this is simply the identity, because the components
+    /// already have correct representations.
+    fn from_base_type(x: Self::BaseType) -> Self::BaseType {
+        x
     }
 }
 
 impl FieldElement<Degree2ExtensionField> {
-    pub fn new_base(a_hex: &str) -> Self {
-        Self::new([
-            FieldElement::new(U384::from_hex_unchecked(a_hex)),
-            FieldElement::zero(),
-        ])
+    pub fn square(&self) -> Self {
+        let [a0, a1] = self.value();
+        let v0 = a0 * a1;
+        let c0 = (a0 + a1) * (a0 - a1);
+        let c1 = &v0 + &v0;
+        Self::new([c0, c1])
     }
 }
+
 
 impl ByteConversion for FieldElement<Degree2ExtensionField> {
     fn to_bytes_be(&self) -> Vec<u8> {
@@ -114,13 +139,55 @@ impl ByteConversion for FieldElement<Degree2ExtensionField> {
     }
 }
 
+
+///////////////
+#[derive(Debug, Clone)]
+pub struct LevelTwoResidue;
+impl HasCubicNonResidue for LevelTwoResidue {
+    type BaseField = Degree2ExtensionField;
+
+    fn residue() -> FieldElement<Degree2ExtensionField> {
+        FieldElement::new([
+            FieldElement::new(U384::from("1")),
+            FieldElement::new(U384::from("1")),
+        ])
+    }
+}
+
+pub type Degree6ExtensionField = CubicExtensionField<LevelTwoResidue>;
+
+#[derive(Debug, Clone)]
+pub struct LevelThreeResidue;
+impl HasQuadraticNonResidue for LevelThreeResidue {
+    type BaseField = Degree6ExtensionField;
+
+    fn residue() -> FieldElement<Degree6ExtensionField> {
+        FieldElement::new([
+            FieldElement::zero(),
+            FieldElement::one(),
+            FieldElement::zero(),
+        ])
+    }
+}
+
+pub type Degree12ExtensionField = QuadraticExtensionField<LevelThreeResidue>;
+
+impl FieldElement<BLS12381PrimeField> {
+    pub fn new_base(a_hex: &str) -> Self {
+        Self::new(U384::from(a_hex))
+    }
+}
+
+impl FieldElement<Degree2ExtensionField> {
+    pub fn new_base(a_hex: &str) -> Self {
+        Self::new([FieldElement::new(U384::from(a_hex)), FieldElement::zero()])
+    }
+}
+
 impl FieldElement<Degree6ExtensionField> {
     pub fn new_base(a_hex: &str) -> Self {
         Self::new([
-            FieldElement::new([
-                FieldElement::new(U384::from_hex_unchecked(a_hex)),
-                FieldElement::zero(),
-            ]),
+            FieldElement::new([FieldElement::new(U384::from(a_hex)), FieldElement::zero()]),
             FieldElement::zero(),
             FieldElement::zero(),
         ])
@@ -139,30 +206,30 @@ impl FieldElement<Degree12ExtensionField> {
         FieldElement::<Degree12ExtensionField>::new([
             FieldElement::new([
                 FieldElement::new([
-                    FieldElement::new(U384::from_hex_unchecked(coefficients[0])),
-                    FieldElement::new(U384::from_hex_unchecked(coefficients[1])),
+                    FieldElement::new(U384::from(coefficients[0])),
+                    FieldElement::new(U384::from(coefficients[1])),
                 ]),
                 FieldElement::new([
-                    FieldElement::new(U384::from_hex_unchecked(coefficients[2])),
-                    FieldElement::new(U384::from_hex_unchecked(coefficients[3])),
+                    FieldElement::new(U384::from(coefficients[2])),
+                    FieldElement::new(U384::from(coefficients[3])),
                 ]),
                 FieldElement::new([
-                    FieldElement::new(U384::from_hex_unchecked(coefficients[4])),
-                    FieldElement::new(U384::from_hex_unchecked(coefficients[5])),
+                    FieldElement::new(U384::from(coefficients[4])),
+                    FieldElement::new(U384::from(coefficients[5])),
                 ]),
             ]),
             FieldElement::new([
                 FieldElement::new([
-                    FieldElement::new(U384::from_hex_unchecked(coefficients[6])),
-                    FieldElement::new(U384::from_hex_unchecked(coefficients[7])),
+                    FieldElement::new(U384::from(coefficients[6])),
+                    FieldElement::new(U384::from(coefficients[7])),
                 ]),
                 FieldElement::new([
-                    FieldElement::new(U384::from_hex_unchecked(coefficients[8])),
-                    FieldElement::new(U384::from_hex_unchecked(coefficients[9])),
+                    FieldElement::new(U384::from(coefficients[8])),
+                    FieldElement::new(U384::from(coefficients[9])),
                 ]),
                 FieldElement::new([
-                    FieldElement::new(U384::from_hex_unchecked(coefficients[10])),
-                    FieldElement::new(U384::from_hex_unchecked(coefficients[11])),
+                    FieldElement::new(U384::from(coefficients[10])),
+                    FieldElement::new(U384::from(coefficients[11])),
                 ]),
             ]),
         ])
@@ -184,8 +251,20 @@ mod tests {
         let element_ones =
             Fp12E::from_coefficients(&["1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1"]);
         let element_ones_squared =
-            Fp12E::from_coefficients(&["5", "7", "3", "9", "1", "b", "4", "8", "2", "a", "0", "c"]);
+            Fp12E::from_coefficients(&["1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaa1",
+            "c",
+            "1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaa5",
+            "c",
+            "1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaa9",
+            "c",
+            "1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaa3",
+            "c",
+            "1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaa7",
+            "c",
+            "0",
+            "c"]);
         assert_eq!(element_ones.pow(2_u16), element_ones_squared);
+        assert_eq!(element_ones.square(), element_ones_squared);
     }
 
     #[test]
@@ -193,32 +272,21 @@ mod tests {
         let element_sequence =
             Fp12E::from_coefficients(&["1", "2", "5", "6", "9", "a", "3", "4", "7", "8", "b", "c"]);
 
-        let element_sequence_squared = Fp12E::from_coefficients(&[
-            "d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd61d",
-            "d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd66f",
-            "d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd62a",
-            "d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd6b0",
-            "d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd597",
-            "d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd6c1",
-            "e0",
-            "142",
-            "a1",
-            "167",
-            "1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa5d",
-            "16c"
-        ]);
+        let element_sequence_squared = Fp12E::from_coefficients(&["1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa87d",
+        "199",
+        "1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa851",
+        "20b",
+        "1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa955",
+        "1cd",
+        "1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa845",
+        "1e8",
+        "1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8a9",
+        "202",
+        "1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa5d",
+        "16c"]);
 
         assert_eq!(element_sequence.pow(2_u16), element_sequence_squared);
-    }
-
-    #[test]
-    fn inverse_of_u_plus_one() {
-        let z =
-            Fp12E::from_coefficients(&["0", "0", "1", "0", "0", "0", "0", "0", "0", "0", "0", "0"])
-                .pow(3_u16);
-        let one_plus_u =
-            Fp12E::from_coefficients(&["1", "1", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0"]);
-        assert_eq!(z * one_plus_u, FieldElement::one());
+        assert_eq!(element_sequence.square(), element_sequence_squared);
     }
 
     #[test]

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -5,15 +5,15 @@ use super::{
 };
 use crate::{
     cyclic_group::IsGroup,
-    elliptic_curve::short_weierstrass::traits::IsShortWeierstrass,
     elliptic_curve::{
         short_weierstrass::{
-            curves::bls12_381::field_extension::Degree6ExtensionField,
+            curves::bls12_381::field_extension::{Degree6ExtensionField, LevelTwoResidue},
             point::ShortWeierstrassProjectivePoint,
+            traits::IsShortWeierstrass,
         },
         traits::IsPairing,
     },
-    field::element::FieldElement,
+    field::{element::FieldElement, extensions::cubic::HasCubicNonResidue},
     unsigned_integer::element::UnsignedInteger,
 };
 
@@ -43,6 +43,110 @@ impl IsPairing for BLS12381AtePairing {
 /// This is equal to the frobenius trace of the BLS12 381 curve minus one.
 const MILLER_LOOP_CONSTANT: u64 = 0xd201000000010000;
 
+fn double_accumulate_line(
+    t: &mut ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,
+    p: &ShortWeierstrassProjectivePoint<BLS12381Curve>,
+    accumulator: &mut FieldElement<Degree12ExtensionField>,
+) {
+    let [x1, y1, z1] = t.coordinates();
+    let [px, py, _] = p.coordinates();
+    let residue = LevelTwoResidue::residue();
+    let two_inv = FieldElement::<Degree2ExtensionField>::new_base("d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd556");
+
+    let a = &two_inv * x1 * y1;
+    let b = y1.square();
+    let c = z1.square();
+    let d = FieldElement::from(3) * &c;
+    let e = BLS12381TwistCurve::b() * d;
+    let f = FieldElement::from(3) * &e;
+    let g = two_inv * (&b + &f);
+    let h = (y1 + z1).square() - (&b + &c);
+
+    let x3 = &a * (&b - &f);
+    let y3 = g.square() - (FieldElement::from(3) * e.square());
+    let z3 = &b * &h;
+
+    let [h0, h1] = h.value();
+    let x1_sq_3 = FieldElement::from(3) * x1.square();
+    let [x1_sq_30, x1_sq_31] = x1_sq_3.value();
+
+    t.0.value = [x3, y3, z3];
+
+    // (a0 + a2w2 + a4w4 + a1w + a3w3 + a5w5) * (b0 + b2 w2 + b3 w3) =
+    // (a0b0 + r (a3b3 + a4b2)) w0 + (a1b0 + r (a4b3 + a5b2)) w
+    // (a2b0 + r  a5b3 + a0b2 ) w2 + (a3b0 + a0b3 + a1b2    ) w3
+    // (a4b0 +    a1b3 + a2b2 ) w4 + (a5b0 + a2b3 + a3b2    ) w5
+    let accumulator_sq = accumulator.square();
+    let [x, y] = accumulator_sq.value();
+    let [a0, a2, a4] = x.value();
+    let [a1, a3, a5] = y.value();
+    let b0 = e - b;
+    let b2 = FieldElement::new([x1_sq_30 * px, x1_sq_31 * px]);
+    let b3 = FieldElement::new([-h0 * py, -h1 * py]);
+    *accumulator = FieldElement::new([
+        FieldElement::new([
+            a0 * &b0 + &residue * (a3 * &b3 + a4 * &b2), // w0
+            a2 * &b0 + &residue * a5 * &b3 + a0 * &b2,   // w2
+            a4 * &b0 + a1 * &b3 + a2 * &b2,              // w4
+        ]),
+        FieldElement::new([
+            a1 * &b0 + &residue * (a4 * &b3 + a5 * &b2), // w1
+            a3 * &b0 + a0 * &b3 + a1 * &b2,              // w3
+            a5 * &b0 + a2 * &b3 + a3 * &b2,              // w5
+        ]),
+    ]);
+}
+fn add_accumulate_line(
+    t: &mut ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,
+    q: &ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,
+    p: &ShortWeierstrassProjectivePoint<BLS12381Curve>,
+    accumulator: &mut FieldElement<Degree12ExtensionField>,
+) {
+    let [x1, y1, z1] = t.coordinates();
+    let [x2, y2, _] = q.coordinates();
+    let [px, py, _] = p.coordinates();
+    let residue = LevelTwoResidue::residue();
+
+    let a = y2 * z1;
+    let b = x2 * z1;
+    let theta = y1 - a;
+    let lambda = x1 - b;
+    let c = theta.square();
+    let d = lambda.square();
+    let e = &lambda * &d;
+    let f = z1 * c;
+    let g = x1 * d;
+    let h = &e + f - FieldElement::from(2) * &g;
+    let i = y1 * &e;
+
+    let x3 = &lambda * &h;
+    let y3 = &theta * (g - h) - i;
+    let z3 = z1 * e;
+
+    t.0.value = [x3, y3, z3];
+
+    let [lambda0, lambda1] = lambda.value();
+    let [theta0, theta1] = theta.value();
+
+    let [x, y] = accumulator.value();
+    let [a0, a2, a4] = x.value();
+    let [a1, a3, a5] = y.value();
+    let b0 = -lambda.clone() * y2 + theta.clone() * x2;
+    let b2 = FieldElement::new([-theta0 * px, -theta1 * px]);
+    let b3 = FieldElement::new([lambda0 * py, lambda1 * py]);
+    *accumulator = FieldElement::new([
+        FieldElement::new([
+            a0 * &b0 + &residue * (a3 * &b3 + a4 * &b2), // w0
+            a2 * &b0 + &residue * a5 * &b3 + a0 * &b2,   // w2
+            a4 * &b0 + a1 * &b3 + a2 * &b2,              // w4
+        ]),
+        FieldElement::new([
+            a1 * &b0 + &residue * (a4 * &b3 + a5 * &b2), // w1
+            a3 * &b0 + a0 * &b3 + a1 * &b2,              // w3
+            a5 * &b0 + a2 * &b3 + a3 * &b2,              // w5
+        ]),
+    ]);
+}
 /// Implements the miller loop for the ate pairing of the BLS12 381 curve.
 /// Based on algorithm 9.2, page 212 of the book
 /// "Topics in computational number theory" by W. Bons and K. Lenstra
@@ -62,14 +166,9 @@ fn miller(
     }
 
     for bit in miller_loop_constant_bits[1..].iter() {
-        f = f.pow(2_u64) * line(&r, &r, p);
-        r = r.operate_with(&r).to_affine();
+        double_accumulate_line(&mut r, p, &mut f);
         if *bit {
-            f = f * line(&r, q, p);
-            r = r.operate_with(q);
-            if !r.is_neutral_element() {
-                r = r.to_affine();
-            }
+            add_accumulate_line(&mut r, q, p, &mut f);
         }
     }
     f.inv()
@@ -111,128 +210,45 @@ fn final_exponentiation(
     f2.pow(PHI_DIVIDED_BY_R)
 }
 
-/// Evaluates the line between points `p` and `r` at point `q`
-pub fn line(
-    p: &ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,
-    r: &ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,
-    q: &ShortWeierstrassProjectivePoint<BLS12381Curve>,
-) -> FieldElement<Degree12ExtensionField> {
-    // TODO: Improve error handling.
-    debug_assert!(
-        !q.is_neutral_element(),
-        "q cannot be the point at infinity."
-    );
-    let [px, py] = p.to_fp12_unnormalized();
-    let [rx, ry] = r.to_fp12_unnormalized();
-    let [qx_fp, qy_fp, _] = q.coordinates().clone();
-    let qx = FieldElement::<Degree12ExtensionField>::new([
-        FieldElement::new([
-            FieldElement::new([qx_fp, FieldElement::zero()]),
-            FieldElement::zero(),
-            FieldElement::zero(),
-        ]),
-        FieldElement::zero(),
-    ]);
-    let qy = FieldElement::<Degree12ExtensionField>::new([
-        FieldElement::new([
-            FieldElement::new([qy_fp, FieldElement::zero()]),
-            FieldElement::zero(),
-            FieldElement::zero(),
-        ]),
-        FieldElement::zero(),
-    ]);
-    let a_of_curve = FieldElement::<Degree12ExtensionField>::new([
-        FieldElement::new([
-            FieldElement::new([BLS12381Curve::a(), FieldElement::zero()]),
-            FieldElement::zero(),
-            FieldElement::zero(),
-        ]),
-        FieldElement::zero(),
-    ]);
-
-    if p.is_neutral_element() || r.is_neutral_element() {
-        if p == r {
-            return FieldElement::one();
-        }
-        if p.is_neutral_element() {
-            qx - rx
-        } else {
-            qx - px
-        }
-    } else if p != r {
-        if px == rx {
-            qx - px
-        } else {
-            let l = (ry - &py) / (rx - &px);
-            qy - py - l * (qx - px)
-        }
-    } else {
-        let numerator = FieldElement::from(3) * &px.pow(2_u16) + a_of_curve;
-        let denominator = FieldElement::from(2) * &py;
-        if denominator == FieldElement::zero() {
-            qx - px
-        } else {
-            let l = numerator / denominator;
-            qy - py - l * (qx - px)
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {
-    use crate::{elliptic_curve::traits::IsEllipticCurve, unsigned_integer::element::U384};
+    use crate::{
+        cyclic_group::IsGroup, elliptic_curve::traits::IsEllipticCurve,
+        unsigned_integer::element::U384,
+    };
 
     use super::*;
 
-    type Fp12E = FieldElement<Degree12ExtensionField>;
-
     #[test]
-    fn test_line_1() {
+    fn test_double_accumulate_line_doubles_point_correctly() {
         let g1 = BLS12381Curve::generator();
         let g2 = BLS12381TwistCurve::generator();
-        let expected = Fp12E::from_coefficients(&[
-            "8b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1",
-            "0",
-            "0",
-            "0",
-            "0",
-            "0",
-            "11bfe7fb8923ace27a0692871443365b3e5e0dd7ef388153c5bb27d923a3dedb6b9f9cbfd022a8eb913e281a830fac9c",
-            "13d0fab25f0e7099c6ffaa8ddd3cb036f5c35df322a9359ff8f98a4f5c6a84c50b6007c296eafda2ffa2d20b253a6633",
-            "4c208bdb300097927393e963768099390a3f9d581d8828070e39167384e44fdaf716fa49d68b0bdf431a2f53189c109",
-            "546ca700477f9c2f9def9691be2f7e6eaa0f1474cb64c53ce3b4d4da03cbdac75933b5468ab4b88cf058f147ba2cda9",
-            "0",
-            "0"
-        ]);
-        assert_eq!(line(&g2, &g2, &g1), expected);
+        let mut r = g2.clone();
+        let mut f = FieldElement::one();
+        double_accumulate_line(&mut r, &g1, &mut f);
+        assert_eq!(r, g2.operate_with(&g2));
     }
 
     #[test]
-    fn test_line_2() {
+    fn test_add_accumulate_line_adds_points_correctly() {
         let g1 = BLS12381Curve::generator();
-        let g2 = BLS12381TwistCurve::generator();
-        let g2_times_5 = g2.operate_with_self(5_u16).to_affine();
-        let expected = Fp12E::from_coefficients(&[
-            "8b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1",
-            "0",
-            "0",
-            "0",
-            "0",
-            "0",
-            "c61af5cbff75e6cdd8100b22636ec410a1cb914a599775a29590dd2c48af1f18a71e120fb72ddc7c1ca57ce58a8670f",
-            "4b7599ae8879affcb68f23ac23ddc7316f81013a2caa8925f33fe978f19ce00effd7e5bd6b51e2d9723e66fd897e125",
-            "449f41bddfdc54476c92f4249f1ce75a9693eb8f0b34ba3c57de3edaa29ba069f0d97376eadb1be6c5a5dfdf595302b",
-            "ebf57b77d5ffe1476a8c8c0f0e0e73e8d32f070c89f09e465cb39312463bc42768c6028a481fb8ba2f5d2a95cd4eedb",
-            "0",
-            "0"
-        ]);
-        assert_eq!(line(&g2, &g2_times_5, &g1), expected);
+        let g = BLS12381TwistCurve::generator();
+        let a: u64 = 12;
+        let b: u64 = 23;
+        let g2 = g.operate_with_self(a).to_affine();
+        let g3 = g.operate_with_self(b).to_affine();
+        let expected = g.operate_with_self(a + b);
+        let mut r = g2.clone();
+        let mut f = FieldElement::one();
+        add_accumulate_line(&mut r, &g3, &g1, &mut f);
+        assert_eq!(r, expected);
     }
 
     #[test]
     fn batch_ate_pairing_bilinearity() {
-        let p = BLS12381Curve::generator().to_affine();
-        let q = BLS12381TwistCurve::generator().to_affine();
+        let p = BLS12381Curve::generator();
+        let q = BLS12381TwistCurve::generator();
         let a = U384::from_u64(11);
         let b = U384::from_u64(93);
 
@@ -241,21 +257,18 @@ mod tests {
                 &p.operate_with_self(a).to_affine(),
                 &q.operate_with_self(b).to_affine(),
             ),
-            (&p.operate_with_self(a * b).to_affine(), &q.neg()),
+            (
+                &p.operate_with_self(a * b).to_affine(),
+                &q.neg().to_affine(),
+            ),
         ]);
         assert_eq!(result, FieldElement::one());
     }
 
     #[test]
-    fn ate_pairing_returns_one_when_one_element_is_the_neutral_element() {
-        let p = BLS12381Curve::generator().to_affine();
-        let q = ShortWeierstrassProjectivePoint::neutral_element();
-        let result = BLS12381AtePairing::compute_batch(&[(&p.to_affine(), &q)]);
-        assert_eq!(result, FieldElement::one());
-
-        let p = ShortWeierstrassProjectivePoint::neutral_element();
+    fn miller_single() {
+        let p = BLS12381Curve::generator();
         let q = BLS12381TwistCurve::generator();
-        let result = BLS12381AtePairing::compute_batch(&[(&p, &q.to_affine())]);
-        assert_eq!(result, FieldElement::one());
+        miller(&q, &p);
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -11,7 +11,7 @@ use crate::{
 use super::{errors::DeserializationError, traits::IsShortWeierstrass};
 
 #[derive(Clone, Debug)]
-pub struct ShortWeierstrassProjectivePoint<E: IsEllipticCurve>(ProjectivePoint<E>);
+pub struct ShortWeierstrassProjectivePoint<E: IsEllipticCurve>(pub ProjectivePoint<E>);
 
 impl<E: IsEllipticCurve> ShortWeierstrassProjectivePoint<E> {
     /// Creates an elliptic curve point giving the projective [x: y: z] coordinates.

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -117,6 +117,16 @@ where
     }
 }
 
+impl<Q: Clone + Debug + HasQuadraticNonResidue> FieldElement<QuadraticExtensionField<Q>> {
+    pub fn square(&self) -> Self {
+        let [a0, a1] = self.value();
+        let v0 = a0 * a1;
+        let c0 = (a0 + a1) * (a0 + Q::residue() * a1) - &v0 - Q::residue() * &v0;
+        let c1 = &v0 + &v0;
+        Self::new([c0, c1])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::field::fields::u64_prime_field::{U64FieldElement, U64PrimeField};


### PR DESCRIPTION
curve

# TITLE

## Description

This PR adds mixed addition optimizations to the miller loop of the bls 12 381 curve ([source](https://eprint.iacr.org/2013/722.pdf)), along with other minor optimizations.

## Type of change
- [x] Optimization

## Checklist
- [x] Unit tests added