### PR TITLE
perf: weaken power in twiddles generation

### DIFF
--- a/fft/benches/criterion_fft.rs
+++ b/fft/benches/criterion_fft.rs
@@ -43,14 +43,22 @@ pub fn fft_benchmarks(c: &mut Criterion) {
 
 fn twiddles_generation_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("FFT twiddles generation");
+    const CONFIGS: [(&str, RootsConfig); 4] = [
+        ("natural", RootsConfig::Natural),
+        ("natural inversed", RootsConfig::NaturalInversed),
+        ("bit-reversed", RootsConfig::BitReverse),
+        ("bit-reversed inversed", RootsConfig::BitReverseInversed),
+    ];
 
     for order in SIZE_ORDERS {
         group.throughput(criterion::Throughput::Elements(1 << (order - 1)));
-        group.bench_with_input("Sequential", &order, |bench, order| {
-            bench.iter_with_large_drop(|| {
-                functions::twiddles_generation(*order);
+        for (name, config) in CONFIGS {
+            group.bench_with_input(name, &(order, config), |bench, (order, config)| {
+                bench.iter_with_large_drop(|| {
+                    functions::twiddles_generation(*order, *config);
+                });
             });
-        });
+        }
     }
 
     group.finish();

--- a/fft/benches/functions/mod.rs
+++ b/fft/benches/functions/mod.rs
@@ -22,8 +22,8 @@ pub fn ordered_fft_rn(input: &[FE], twiddles: &[FE]) {
     in_place_rn_2radix_fft(&mut input, twiddles);
 }
 
-pub fn twiddles_generation(order: u64) {
-    get_twiddles::<F>(order, RootsConfig::Natural).unwrap();
+pub fn twiddles_generation(order: u64, config: RootsConfig) {
+    get_twiddles::<F>(order, config).unwrap();
 }
 
 pub fn bitrev_permute(input: &[FE]) {

--- a/fft/benches/iai_fft.rs
+++ b/fft/benches/iai_fft.rs
@@ -19,8 +19,23 @@ fn seq_fft_benchmarks() {
 }
 
 #[inline(never)]
-fn seq_twiddles_generation_benchmarks() {
-    functions::twiddles_generation(black_box(SIZE_ORDER));
+fn seq_twiddles_generation_natural_benchmarks() {
+    functions::twiddles_generation(black_box(SIZE_ORDER), RootsConfig::Natural);
+}
+
+#[inline(never)]
+fn seq_twiddles_generation_natural_inversed_benchmarks() {
+    functions::twiddles_generation(black_box(SIZE_ORDER), RootsConfig::NaturalInversed);
+}
+
+#[inline(never)]
+fn seq_twiddles_generation_bitrev_benchmarks() {
+    functions::twiddles_generation(black_box(SIZE_ORDER), RootsConfig::BitReverse);
+}
+
+#[inline(never)]
+fn seq_twiddles_generation_bitrev_inversed_benchmarks() {
+    functions::twiddles_generation(black_box(SIZE_ORDER), RootsConfig::BitReverseInversed);
 }
 
 #[inline(never)]
@@ -45,7 +60,10 @@ fn seq_poly_interpolation_benchmarks() {
 iai_callgrind::main!(
     callgrind_args = "toggle-collect=util::*";
     functions = seq_fft_benchmarks,
-    seq_twiddles_generation_benchmarks,
+    seq_twiddles_generation_natural_benchmarks,
+    seq_twiddles_generation_natural_inversed_benchmarks,
+    seq_twiddles_generation_bitrev_benchmarks,
+    seq_twiddles_generation_bitrev_inversed_benchmarks,
     seq_bitrev_permutation_benchmarks,
     seq_poly_evaluation_benchmarks,
     seq_poly_interpolation_benchmarks
@@ -55,6 +73,9 @@ iai_callgrind::main!(
 iai_callgrind::main!(
     callgrind_args = "toggle-collect=util::*";
     functions = seq_fft_benchmarks,
-    seq_twiddles_generation_benchmarks,
+    seq_twiddles_generation_natural_benchmarks,
+    seq_twiddles_generation_natural_inversed_benchmarks,
+    seq_twiddles_generation_bitrev_benchmarks,
+    seq_twiddles_generation_bitrev_inversed_benchmarks,
     seq_bitrev_permutation_benchmarks,
 );

--- a/fft/src/roots_of_unity.rs
+++ b/fft/src/roots_of_unity.rs
@@ -22,10 +22,12 @@ pub fn get_powers_of_primitive_root<F: IsFFTField>(
     };
     let up_to = match config {
         RootsConfig::Natural | RootsConfig::NaturalInversed => count,
+        // In bit reverse form we could need as many as `(1 << count.bits()) - 1` roots
         _ => count.next_power_of_two(),
     };
 
     let mut results = Vec::with_capacity(up_to);
+    // NOTE: a nice version would be using `core::iter::successors`. However, this is 10% faster.
     results.extend((0..up_to).scan(FieldElement::one(), |state, _| {
         let res = state.clone();
         *state = &(*state) * &root;


### PR DESCRIPTION
Because we save all powers, we can extract the computation from the loop and turn it into successive products instead.
This improves twiddle generation from 5 to 23 times depending on config, and FFT itself by about 10%.
Additional improvement by replacing the batched inverse by simply computing the inverse of the root ahead of time.

Uses the benchmarks introduced in #373 

## Type of change

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added/run

Results (ran in MacBook Pro M1 2020 16GB with MacOS Ventura 13.3.1:
```
Ordered FFT/Sequential from NR radix2                                                                                                                                                              [17/1824]
                        time:   [676.77 ms 677.22 ms 677.82 ms]
                        thrpt:  [3.0940 Melem/s 3.0967 Melem/s 3.0988 Melem/s]
                 change:
                        time:   [-20.765% -20.376% -20.003%] (p = 0.00 < 0.05)
                        thrpt:  [+25.004% +25.590% +26.207%]
                        Performance has improved.

Ordered FFT/Sequential from RN radix2                                                                           
                        time:   [1.2457 s 1.2508 s 1.2559 s]                                                                                                                                                
                        thrpt:  [1.6699 Melem/s 1.6767 Melem/s 1.6835 Melem/s]
                 change:                                                                              
                        time:   [-17.362% -15.432% -13.770%] (p = 0.00 < 0.05)
                        thrpt:  [+15.969% +18.248% +21.009%]                  
                        Performance has improved.                                                     
                                                   
FFT twiddles generation/natural                                                                            
                        time:   [19.367 ms 19.426 ms 19.510 ms]
                        thrpt:  [53.746 Melem/s 53.978 Melem/s 54.143 Melem/s]
                 change:
                        time:   [-96.929% -96.916% -96.902%] (p = 0.00 < 0.05)
                        thrpt:  [+3128.1% +3142.7% +3156.6%]
                        Performance has improved.

FFT twiddles generation/natural inversed                                                                            
                        time:   [19.369 ms 19.566 ms 19.702 ms]
                        thrpt:  [53.223 Melem/s 53.593 Melem/s 54.136 Melem/s]
                 change:
                        time:   [-97.226% -97.208% -97.189%] (p = 0.00 < 0.05)
                        thrpt:  [+3457.6% +3481.0% +3504.4%]
                        Performance has improved.

FFT twiddles generation/bit-reversed                                                                            
                        time:   [29.767 ms 29.791 ms 29.826 ms]
                        thrpt:  [35.157 Melem/s 35.198 Melem/s 35.226 Melem/s]
                 change:
                        time:   [-95.303% -95.254% -95.213%] (p = 0.00 < 0.05)
                        thrpt:  [+1988.8% +2007.2% +2028.9%]
                        Performance has improved.

FFT twiddles generation/bit-reversed inversed                                                                            
                        time:   [29.821 ms 29.909 ms 30.006 ms]
                        thrpt:  [34.945 Melem/s 35.059 Melem/s 35.163 Melem/s]
                 change:
                        time:   [-95.698% -95.684% -95.668%] (p = 0.00 < 0.05)
                        thrpt:  [+2208.3% +2216.9% +2224.6%]
                        Performance has improved.

Bit-reverse permutation/Sequential                                                                            
                        time:   [24.589 ms 24.667 ms 24.824 ms]
                        thrpt:  [84.480 Melem/s 85.017 Melem/s 85.289 Melem/s]
                 change:
                        time:   [-9.3776% -6.9110% -4.4375%] (p = 0.00 < 0.05)
                        thrpt:  [+4.6435% +7.4240% +10.348%]
                        Performance has improved.

Polynomial evaluation/Sequential FFT                                                                           
                        time:   [718.67 ms 721.94 ms 724.82 ms]
                        thrpt:  [2.8933 Melem/s 2.9049 Melem/s 2.9181 Melem/s]
                 change:
                        time:   [-52.667% -52.025% -51.465%] (p = 0.00 < 0.05)
                        thrpt:  [+106.04% +108.44% +111.27%]
                        Performance has improved.

Polynomial interpolation/Sequential FFT                                                                           
                        time:   [755.05 ms 756.12 ms 757.24 ms]
                        thrpt:  [2.7695 Melem/s 2.7736 Melem/s 2.7775 Melem/s]
                 change:
                        time:   [-52.984% -52.796% -52.608%] (p = 0.00 < 0.05)
                        thrpt:  [+111.01% +111.85% +112.69%]
                        Performance has improved.
```