### PR TITLE
inline cios + several arithmetical ops

### DIFF
--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -143,7 +143,7 @@ impl<const NUM_LIMBS: usize> Sub<&UnsignedInteger<NUM_LIMBS>> for UnsignedIntege
 
 impl<const NUM_LIMBS: usize> Sub<UnsignedInteger<NUM_LIMBS>> for &UnsignedInteger<NUM_LIMBS> {
     type Output = UnsignedInteger<NUM_LIMBS>;
-
+    #[inline(always)]
     fn sub(self, other: UnsignedInteger<NUM_LIMBS>) -> UnsignedInteger<NUM_LIMBS> {
         self - &other
     }
@@ -154,6 +154,7 @@ impl<const NUM_LIMBS: usize> Sub<UnsignedInteger<NUM_LIMBS>> for &UnsignedIntege
 impl<const NUM_LIMBS: usize> Mul<&UnsignedInteger<NUM_LIMBS>> for &UnsignedInteger<NUM_LIMBS> {
     type Output = UnsignedInteger<NUM_LIMBS>;
 
+    #[inline(always)]
     fn mul(self, other: &UnsignedInteger<NUM_LIMBS>) -> UnsignedInteger<NUM_LIMBS> {
         let (mut n, mut t) = (0, 0);
         for i in (0..NUM_LIMBS).rev() {
@@ -197,7 +198,7 @@ impl<const NUM_LIMBS: usize> Mul<&UnsignedInteger<NUM_LIMBS>> for &UnsignedInteg
 
 impl<const NUM_LIMBS: usize> Mul<UnsignedInteger<NUM_LIMBS>> for UnsignedInteger<NUM_LIMBS> {
     type Output = UnsignedInteger<NUM_LIMBS>;
-
+    #[inline(always)]
     fn mul(self, other: UnsignedInteger<NUM_LIMBS>) -> UnsignedInteger<NUM_LIMBS> {
         &self * &other
     }
@@ -205,7 +206,7 @@ impl<const NUM_LIMBS: usize> Mul<UnsignedInteger<NUM_LIMBS>> for UnsignedInteger
 
 impl<const NUM_LIMBS: usize> Mul<&UnsignedInteger<NUM_LIMBS>> for UnsignedInteger<NUM_LIMBS> {
     type Output = UnsignedInteger<NUM_LIMBS>;
-
+    #[inline(always)]
     fn mul(self, other: &Self) -> Self {
         &self * other
     }
@@ -213,7 +214,7 @@ impl<const NUM_LIMBS: usize> Mul<&UnsignedInteger<NUM_LIMBS>> for UnsignedIntege
 
 impl<const NUM_LIMBS: usize> Mul<UnsignedInteger<NUM_LIMBS>> for &UnsignedInteger<NUM_LIMBS> {
     type Output = UnsignedInteger<NUM_LIMBS>;
-
+    #[inline(always)]
     fn mul(self, other: UnsignedInteger<NUM_LIMBS>) -> UnsignedInteger<NUM_LIMBS> {
         self * &other
     }
@@ -221,7 +222,7 @@ impl<const NUM_LIMBS: usize> Mul<UnsignedInteger<NUM_LIMBS>> for &UnsignedIntege
 
 impl<const NUM_LIMBS: usize> Shl<usize> for &UnsignedInteger<NUM_LIMBS> {
     type Output = UnsignedInteger<NUM_LIMBS>;
-
+    #[inline(always)]
     fn shl(self, times: usize) -> UnsignedInteger<NUM_LIMBS> {
         self.const_shl(times)
     }
@@ -229,7 +230,7 @@ impl<const NUM_LIMBS: usize> Shl<usize> for &UnsignedInteger<NUM_LIMBS> {
 
 impl<const NUM_LIMBS: usize> Shl<usize> for UnsignedInteger<NUM_LIMBS> {
     type Output = UnsignedInteger<NUM_LIMBS>;
-
+    #[inline(always)]
     fn shl(self, times: usize) -> UnsignedInteger<NUM_LIMBS> {
         &self << times
     }
@@ -239,7 +240,7 @@ impl<const NUM_LIMBS: usize> Shl<usize> for UnsignedInteger<NUM_LIMBS> {
 
 impl<const NUM_LIMBS: usize> Shr<usize> for &UnsignedInteger<NUM_LIMBS> {
     type Output = UnsignedInteger<NUM_LIMBS>;
-
+    #[inline(always)]
     fn shr(self, times: usize) -> UnsignedInteger<NUM_LIMBS> {
         self.const_shr(times)
     }
@@ -247,7 +248,7 @@ impl<const NUM_LIMBS: usize> Shr<usize> for &UnsignedInteger<NUM_LIMBS> {
 
 impl<const NUM_LIMBS: usize> Shr<usize> for UnsignedInteger<NUM_LIMBS> {
     type Output = UnsignedInteger<NUM_LIMBS>;
-
+    #[inline(always)]
     fn shr(self, times: usize) -> UnsignedInteger<NUM_LIMBS> {
         &self >> times
     }
@@ -257,6 +258,7 @@ impl<const NUM_LIMBS: usize> Shr<usize> for UnsignedInteger<NUM_LIMBS> {
 
 impl<const NUM_LIMBS: usize> BitAnd for UnsignedInteger<NUM_LIMBS> {
     type Output = Self;
+    #[inline(always)]
     fn bitand(self, rhs: Self) -> Self::Output {
         let mut limbs = [0; NUM_LIMBS];
         // Clippy solution is complicated in this case
@@ -269,19 +271,20 @@ impl<const NUM_LIMBS: usize> BitAnd for UnsignedInteger<NUM_LIMBS> {
 }
 
 impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
+    #[inline(always)]
     pub const fn from_u64(value: u64) -> Self {
         let mut limbs = [0u64; NUM_LIMBS];
         limbs[NUM_LIMBS - 1] = value;
         UnsignedInteger { limbs }
     }
-
+    #[inline(always)]
     pub const fn from_u128(value: u128) -> Self {
         let mut limbs = [0u64; NUM_LIMBS];
         limbs[NUM_LIMBS - 1] = value as u64;
         limbs[NUM_LIMBS - 2] = (value >> 64) as u64;
         UnsignedInteger { limbs }
     }
-
+    #[inline(always)]
     const fn is_hex_string(string: &str) -> bool {
         let len: usize = string.len();
         let bytes = string.as_bytes();
@@ -451,6 +454,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
     /// Multi-precision subtraction.
     /// Adapted from Algorithm 14.9 of "Handbook of Applied Cryptography" (https://cacr.uwaterloo.ca/hac/)
     /// Returns the results and a flag that is set if the substraction underflowed
+    #[inline(always)]
     pub const fn sub(
         a: &UnsignedInteger<NUM_LIMBS>,
         b: &UnsignedInteger<NUM_LIMBS>,

--- a/math/src/unsigned_integer/montgomery.rs
+++ b/math/src/unsigned_integer/montgomery.rs
@@ -8,6 +8,7 @@ impl MontgomeryAlgorithms {
     /// Notice CIOS stands for Coarsely Integrated Operand Scanning
     /// For more information see section 2.3.2 of Tolga Acar's thesis
     /// https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
+    #[inline(always)]
     pub const fn cios<const NUM_LIMBS: usize>(
         a: &UnsignedInteger<NUM_LIMBS>,
         b: &UnsignedInteger<NUM_LIMBS>,


### PR DESCRIPTION
# Inline cios

## Description

This PR applies the #[inline(always)] attribute to the cios operation and several other arithmetical operations.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [x] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
