### PR TITLE
perf: use `2` as first non-qr candidate

### DIFF
--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -431,7 +431,7 @@ impl<F: IsPrimeField> FieldElement<F> {
 
         let mut c = {
             // Calculate a non residue:
-            let mut non_qr = one.clone();
+            let mut non_qr = two.clone();
             while non_qr.legendre_symbol() != LegendreSymbol::MinusOne {
                 non_qr += one.clone();
             }


### PR DESCRIPTION
`1` is a quad residue no matter the field, so we can just skip it when we look for our first non-residue for `sqrt`. This saves us a call to `legendre_symbol`, giving a tiny but non-negligible boost.

## Type of change

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added/run

Results:
```
Stark FP operations/sqrt squared
                        time:   [347.54 µs 347.98 µs 348.45 µs]
                        change: [-4.5765% -4.4747% -4.3736%] (p = 0.00 < 0.05)
                        Performance has improved.
```