### PR TITLE
perf: specialize is_neutral_element for each curve

### DIFF
--- a/math/src/elliptic_curve/edwards/point.rs
+++ b/math/src/elliptic_curve/edwards/point.rs
@@ -78,6 +78,11 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
         ])
     }
 
+    fn is_neutral_element(&self) -> bool {
+        let [px, py, pz] = self.coordinates();
+        px == &FieldElement::zero() && py == pz
+    }
+
     /// Computes the addition of `self` and `other`.
     /// Taken from "Moonmath" (Eq 5.38, page 97)
     fn operate_with(&self, other: &Self) -> Self {

--- a/math/src/elliptic_curve/montgomery/point.rs
+++ b/math/src/elliptic_curve/montgomery/point.rs
@@ -78,6 +78,11 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
         ])
     }
 
+    fn is_neutral_element(&self) -> bool {
+        let pz = self.z();
+        pz == &FieldElement::zero()
+    }
+
     /// Computes the addition of `self` and `other`.
     /// Taken from "Moonmath" (Definition 5.2.2.1, page 94)
     fn operate_with(&self, other: &Self) -> Self {

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -79,6 +79,11 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
         ])
     }
 
+    fn is_neutral_element(&self) -> bool {
+        let pz = self.z();
+        pz == &FieldElement::zero()
+    }
+
     /// Computes the addition of `self` and `other`.
     /// Taken from "Moonmath" (Algorithm 7, page 89)
     fn operate_with(&self, other: &Self) -> Self {


### PR DESCRIPTION
Create `is_neutral_element` implementations for Montgomery, Short Weiestrass and Edwards curves.

## Type of change

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added/run

## Benchmark results

TL;DR: 25-40% speedup.

```
MSM benchmarks with size 2/Naive                                                                                                                                                                                                              
                        time:   [1.0780 ms 1.0783 ms 1.0785 ms]                                                                                                                                                                               
                        change: [-26.694% -26.659% -26.623%] (p = 0.00 < 0.05)                                                        
MSM benchmarks with size 2/Sequential Pippenger/1                                                                                                                                                                                             
                        time:   [1.0874 ms 1.0877 ms 1.0879 ms]                                                                                                                                                                               
                        change: [-37.072% -36.949% -36.828%] (p = 0.00 < 0.05)                                                                                                                                                              
MSM benchmarks with size 2/Parallel Pippenger/1                                                                                                                                                                                               
                        time:   [4.1959 ms 4.2006 ms 4.2051 ms]                                                                                                                                                                               
                        change: [-27.033% -26.910% -26.789%] (p = 0.00 < 0.05)                                                               
MSM benchmarks with size 2/Sequential Pippenger/2                                                                                                                                                                                             
                        time:   [1.0839 ms 1.0844 ms 1.0849 ms]                                                                                                                                                                               
                        change: [-38.057% -37.997% -37.936%] (p = 0.00 < 0.05)                                                                                                                                                      
MSM benchmarks with size 2/Parallel Pippenger/2                                                                                                                                                                                               
                        time:   [2.6903 ms 2.6937 ms 2.6970 ms]                                                                                                                                                                               
                        change: [-25.115% -24.971% -24.819%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Sequential Pippenger/4                                                                                                                                                                                             
                        time:   [1.4155 ms 1.4159 ms 1.4163 ms]                                                        
                        change: [-39.365% -39.332% -39.298%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Parallel Pippenger/4
                        time:   [1.6254 ms 1.6279 ms 1.6303 ms]
                        change: [-25.903% -25.659% -25.361%] (p = 0.00 < 0.05)                                   
MSM benchmarks with size 2/Sequential Pippenger/8                                                                                                                                                                                             
                        time:   [7.5383 ms 7.5410 ms 7.5437 ms]
                        change: [-42.754% -42.659% -42.561%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Parallel Pippenger/8
                        time:   [1.5617 ms 1.5659 ms 1.5703 ms]
                        change: [-32.997% -32.658% -32.329%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Sequential Pippenger/12                                                                                                                                                                                   [61/1958]
                        time:   [78.514 ms 78.539 ms 78.565 ms]
                        change: [-42.778% -42.671% -42.565%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Parallel Pippenger/12
                        time:   [6.9643 ms 6.9937 ms 7.0235 ms]
                        change: [-41.578% -41.157% -40.728%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Naive
                        time:   [2.1828 ms 2.1847 ms 2.1864 ms]
                        change: [-25.940% -25.842% -25.743%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Sequential Pippenger/1
                        time:   [1.3428 ms 1.3438 ms 1.3448 ms]
                        change: [-37.176% -37.087% -37.001%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Parallel Pippenger/1
                        time:   [5.0040 ms 5.0086 ms 5.0133 ms]
                        change: [-25.249% -25.141% -25.027%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Sequential Pippenger/2
                        time:   [1.3330 ms 1.3361 ms 1.3390 ms]
                        change: [-37.147% -37.013% -36.880%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Parallel Pippenger/2
                        time:   [2.8434 ms 2.8471 ms 2.8509 ms]
                        change: [-24.671% -24.533% -24.392%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Sequential Pippenger/4
                        time:   [1.6949 ms 1.6974 ms 1.7007 ms]
                        change: [-37.099% -36.952% -36.755%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Parallel Pippenger/4
                        time:   [1.6528 ms 1.6551 ms 1.6574 ms]
                        change: [-25.658% -25.445% -25.240%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Sequential Pippenger/8
                        time:   [8.3688 ms 8.3824 ms 8.3960 ms]
                        change: [-40.983% -40.814% -40.625%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Parallel Pippenger/8
                        time:   [1.6157 ms 1.6198 ms 1.6240 ms]
                        change: [-33.195% -32.738% -32.332%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Sequential Pippenger/12
                        time:   [85.617 ms 85.652 ms 85.688 ms]
                        change: [-41.297% -41.239% -41.181%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Parallel Pippenger/12
                        time:   [7.1005 ms 7.1322 ms 7.1661 ms]
                        change: [-43.183% -42.756% -42.319%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Naive
                        time:   [4.2555 ms 4.2568 ms 4.2581 ms]
                        change: [-27.461% -27.414% -27.367%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Sequential Pippenger/1
                        time:   [1.7517 ms 1.7521 ms 1.7526 ms]
                        change: [-36.385% -36.355% -36.324%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Parallel Pippenger/1
                        time:   [5.4060 ms 5.4105 ms 5.4150 ms]
                        change: [-24.699% -24.599% -24.495%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Sequential Pippenger/2
                        time:   [1.7651 ms 1.7696 ms 1.7743 ms]
                        change: [-36.094% -35.900% -35.706%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Parallel Pippenger/2
                        time:   [2.9347 ms 2.9393 ms 2.9439 ms]
                        change: [-24.370% -24.208% -24.046%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Sequential Pippenger/4 
                        time:   [2.0454 ms 2.0472 ms 2.0489 ms]
                        change: [-37.077% -37.000% -36.922%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Parallel Pippenger/4                                                                        
                        time:   [1.7121 ms 1.7148 ms 1.7175 ms]
                        change: [-25.538% -25.332% -25.143%] (p = 0.00 < 0.05)                          
MSM benchmarks with size 8/Sequential Pippenger/8                                                                      
                        time:   [9.3000 ms 9.3031 ms 9.3061 ms]               
                        change: [-39.749% -39.718% -39.689%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Parallel Pippenger/8
                        time:   [1.7033 ms 1.7076 ms 1.7118 ms]
                        change: [-32.406% -32.116% -31.835%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Sequential Pippenger/12
                        time:   [92.232 ms 92.411 ms 92.588 ms]
                        change: [-40.511% -40.384% -40.277%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Parallel Pippenger/12
                        time:   [7.3891 ms 7.4204 ms 7.4534 ms]
                        change: [-43.906% -43.556% -43.188%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Naive
                        time:   [8.6346 ms 8.6440 ms 8.6528 ms]
                        change: [-25.961% -25.876% -25.794%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Sequential Pippenger/1
                        time:   [2.6303 ms 2.6355 ms 2.6406 ms]
                        change: [-33.091% -32.941% -32.815%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Parallel Pippenger/1
                        time:   [5.4915 ms 5.4962 ms 5.5009 ms]
                        change: [-24.514% -24.417% -24.322%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Sequential Pippenger/2
                        time:   [2.6571 ms 2.6580 ms 2.6589 ms]
                        change: [-33.451% -33.342% -33.234%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Parallel Pippenger/2
                        time:   [2.9966 ms 3.0002 ms 3.0037 ms]
                        change: [-24.713% -24.569% -24.422%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Sequential Pippenger/4                                                                                                                                                                                                           
                        time:   [2.5965 ms 2.5971 ms 2.5977 ms]
                        change: [-36.997% -36.967% -36.936%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Parallel Pippenger/4
                        time:   [1.7541 ms 1.7569 ms 1.7597 ms]
                        change: [-25.341% -25.131% -24.914%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Sequential Pippenger/8
                        time:   [10.167 ms 10.170 ms 10.173 ms]
                        change: [-38.026% -38.001% -37.977%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Parallel Pippenger/8
                        time:   [1.7838 ms 1.7880 ms 1.7922 ms]
                        change: [-31.708% -31.376% -31.047%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Sequential Pippenger/12
                        time:   [96.583 ms 96.681 ms 96.786 ms]
                        change: [-38.845% -38.779% -38.700%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Parallel Pippenger/12
                        time:   [7.7550 ms 7.7861 ms 7.8191 ms]
                        change: [-42.985% -42.660% -42.340%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Naive
                        time:   [17.405 ms 17.429 ms 17.453 ms]
                        change: [-25.610% -25.504% -25.400%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Sequential Pippenger/1
                        time:   [4.3730 ms 4.3772 ms 4.3814 ms]
                        change: [-32.576% -32.509% -32.432%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Parallel Pippenger/1
                        time:   [5.6549 ms 5.6600 ms 5.6652 ms]
                        change: [-24.610% -24.516% -24.412%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Sequential Pippenger/2
                        time:   [4.3674 ms 4.3687 ms 4.3701 ms]
                        change: [-32.782% -32.753% -32.722%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Parallel Pippenger/2
                        time:   [3.0984 ms 3.1025 ms 3.1067 ms]
                        change: [-25.151% -25.004% -24.854%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Sequential Pippenger/4
                        time:   [3.6683 ms 3.6724 ms 3.6768 ms]
                        change: [-35.627% -35.557% -35.473%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM benchmarks with size 32/Parallel Pippenger/4
                        time:   [1.8490 ms 1.8528 ms 1.8566 ms]
                        change: [-25.358% -25.129% -24.909%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Sequential Pippenger/8                                                                     
                        time:   [10.870 ms 10.873 ms 10.877 ms]               
                        change: [-38.246% -38.114% -37.981%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Parallel Pippenger/8                                                                       
                        time:   [1.8569 ms 1.8615 ms 1.8660 ms]               
                        change: [-32.283% -31.900% -31.529%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Sequential Pippenger/12                                                                    
                        time:   [98.547 ms 98.576 ms 98.606 ms]               
                        change: [-38.620% -38.597% -38.575%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Parallel Pippenger/12
                        time:   [7.9862 ms 8.0137 ms 8.0429 ms]
                        change: [-42.666% -42.389% -42.083%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Naive                                                                                      
                        time:   [34.730 ms 34.793 ms 34.854 ms]               
                        change: [-23.933% -23.791% -23.656%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Sequential Pippenger/1                                                                     
                        time:   [7.7311 ms 7.7441 ms 7.7572 ms]               
                        change: [-31.181% -31.058% -30.934%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Parallel Pippenger/1                                                                       
                        time:   [5.9657 ms 5.9722 ms 5.9786 ms]               
                        change: [-24.932% -24.821% -24.711%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Sequential Pippenger/2
                        time:   [7.7267 ms 7.7414 ms 7.7562 ms]
                        change: [-31.772% -31.642% -31.521%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Parallel Pippenger/2                                                                       
                        time:   [3.3291 ms 3.3327 ms 3.3364 ms]
                        change: [-25.439% -25.305% -25.178%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Sequential Pippenger/4                                                                     
                        time:   [5.8627 ms 5.8689 ms 5.8752 ms]
                        change: [-33.947% -33.877% -33.808%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Parallel Pippenger/4                                                                                                                                                                                      
                        time:   [2.0062 ms 2.0096 ms 2.0130 ms]                        
                        change: [-25.733% -25.523% -25.317%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Sequential Pippenger/8
                        time:   [12.237 ms 12.242 ms 12.247 ms]
                        change: [-37.278% -37.249% -37.220%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Parallel Pippenger/8
                        time:   [1.9649 ms 1.9695 ms 1.9743 ms]
                        change: [-32.085% -31.742% -31.405%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Sequential Pippenger/12
                        time:   [101.85 ms 102.06 ms 102.27 ms]
                        change: [-38.773% -38.626% -38.469%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Parallel Pippenger/12
                        time:   [8.1429 ms 8.1673 ms 8.1928 ms]
                        change: [-42.613% -42.349% -42.081%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Naive
                        time:   [68.230 ms 68.248 ms 68.267 ms]
                        change: [-26.772% -26.739% -26.706%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Sequential Pippenger/1
                        time:   [14.364 ms 14.368 ms 14.372 ms]
                        change: [-32.516% -32.481% -32.444%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Parallel Pippenger/1
                        time:   [6.5578 ms 6.5635 ms 6.5691 ms]
                        change: [-25.654% -25.551% -25.442%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Sequential Pippenger/2
                        time:   [14.655 ms 14.660 ms 14.666 ms]
                        change: [-30.975% -30.944% -30.912%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Parallel Pippenger/2
                        time:   [3.8036 ms 3.8083 ms 3.8131 ms]
                        change: [-26.272% -26.143% -26.011%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Sequential Pippenger/4
                        time:   [9.9391 ms 9.9405 ms 9.9418 ms]
                        change: [-33.621% -33.515% -33.405%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Parallel Pippenger/4                                                                                                                                                                                   
                        time:   [2.2862 ms 2.2893 ms 2.2925 ms]                                                        
                        change: [-27.499% -27.320% -27.140%] (p = 0.00 < 0.05)                                         
MSM benchmarks with size 128/Sequential Pippenger/8
                        time:   [14.684 ms 14.699 ms 14.713 ms]                                                        
                        change: [-37.377% -37.308% -37.236%] (p = 0.00 < 0.05)                                         
MSM benchmarks with size 128/Parallel Pippenger/8                                                                      
                        time:   [2.1579 ms 2.1633 ms 2.1689 ms]                                                        
                        change: [-32.539% -32.222% -31.909%] (p = 0.00 < 0.05)                                         
MSM benchmarks with size 128/Sequential Pippenger/12 
                        time:   [104.86 ms 104.89 ms 104.92 ms]                                                        
                        change: [-38.422% -38.318% -38.212%] (p = 0.00 < 0.05)                                         
MSM benchmarks with size 128/Parallel Pippenger/12                                                                     
                        time:   [8.4296 ms 8.4619 ms 8.4974 ms]                                                                                                                                                                               
                        change: [-41.670% -41.343% -41.002%] (p = 0.00 < 0.05)                                                                                                                                                                
MSM benchmarks with size 256/Naive
                        time:   [138.16 ms 138.21 ms 138.25 ms]
                        change: [-25.972% -25.915% -25.857%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Sequential Pippenger/1
                        time:   [27.719 ms 27.726 ms 27.732 ms]
                        change: [-31.780% -31.674% -31.568%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Parallel Pippenger/1
                        time:   [7.7650 ms 7.7719 ms 7.7786 ms]
                        change: [-26.465% -26.364% -26.267%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Sequential Pippenger/2
                        time:   [28.182 ms 28.190 ms 28.198 ms]
                        change: [-30.875% -30.738% -30.597%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Parallel Pippenger/2
                        time:   [4.7291 ms 4.7348 ms 4.7405 ms]
                        change: [-27.017% -26.881% -26.751%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Sequential Pippenger/4
                        time:   [18.438 ms 18.444 ms 18.450 ms]
                        change: [-33.031% -32.995% -32.958%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Parallel Pippenger/4
                        time:   [2.9152 ms 2.9203 ms 2.9255 ms]
                        change: [-27.601% -27.409% -27.218%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Sequential Pippenger/8                                                                                                                                                                                  
                        time:   [19.220 ms 19.227 ms 19.235 ms]
                        change: [-37.032% -37.002% -36.973%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Parallel Pippenger/8
                        time:   [2.5306 ms 2.5378 ms 2.5449 ms]
                        change: [-33.468% -33.193% -32.927%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Sequential Pippenger/12
                        time:   [108.09 ms 108.12 ms 108.16 ms]
                        change: [-38.143% -38.051% -37.962%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Parallel Pippenger/12
                        time:   [8.7455 ms 8.7758 ms 8.8077 ms]
                        change: [-41.688% -41.453% -41.202%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Naive
                        time:   [276.39 ms 276.78 ms 277.16 ms]
                        change: [-26.100% -25.990% -25.889%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Sequential Pippenger/1
                        time:   [55.605 ms 55.701 ms 55.787 ms]
                        change: [-29.059% -28.925% -28.808%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Parallel Pippenger/1
                        time:   [10.222 ms 10.231 ms 10.240 ms]
                        change: [-27.379% -27.280% -27.176%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Sequential Pippenger/2
                        time:   [55.755 ms 55.771 ms 55.788 ms]
                        change: [-30.162% -30.134% -30.106%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Parallel Pippenger/2
                        time:   [6.5959 ms 6.6040 ms 6.6122 ms]
                        change: [-28.245% -28.119% -27.999%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Sequential Pippenger/4
                        time:   [35.806 ms 35.820 ms 35.835 ms]
                        change: [-30.458% -30.416% -30.376%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Parallel Pippenger/4                                                                                                                                                                                    
                        time:   [4.1057 ms 4.1123 ms 4.1187 ms]
                        change: [-28.963% -28.781% -28.601%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Sequential Pippenger/8
                        time:   [28.649 ms 28.663 ms 28.678 ms]
                        change: [-34.212% -34.169% -34.129%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Parallel Pippenger/8
                        time:   [3.3084 ms 3.3165 ms 3.3248 ms]
                        change: [-32.683% -32.453% -32.220%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Sequential Pippenger/12
                        time:   [114.75 ms 114.94 ms 115.13 ms]
                        change: [-36.939% -36.839% -36.713%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Parallel Pippenger/12
                        time:   [9.3803 ms 9.4072 ms 9.4350 ms]
                        change: [-41.315% -41.045% -40.770%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Naive
                        time:   [553.73 ms 554.65 ms 555.55 ms]
                        change: [-25.173% -25.020% -24.871%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Sequential Pippenger/1
                        time:   [109.53 ms 109.77 ms 110.00 ms]
                        change: [-30.593% -30.410% -30.230%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Parallel Pippenger/1
                        time:   [15.037 ms 15.049 ms 15.062 ms]
                        change: [-28.990% -28.893% -28.798%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Sequential Pippenger/2
                        time:   [111.16 ms 111.18 ms 111.20 ms]
                        change: [-28.392% -28.371% -28.348%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Parallel Pippenger/2
                        time:   [10.337 ms 10.352 ms 10.367 ms]
                        change: [-29.494% -29.346% -29.194%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Sequential Pippenger/4
                        time:   [69.967 ms 69.984 ms 70.002 ms]
                        change: [-30.261% -30.230% -30.200%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Parallel Pippenger/4
                        time:   [6.5529 ms 6.5656 ms 6.5783 ms]
                        change: [-30.453% -30.236% -30.013%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Sequential Pippenger/8
                        time:   [46.473 ms 46.560 ms 46.647 ms]
                        change: [-33.799% -33.672% -33.557%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Parallel Pippenger/8
                        time:   [4.8007 ms 4.8113 ms 4.8221 ms]
                        change: [-32.621% -32.438% -32.257%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Sequential Pippenger/12
                        time:   [127.38 ms 127.42 ms 127.47 ms]
                        change: [-38.171% -38.075% -37.980%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Parallel Pippenger/12
                        time:   [10.551 ms 10.577 ms 10.605 ms]
                        change: [-41.133% -40.800% -40.479%] (p = 0.00 < 0.05)
```