### PR TITLE
Compress and sqrt for BLS12-381 points

### DIFF
--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -13,6 +13,7 @@ rayon = { version = "1.7.0", optional = true }
 [dev-dependencies]
 proptest = "1.1.0"
 criterion = "0.4"
+hex = "0.4"
 const-random = "0.1.15"
 iai-callgrind.workspace = true
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
@@ -1,0 +1,142 @@
+use super::curve::{BLS12381Curve, BLS12381FieldElement};
+use super::twist::BLS12381TwistCurve;
+use crate::cyclic_group::IsGroup;
+use crate::elliptic_curve::{
+    short_weierstrass::curves::bls12_381::{
+        default_types::FrConfig, field_extension::Degree2ExtensionField,
+    },
+    short_weierstrass::point::ShortWeierstrassProjectivePoint,
+    traits::FromAffine,
+    traits::{Compress, EllipticCurveError, IsEllipticCurve},
+};
+use crate::field::element::FieldElement;
+use crate::field::fields::montgomery_backed_prime_fields::IsModulus;
+use crate::traits::ByteConversion;
+use crate::unsigned_integer::element::UnsignedInteger;
+use std::ops::Neg;
+
+fn check_point_is_in_subgroup(point: &ShortWeierstrassProjectivePoint<BLS12381Curve>) -> bool {
+    const MODULUS: UnsignedInteger<4> = FrConfig::MODULUS;
+    let inf = ShortWeierstrassProjectivePoint::<BLS12381Curve>::neutral_element();
+    let aux_point = point.operate_with_self(MODULUS);
+    inf == aux_point
+}
+
+impl Compress for ShortWeierstrassProjectivePoint<BLS12381Curve> {
+    type G1Point = ShortWeierstrassProjectivePoint<BLS12381Curve>;
+    type G2Point = <BLS12381TwistCurve as IsEllipticCurve>::PointRepresentation;
+
+    fn compress_g1_point(point: &Self::G1Point) -> Result<[u8; 48], EllipticCurveError> {
+        let ret_vec = if *point == Self::G1Point::neutral_element() {
+            // point is at infinity
+            let mut x_bytes = vec![0_u8; 48];
+            x_bytes[0] |= 1 << 7;
+            x_bytes[0] |= 1 << 6;
+            x_bytes
+        } else {
+            // point is not at infinity
+            let point_affine = point.to_affine();
+            let x = point_affine.x();
+            let y = point_affine.y();
+
+            let mut x_bytes = x.to_bytes_be();
+
+            // Set first bit to to 1 indicate this is compressed element.
+            x_bytes[0] |= 1 << 7;
+
+            let y_neg = y.neg();
+            if y_neg.representative() < y.representative() {
+                x_bytes[0] |= 1 << 5;
+            }
+            x_bytes
+        };
+        ret_vec
+            .try_into()
+            .map_err(|_e| EllipticCurveError::InvalidPoint)
+    }
+
+    fn decompress_g1_point(
+        input_bytes: &mut [u8; 48],
+    ) -> Result<Self::G1Point, EllipticCurveError> {
+        let first_byte = input_bytes.first().unwrap();
+        // We get the first 3 bits
+        let prefix_bits = first_byte >> 5;
+        let first_bit = (prefix_bits & 4_u8) >> 2;
+        // If first bit is not 1, then the value is not compressed.
+        if first_bit != 1 {
+            return Err(EllipticCurveError::InvalidPoint);
+        }
+        let second_bit = (prefix_bits & 2_u8) >> 1;
+        // If the second bit is 1, then the compressed point is the
+        // point at infinity and we return it directly.
+        if second_bit == 1 {
+            return Ok(Self::G1Point::neutral_element());
+        }
+        let third_bit = prefix_bits & 1_u8;
+
+        let first_byte_without_contorl_bits = (first_byte << 3) >> 3;
+        input_bytes[0] = first_byte_without_contorl_bits;
+
+        let x = BLS12381FieldElement::from_bytes_be(input_bytes)
+            .map_err(|_e| EllipticCurveError::InvalidPoint)?;
+
+        // We apply the elliptic curve formula to know the y^2 value.
+        let y_squared = x.pow(3_u16) + BLS12381FieldElement::from(4);
+
+        let (y_sqrt_1, y_sqrt_2) = &y_squared.sqrt().ok_or(EllipticCurveError::InvalidPoint)?;
+
+        // we call "negative" to the greate root,
+        // if the third bit is 1, we take this grater value.
+        // Otherwise, we take the second one.
+        let y = super::sqrt::select_sqrt_value_from_third_bit(
+            y_sqrt_1.clone(),
+            y_sqrt_2.clone(),
+            third_bit,
+        );
+        let point =
+            Self::G1Point::from_affine(x, y).map_err(|_| EllipticCurveError::InvalidPoint)?;
+
+        check_point_is_in_subgroup(&point)
+            .then_some(point)
+            .ok_or(EllipticCurveError::InvalidPoint)
+    }
+
+    fn decompress_g2_point(
+        input_bytes: &mut [u8; 96],
+    ) -> Result<Self::G2Point, EllipticCurveError> {
+        let binding = input_bytes[48..96].to_owned();
+        let input0 = binding.as_slice();
+        let input1 = &mut input_bytes[0..48];
+
+        let first_byte = input1.first().unwrap();
+        // We get the first 3 bits
+        let prefix_bits = first_byte >> 5;
+        let first_bit = (prefix_bits & 4_u8) >> 2;
+        // If first bit is not 1, then the value is not compressed.
+        if first_bit != 1 {
+            return Err(EllipticCurveError::InvalidPoint);
+        }
+        let second_bit = (prefix_bits & 2_u8) >> 1;
+        // If the second bit is 1, then the compressed point is the
+        // point at infinity and we return it directly.
+        if second_bit == 1 {
+            return Ok(Self::G2Point::neutral_element());
+        }
+
+        let first_byte_without_contorl_bits = (first_byte << 3) >> 3;
+        input1[0] = first_byte_without_contorl_bits;
+
+        let x0 = BLS12381FieldElement::from_bytes_be(input0).unwrap();
+        let x1 = BLS12381FieldElement::from_bytes_be(input1).unwrap();
+        let x: FieldElement<Degree2ExtensionField> = FieldElement::new([x0, x1]);
+
+        let b_param_qfe = FieldElement::<Degree2ExtensionField>::new([
+            BLS12381FieldElement::from_hex("0x4").unwrap(),
+            BLS12381FieldElement::from_hex("0x4").unwrap(),
+        ]);
+
+        let y = super::sqrt::sqrt_qfe(&(x.pow(3_u64) + b_param_qfe), 0)
+            .ok_or(EllipticCurveError::InvalidPoint)?;
+        Self::G2Point::from_affine(x, y).map_err(|_| EllipticCurveError::InvalidPoint)
+    }
+}

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
@@ -129,10 +129,8 @@ impl Compress for ShortWeierstrassProjectivePoint<BLS12381Curve> {
         let x1 = BLS12381FieldElement::from_bytes_be(input1).unwrap();
         let x: FieldElement<Degree2ExtensionField> = FieldElement::new([x0, x1]);
 
-        let b_param_qfe = FieldElement::<Degree2ExtensionField>::new([
-            BLS12381FieldElement::from_hex_unchecked("0x4"),
-            BLS12381FieldElement::from_hex_unchecked("0x4"),
-        ]);
+        const VALUE: BLS12381FieldElement = BLS12381FieldElement::from_hex_unchecked("4");
+        let b_param_qfe = FieldElement::<Degree2ExtensionField>::new([VALUE, VALUE]);
 
         let y = super::sqrt::sqrt_qfe(&(x.pow(3_u64) + b_param_qfe), 0)
             .ok_or(EllipticCurveError::InvalidPoint)?;

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
@@ -1,10 +1,12 @@
+use super::field_extension::{BLS12381PrimeField, Degree2ExtensionField};
 use crate::elliptic_curve::short_weierstrass::point::ShortWeierstrassProjectivePoint;
 use crate::elliptic_curve::traits::IsEllipticCurve;
 use crate::{
     elliptic_curve::short_weierstrass::traits::IsShortWeierstrass, field::element::FieldElement,
 };
 
-use super::field_extension::BLS12381PrimeField;
+pub type BLS12381FieldElement = FieldElement<BLS12381PrimeField>;
+pub type BLS12381TwistCurveFieldElement = FieldElement<Degree2ExtensionField>;
 
 /// The description of the curve.
 #[derive(Clone, Debug)]

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/mod.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/mod.rs
@@ -1,5 +1,7 @@
+pub mod compression;
 pub mod curve;
 pub mod default_types;
 pub mod field_extension;
 pub mod pairing;
+pub mod sqrt;
 pub mod twist;

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/sqrt.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/sqrt.rs
@@ -1,0 +1,72 @@
+use super::{curve::BLS12381FieldElement, curve::BLS12381TwistCurveFieldElement};
+use crate::field::element::LegendreSymbol;
+use std::cmp::Ordering;
+
+#[must_use]
+pub fn select_sqrt_value_from_third_bit(
+    sqrt_1: BLS12381FieldElement,
+    sqrt_2: BLS12381FieldElement,
+    third_bit: u8,
+) -> BLS12381FieldElement {
+    match (
+        sqrt_1.representative().cmp(&sqrt_2.representative()),
+        third_bit,
+    ) {
+        (Ordering::Greater, 0) => sqrt_2,
+        (Ordering::Greater, _) | (Ordering::Less, 0) | (Ordering::Equal, _) => sqrt_1,
+        (Ordering::Less, _) => sqrt_2,
+    }
+}
+
+/// * `third_bit` - if 1, then the square root is the greater one, otherwise it is the smaller one.
+#[must_use]
+pub fn sqrt_qfe(
+    input: &BLS12381TwistCurveFieldElement,
+    third_bit: u8,
+) -> Option<BLS12381TwistCurveFieldElement> {
+    // Algorithm 8, https://eprint.iacr.org/2012/685.pdf
+    if *input == BLS12381TwistCurveFieldElement::zero() {
+        Some(BLS12381TwistCurveFieldElement::zero())
+    } else {
+        let a = input.value()[0].clone();
+        let b = input.value()[1].clone();
+        if b == BLS12381FieldElement::zero() {
+            // second part is zero
+            let (y_sqrt_1, y_sqrt_2) = a.sqrt()?;
+            let y_aux = select_sqrt_value_from_third_bit(y_sqrt_1, y_sqrt_2, third_bit);
+
+            Some(BLS12381TwistCurveFieldElement::new([
+                y_aux,
+                BLS12381FieldElement::zero(),
+            ]))
+        } else {
+            // second part of the input field number is non-zero
+
+            // instead of "sum" is -beta
+            let alpha = a.pow(2u64) + b.pow(2u64);
+            let gamma = alpha.legendre_symbol();
+            match gamma {
+                LegendreSymbol::One => {
+                    let two = BLS12381FieldElement::from(2u64);
+                    let two_inv = two.inv();
+                    // calculate the square root of alpha
+                    let (y_sqrt1, y_sqrt2) = alpha.sqrt()?;
+                    let mut delta = (a.clone() + y_sqrt1) * two_inv.clone();
+
+                    let legendre_delta = delta.legendre_symbol();
+                    if legendre_delta == LegendreSymbol::MinusOne {
+                        delta = (a + y_sqrt2) * two_inv;
+                    };
+                    let (x_sqrt_1, x_sqrt_2) = delta.sqrt()?;
+                    let x_0 = select_sqrt_value_from_third_bit(x_sqrt_1, x_sqrt_2, third_bit);
+                    let x_1 = b * (two * x_0.clone()).inv();
+                    Some(BLS12381TwistCurveFieldElement::new([x_0, x_1]))
+                }
+                LegendreSymbol::MinusOne => None,
+                LegendreSymbol::Zero => {
+                    unreachable!("The input is zero, but we already handled this case.")
+                }
+            }
+        }
+    }
+}

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/sqrt.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/sqrt.rs
@@ -41,8 +41,7 @@ pub fn sqrt_qfe(
             ]))
         } else {
             // second part of the input field number is non-zero
-
-            // instead of "sum" is -beta
+            // instead of "sum" is: -beta
             let alpha = a.pow(2u64) + b.pow(2u64);
             let gamma = alpha.legendre_symbol();
             match gamma {
@@ -68,5 +67,61 @@ pub fn sqrt_qfe(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::curve::BLS12381FieldElement;
+
+    #[test]
+    fn test_sqrt_qfe() {
+        let c1 = BLS12381FieldElement::from_hex(
+            "0x13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e",
+        ).unwrap();
+        let c0 = BLS12381FieldElement::from_hex(
+        "0x024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
+        ).unwrap();
+        let qfe = super::BLS12381TwistCurveFieldElement::new([c0, c1]);
+
+        let b1 = BLS12381FieldElement::from_hex("0x4").unwrap();
+        let b0 = BLS12381FieldElement::from_hex("0x4").unwrap();
+        let qfe_b = super::BLS12381TwistCurveFieldElement::new([b0, b1]);
+
+        let cubic_value = qfe.pow(3_u64) + qfe_b;
+        let root = super::sqrt_qfe(&cubic_value, 0).unwrap();
+
+        let c0_expected = BLS12381FieldElement::from_hex("0x0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801").unwrap();
+        let c1_expected = BLS12381FieldElement::from_hex("0x0606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be").unwrap();
+        let qfe_expected = super::BLS12381TwistCurveFieldElement::new([c0_expected, c1_expected]);
+
+        let value_root = root.value();
+        let value_qfe_expected = qfe_expected.value();
+
+        assert_eq!(value_root[0].clone(), value_qfe_expected[0].clone());
+        assert_eq!(value_root[1].clone(), value_qfe_expected[1].clone());
+    }
+
+    #[test]
+    fn test_sqrt_qfe_2() {
+        let c0 = BLS12381FieldElement::from_hex("0x02").unwrap();
+        let c1 = BLS12381FieldElement::from_hex("0x00").unwrap();
+        let qfe = super::BLS12381TwistCurveFieldElement::new([c0, c1]);
+
+        let c0_expected = BLS12381FieldElement::from_hex("0x013a59858b6809fca4d9a3b6539246a70051a3c88899964a42bc9a69cf9acdd9dd387cfa9086b894185b9a46a402be73").unwrap();
+        let c1_expected = BLS12381FieldElement::from_hex("0x02d27e0ec3356299a346a09ad7dc4ef68a483c3aed53f9139d2f929a3eecebf72082e5e58c6da24ee32e03040c406d4f").unwrap();
+        let qfe_expected = super::BLS12381TwistCurveFieldElement::new([c0_expected, c1_expected]);
+
+        let b1 = BLS12381FieldElement::from_hex("0x4").unwrap();
+        let b0 = BLS12381FieldElement::from_hex("0x4").unwrap();
+        let qfe_b = super::BLS12381TwistCurveFieldElement::new([b0, b1]);
+
+        let root = super::sqrt_qfe(&(qfe.pow(3_u64) + qfe_b), 0).unwrap();
+
+        let value_root = root.value();
+        let value_qfe_expected = qfe_expected.value();
+
+        assert_eq!(value_root[0].clone(), value_qfe_expected[0].clone());
+        assert_eq!(value_root[1].clone(), value_qfe_expected[1].clone());
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/errors.rs
+++ b/math/src/elliptic_curve/short_weierstrass/errors.rs
@@ -10,6 +10,8 @@ pub enum DeserializationError {
     FieldFromBytesError,
     #[error("Error trying to load a pointer bigger than the supported architecture")]
     PointerSizeError,
+    #[error("Invalid value")]
+    InvalidValue,
 }
 
 impl From<ByteConversionError> for DeserializationError {
@@ -17,6 +19,9 @@ impl From<ByteConversionError> for DeserializationError {
         match error {
             ByteConversionError::FromBEBytesError => DeserializationError::FieldFromBytesError,
             ByteConversionError::FromLEBytesError => DeserializationError::FieldFromBytesError,
+            ByteConversionError::InvalidValue => DeserializationError::InvalidValue,
+            ByteConversionError::PointNotInSubgroup => DeserializationError::InvalidValue,
+            ByteConversionError::ValueNotCompressed => DeserializationError::InvalidValue,
         }
     }
 }

--- a/math/src/elliptic_curve/traits.rs
+++ b/math/src/elliptic_curve/traits.rs
@@ -50,3 +50,16 @@ pub trait IsPairing {
         Self::compute_batch(&[(p, q)])
     }
 }
+
+pub trait Compress {
+    type G1Point: IsGroup;
+    type G2Point: IsGroup;
+
+    fn compress_g1_point(point: &Self::G1Point) -> Result<[u8; 48], EllipticCurveError>;
+
+    fn decompress_g1_point(input_bytes: &mut [u8; 48])
+        -> Result<Self::G1Point, EllipticCurveError>;
+
+    fn decompress_g2_point(input_bytes: &mut [u8; 96])
+        -> Result<Self::G2Point, EllipticCurveError>;
+}

--- a/math/src/errors.rs
+++ b/math/src/errors.rs
@@ -6,6 +6,12 @@ pub enum ByteConversionError {
     FromBEBytesError,
     #[error("from_le_bytes failed")]
     FromLEBytesError,
+    #[error("Invalid value")]
+    InvalidValue,
+    #[error("The point is not in the subgroup")]
+    PointNotInSubgroup,
+    #[error("Value is not compressed")]
+    ValueNotCompressed,
 }
 
 #[derive(Error, Debug, PartialEq, Eq)]

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -381,7 +381,7 @@ where
 }
 
 #[derive(PartialEq)]
-enum LegendreSymbol {
+pub enum LegendreSymbol {
     MinusOne,
     Zero,
     One,
@@ -397,7 +397,7 @@ impl<F: IsPrimeField> FieldElement<F> {
         self.representative() & 1.into() == 0.into()
     }
 
-    fn legendre_symbol(&self) -> LegendreSymbol {
+    pub fn legendre_symbol(&self) -> LegendreSymbol {
         let mod_minus_one: FieldElement<F> = Self::zero() - Self::one();
         let symbol = self.pow((mod_minus_one / FieldElement::from(2)).representative());
 


### PR DESCRIPTION
# TITLE

## Description

Compress and sqrt for BLS12-381 points.

This PR adds a new trait called `Compress` that enables the implementation of compress and decompress point of the EC.

## Type of change

Please delete options that are not relevant.

- [X] New feature


## Checklist
- [ ] Linked to Github Issue
- [X] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
