### PR TITLE
Remove stark criterion benches from CI

### DIFF
--- a/.github/workflows/criterion_benchs.yml
+++ b/.github/workflows/criterion_benchs.yml
@@ -26,7 +26,6 @@ jobs:
       run: |
         cargo bench --no-fail-fast --bench "criterion_fft" \
                                    --bench "criterion_polynomial" \
-                                   --bench "criterion_stark" \
         -- --output-format bencher | tee output.txt
     - name: Store benchmark result
       uses: benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
# Remove stark criterion benches from CI

## Description

Main CI benches are broken because of this

## Type of change

Please delete options that are not relevant.

- Bug fix