### PR TITLE
perf: weaken power in sqrt

### DIFF
--- a/math/benches/criterion_field.rs
+++ b/math/benches/criterion_field.rs
@@ -41,8 +41,16 @@ pub fn starkfield_ops_benchmarks(c: &mut Criterion) {
         bench.iter(|| x / y);
     });
 
-    group.bench_with_input("eq", &(x, y), |bench, (x, y)| {
+    group.bench_with_input("eq", &(x.clone(), y), |bench, (x, y)| {
         bench.iter(|| x == y);
+    });
+
+    group.bench_with_input("sqrt", &x, |bench, x| {
+        bench.iter(|| x.sqrt());
+    });
+
+    group.bench_with_input("sqrt squared", &(&x * &x), |bench, x| {
+        bench.iter(|| x.sqrt());
     });
 }
 

--- a/math/benches/iai_field.rs
+++ b/math/benches/iai_field.rs
@@ -92,6 +92,17 @@ fn fp_eq_benchmarks() {
     let _ = black_box(x) == black_box(y);
 }
 
+#[inline(never)]
+fn fp_sqrt_benchmarks() {
+    let x = FieldElement::<Stark252PrimeField>::from_hex(
+        "0x03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
+    )
+    .unwrap();
+    // Make sure it has a square root
+    let x = &x * &x;
+    let _ = black_box(black_box(x).sqrt());
+}
+
 iai_callgrind::main!(
     callgrind_args = "toggle-collect=util::*";
     functions = fp_add_benchmarks,
@@ -100,5 +111,6 @@ iai_callgrind::main!(
     fp_sub_benchmarks,
     fp_inv_benchmarks,
     fp_div_benchmarks,
-    fp_eq_benchmarks
+    fp_eq_benchmarks,
+    fp_sqrt_benchmarks,
 );

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -445,13 +445,13 @@ impl<F: IsPrimeField> FieldElement<F> {
 
         while t != one {
             let mut i = zero.clone();
-            let mut e = FieldElement::from(2);
+            let mut e = &t * &t;
             while i.representative() < m.representative() {
                 i += FieldElement::one();
-                if t.pow(e.representative()) == one {
+                if e == one {
                     break;
                 }
-                e = e * &two;
+                e = &e * &e;
             }
 
             let b = c.pow(two.pow((m - &i - &one).representative()).representative());

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -419,13 +419,13 @@ impl<F: IsPrimeField> FieldElement<F> {
             LegendreSymbol::One => (),
         };
 
-        let (zero, one, two) = (Self::zero(), Self::one(), Self::from(2));
+        let (one, two) = (Self::one(), Self::from(2));
 
         let mut q = Self::zero() - &one;
-        let mut s = Self::zero();
+        let mut s = 0u64;
 
         while q.is_even() {
-            s = s + &one;
+            s += 1;
             q = q / &two;
         }
 
@@ -444,17 +444,17 @@ impl<F: IsPrimeField> FieldElement<F> {
         let mut m = s;
 
         while t != one {
-            let mut i = zero.clone();
+            let mut i = 0;
             let mut e = &t * &t;
-            while i.representative() < m.representative() {
-                i += FieldElement::one();
+            while i < m {
+                i += 1;
                 if e == one {
                     break;
                 }
                 e = &e * &e;
             }
 
-            let b = c.pow(two.pow((m - &i - &one).representative()).representative());
+            let b = c.pow(two.pow(m - i - 1).representative());
 
             x = x * &b;
             t = t * &b * &b;


### PR DESCRIPTION
`FieldElement::sqrt` computes `t^(2^i)` on each iteration of an inner loop. This is replaced by computing the latest square squared again (that is, `t_i+1 = t_i* t_i`) instead.
Added Criterion and IAI benchmarks.

Benchmark results:
```
Stark FP operations/sqrt squared                                                                             
                        time:   [1.6231 ms 1.6272 ms 1.6304 ms]
                        change: [-91.101% -91.072% -91.049%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## Type of change

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added/run
