### PR TITLE
bench: hide results behind black_box to avoid elimination

### DIFF
--- a/.github/workflows/iai_benchs_main.yml
+++ b/.github/workflows/iai_benchs_main.yml
@@ -28,5 +28,5 @@ jobs:
       uses: actions/cache/save@v3
       with:
         path: |
-          */target
-        key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.pull_request.base.sha }}
+          **/target/iai
+        key: ${{ runner.os }}-iai-benchmark-cache-${{ github.sha }}

--- a/.github/workflows/iai_benchs_pr.yml
+++ b/.github/workflows/iai_benchs_pr.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         lookup-only: true
         path: |
-          */target
+          **/target/iai
         key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.pull_request.base.sha }}
     - name: Install valgrind
       if: ${{ steps.cache-iai-results.outputs.cache-hit != 'true' }}
@@ -48,7 +48,7 @@ jobs:
       uses: actions/cache/save@v3
       with:
         path: |
-          */target
+          **/target/iai
         key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.pull_request.base.sha }}
   run_iai_benchs:
     name: Run iai benchmarks
@@ -67,13 +67,13 @@ jobs:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2
       with:
-        shared-key: ${{ runner.os }}-iai-benchmark-cache
+        shared-key: ${{ runner.os }}-benchmark-build-cache
     - name: Restore cache
       id: cache-iai-results
       uses: actions/cache/restore@v3
       with:
         path: |
-          */target
+          **/target/iai
         key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.pull_request.base.sha }}
         fail-on-cache-miss: true
     - name: Run benchmarks

--- a/fft/benches/functions/mod.rs
+++ b/fft/benches/functions/mod.rs
@@ -10,30 +10,37 @@ use lambdaworks_math::{field::traits::RootsConfig, polynomial::Polynomial};
 
 use crate::util::{F, FE};
 
+#[inline(never)]
 pub fn ordered_fft_nr(input: &[FE], twiddles: &[FE]) {
     let mut input = input.to_vec();
     in_place_nr_2radix_fft(&mut input, twiddles);
     in_place_bit_reverse_permute(&mut input);
 }
 
+#[inline(never)]
 pub fn ordered_fft_rn(input: &[FE], twiddles: &[FE]) {
     let mut input = input.to_vec();
     in_place_bit_reverse_permute(&mut input);
     in_place_rn_2radix_fft(&mut input, twiddles);
 }
 
+#[inline(never)]
 pub fn twiddles_generation(order: u64) {
     get_twiddles::<F>(order, RootsConfig::Natural).unwrap();
 }
 
+#[inline(never)]
 pub fn bitrev_permute(input: &[FE]) {
     let mut input = input.to_vec();
     in_place_bit_reverse_permute(&mut input);
 }
 
+#[inline(never)]
 pub fn poly_evaluate_fft(poly: &Polynomial<FE>) {
     poly.evaluate_fft(1, None).unwrap();
 }
+
+#[inline(never)]
 pub fn poly_interpolate_fft(evals: &[FE]) {
     Polynomial::interpolate_fft(evals).unwrap();
 }

--- a/fft/benches/util.rs
+++ b/fft/benches/util.rs
@@ -11,6 +11,7 @@ use rand::random;
 pub type F = Stark252PrimeField;
 pub type FE = FieldElement<F>;
 
+#[inline(never)]
 pub fn rand_field_elements(order: u64) -> Vec<FE> {
     let mut result = Vec::with_capacity(1 << order);
     for _ in 0..result.capacity() {
@@ -20,6 +21,7 @@ pub fn rand_field_elements(order: u64) -> Vec<FE> {
     result
 }
 
+#[inline(never)]
 pub fn rand_poly(order: u64) -> Polynomial<FE> {
     Polynomial::new(&rand_field_elements(order))
 }

--- a/math/benches/iai_field.rs
+++ b/math/benches/iai_field.rs
@@ -6,44 +6,51 @@ mod util;
 #[inline(never)]
 fn fp_add_benchmarks() {
     let (x, y) = rand_field_elements_pair();
-    let _ = black_box(x) + black_box(y);
+    let res = black_box(x) + black_box(y);
+    black_box(res);
 }
 
 #[inline(never)]
 fn fp_mul_benchmarks() {
     let (x, y) = rand_field_elements_pair();
-    let _ = black_box(x) * black_box(y);
+    let res = black_box(x) * black_box(y);
+    black_box(res);
 }
 
 #[inline(never)]
 fn fp_pow_benchmarks() {
-    let (x, _) = rand_field_elements_pair();
+    let (x, _res) = rand_field_elements_pair();
     let y: u64 = 5;
-    let _ = black_box(x).pow(black_box(y));
+    let res = black_box(x).pow(black_box(y));
+    black_box(res);
 }
 
 #[inline(never)]
 fn fp_sub_benchmarks() {
     let (x, y) = rand_field_elements_pair();
-    let _ = black_box(x) - black_box(y);
+    let res = black_box(x) - black_box(y);
+    black_box(res);
 }
 
 #[inline(never)]
 fn fp_inv_benchmarks() {
-    let (x, _) = rand_field_elements_pair();
-    let _ = black_box(x).inv();
+    let (x, _res) = rand_field_elements_pair();
+    let res = black_box(x).inv();
+    black_box(res);
 }
 
 #[inline(never)]
 fn fp_div_benchmarks() {
     let (x, y) = rand_field_elements_pair();
-    let _ = black_box(x) / black_box(y);
+    let res = black_box(x) / black_box(y);
+    black_box(res);
 }
 
 #[inline(never)]
 fn fp_eq_benchmarks() {
     let (x, y) = rand_field_elements_pair();
-    let _ = black_box(x) == black_box(y);
+    let res = black_box(x) == black_box(y);
+    black_box(res);
 }
 
 iai_callgrind::main!(

--- a/math/benches/iai_polynomial.rs
+++ b/math/benches/iai_polynomial.rs
@@ -10,48 +10,55 @@ const ORDER: u64 = const_random!(u64) % 8;
 fn poly_evaluate_benchmarks() {
     let poly = rand_poly(ORDER);
     let x = FE::new(rand::random::<u64>());
-    poly.evaluate(black_box(&x));
+    let res = poly.evaluate(black_box(&x));
+    black_box(res);
 }
 
 #[inline(never)]
 fn poly_evaluate_slice_benchmarks() {
     let poly = rand_poly(ORDER);
     let inputs = rand_field_elements(ORDER);
-    poly.evaluate_slice(black_box(&inputs));
+    let res = poly.evaluate_slice(black_box(&inputs));
+    black_box(res);
 }
 
 #[inline(never)]
 fn poly_add_benchmarks() {
     let x_poly = rand_poly(ORDER);
     let y_poly = rand_poly(ORDER);
-    let _ = black_box(&x_poly) + black_box(&y_poly);
+    let res = black_box(&x_poly) + black_box(&y_poly);
+    black_box(res);
 }
 
 #[inline(never)]
 fn poly_neg_benchmarks() {
     let x_poly = rand_poly(ORDER);
-    let _ = black_box(x_poly);
+    let res = black_box(x_poly);
+    black_box(res);
 }
 
 #[inline(never)]
 fn poly_sub_benchmarks() {
     let x_poly = rand_poly(ORDER);
     let y_poly = rand_poly(ORDER);
-    let _ = black_box(x_poly) - black_box(y_poly);
+    let res = black_box(x_poly) - black_box(y_poly);
+    black_box(res);
 }
 
 #[inline(never)]
 fn poly_mul_benchmarks() {
     let x_poly = rand_poly(ORDER);
     let y_poly = rand_poly(ORDER);
-    let _ = black_box(x_poly) + black_box(y_poly);
+    let res = black_box(x_poly) * black_box(y_poly);
+    black_box(res);
 }
 
 #[inline(never)]
 fn poly_div_benchmarks() {
     let x_poly = rand_poly(ORDER);
     let y_poly = rand_poly(ORDER);
-    let _ = black_box(x_poly) + black_box(y_poly);
+    let res = black_box(x_poly) / black_box(y_poly);
+    black_box(res);
 }
 
 iai_callgrind::main!(

--- a/math/benches/util.rs
+++ b/math/benches/util.rs
@@ -14,6 +14,7 @@ const MODULUS: u64 = PRIMES[const_random!(usize) % PRIMES.len()];
 pub type FE = U64FieldElement<MODULUS>;
 
 #[allow(dead_code)]
+#[inline(never)]
 pub fn rand_field_elements(order: u64) -> Vec<FE> {
     let mut result = Vec::with_capacity(1 << order);
     for _ in 0..result.capacity() {
@@ -23,11 +24,13 @@ pub fn rand_field_elements(order: u64) -> Vec<FE> {
 }
 
 #[allow(dead_code)]
+#[inline(never)]
 pub fn rand_field_elements_pair() -> (FE, FE) {
     (FE::new(random()), FE::new(random()))
 }
 
 #[allow(dead_code)]
+#[inline(never)]
 pub fn rand_poly(order: u64) -> Polynomial<FE> {
     Polynomial::new(&rand_field_elements(order))
 }

--- a/proving_system/stark/benches/functions/stark.rs
+++ b/proving_system/stark/benches/functions/stark.rs
@@ -15,6 +15,7 @@ use lambdaworks_stark::air::example::{
 
 use crate::util::FE;
 
+#[inline(never)]
 pub fn prove_fib(trace_length: usize) {
     let trace = simple_fibonacci::fibonacci_trace([FE::from(1), FE::from(1)], trace_length);
     let trace_length = trace[0].len();
@@ -39,6 +40,7 @@ pub fn prove_fib(trace_length: usize) {
     verify(&result, &fibonacci_air);
 }
 
+#[inline(never)]
 pub fn prove_fib_2_cols() {
     let trace_columns =
         fibonacci_2_columns::fibonacci_trace_2_columns([FE::from(1), FE::from(1)], 16);
@@ -64,6 +66,7 @@ pub fn prove_fib_2_cols() {
 }
 
 #[allow(dead_code)]
+#[inline(never)]
 pub fn prove_fib17() {
     let trace = simple_fibonacci::fibonacci_trace([FE17::from(1), FE17::from(1)], 4);
 
@@ -88,6 +91,7 @@ pub fn prove_fib17() {
 }
 
 #[allow(dead_code)]
+#[inline(never)]
 pub fn prove_quadratic() {
     let trace = quadratic_air::quadratic_trace(FE::from(3), 16);
 
@@ -115,6 +119,7 @@ pub fn prove_quadratic() {
 // functions used by criterion.
 
 #[allow(dead_code)]
+#[inline(never)]
 pub fn prove_cairo_fibonacci_5() {
     let base_dir = env!("CARGO_MANIFEST_DIR");
     let dir_trace = base_dir.to_owned() + "/src/cairo_vm/test_data/fibonacci_5.trace";
@@ -135,6 +140,7 @@ pub fn prove_cairo_fibonacci_5() {
 }
 
 #[allow(dead_code)]
+#[inline(never)]
 pub fn prove_cairo_fibonacci_10() {
     let base_dir = env!("CARGO_MANIFEST_DIR");
     let dir_trace = base_dir.to_owned() + "/src/cairo_vm/test_data/fibonacci_10.trace";
@@ -155,6 +161,7 @@ pub fn prove_cairo_fibonacci_10() {
 }
 
 #[allow(dead_code)]
+#[inline(never)]
 pub fn prove_cairo_fibonacci_30() {
     let base_dir = env!("CARGO_MANIFEST_DIR");
     let dir_trace = base_dir.to_owned() + "/src/cairo_vm/test_data/fibonacci_30.trace";
@@ -175,6 +182,7 @@ pub fn prove_cairo_fibonacci_30() {
 }
 
 #[allow(dead_code)]
+#[inline(never)]
 pub fn prove_cairo_fibonacci_50() {
     let base_dir = env!("CARGO_MANIFEST_DIR");
     let dir_trace = base_dir.to_owned() + "/src/cairo_vm/test_data/fibonacci_50.trace";
@@ -195,6 +203,7 @@ pub fn prove_cairo_fibonacci_50() {
 }
 
 #[allow(dead_code)]
+#[inline(never)]
 pub fn prove_cairo_fibonacci_100() {
     let base_dir = env!("CARGO_MANIFEST_DIR");
     let dir_trace = base_dir.to_owned() + "/src/cairo_vm/test_data/fibonacci_100.trace";


### PR DESCRIPTION
Several benchmarks were misreporting 0 cycles due to dead code removal. The calls have been wrapped in `black_box` to avoid this. Many benchmark functions have been marked as no inline as well. There are also a few necessary fixes to the iai workflows.

## Type of change

- [x] Bug fix

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
