### PR TITLE
Fix `const_le` in UnsignedInteger

### DIFF
--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -892,9 +892,16 @@ mod tests_u256_prime_fields {
     }
 
     #[test]
-    fn creating_a_field_element_from_hex_works() {
+    fn creating_a_field_element_from_hex_works_2() {
         let a = U256F29Element::from_hex_unchecked("aa");
         let b = U256F29Element::from(25);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn creating_a_field_element_from_hex_works_3() {
+        let a = U256F29Element::from_hex_unchecked("1d");
+        let b = U256F29Element::zero();
         assert_eq!(a, b);
     }
 }

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -375,7 +375,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
             }
             i += 1;
         }
-        false
+        true
     }
 
     pub const fn const_shl(self, times: usize) -> Self {
@@ -1846,6 +1846,15 @@ mod tests_u256 {
         let (b, overflow) = U256::sub(&a, &c);
         assert!(overflow);
         assert_eq!(b_expected, b);
+    }
+
+    #[test]
+    fn const_le_works() {
+        let a = U256::from_u64(334);
+        let b = U256::from_u128(333);
+        assert!(U256::const_le(&b, &a));
+        assert!(U256::const_le(&a, &a));
+        assert!(!U256::const_le(&a, &b));
     }
 
     #[test]


### PR DESCRIPTION
# Fix `const_le` in UnsignedInteger

## Description

It fixes the function to return `true` when elements are equal.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist
- [x] Unit tests added