### PR TITLE
fix: substraction overflow in `sqrt`

### DIFF
--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -441,20 +441,20 @@ impl<F: IsPrimeField> FieldElement<F> {
 
         let mut x = self.pow(((&q + &one) / &two).representative());
         let mut t = self.pow(q.representative());
-        let mut m = s;
+        let mut m = FieldElement::from(s);
 
         while t != one {
-            let mut i = 0;
+            let mut i = FieldElement::zero();
             let mut e = &t * &t;
-            while i < m {
-                i += 1;
+            while i != m {
+                i = &i + &one;
                 if e == one {
                     break;
                 }
                 e = &e * &e;
             }
 
-            let b = c.pow(two.pow(m - i - 1).representative());
+            let b = c.pow(two.pow((m - &i - &one).representative()).representative());
 
             x = x * &b;
             t = t * &b * &b;


### PR DESCRIPTION
An edge case where the inner loop exits without finding a power such that it becomes `one` makes `i == m` which in turn causes a later `m - i - 1` to overflow.
This was caused by the demotion to primitive type in a previous optimization.
Fixed by promoting back to `FieldElement`.

## Type of change

- [x] Bug fix

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
