### PR TITLE
perf: compute inverse of 2 only once in sqrt

### DIFF
--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -420,13 +420,14 @@ impl<F: IsPrimeField> FieldElement<F> {
         };
 
         let (one, two) = (Self::one(), Self::from(2));
+        let two_inv = two.inv();
 
         let mut q = Self::zero() - &one;
         let mut s = 0u64;
 
         while q.is_even() {
             s += 1;
-            q = q / &two;
+            q = q * &two_inv;
         }
 
         let mut c = {
@@ -439,7 +440,7 @@ impl<F: IsPrimeField> FieldElement<F> {
             non_qr.pow(q.representative())
         };
 
-        let mut x = self.pow(((&q + &one) / &two).representative());
+        let mut x = self.pow(((&q + &one) * &two_inv).representative());
         let mut t = self.pow(q.representative());
         let mut m = s;
 


### PR DESCRIPTION
Yet another repeated inverse removal.

## Type of change

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added/run

Benchmark results:
```
Stark FP operations/sqrt                                                                             
                        time:   [5.3247 µs 5.3269 µs 5.3293 µs]
                        change: [+2.6661% +2.7406% +2.8178%] (p = 0.00 < 0.05)
                        Performance has regressed.

Stark FP operations/sqrt squared                                                                            
                        time:   [220.20 µs 220.26 µs 220.33 µs]
                        change: [-38.188% -38.152% -38.117%] (p = 0.00 < 0.05)
                        Performance has improved.
```