### PR TITLE
perf: optimize MSM routines

### DIFF
--- a/math/src/cyclic_group.rs
+++ b/math/src/cyclic_group.rs
@@ -18,7 +18,7 @@ pub trait IsGroup: Clone + PartialEq + Eq {
         let mut result = Self::neutral_element();
         let mut base = self.clone();
 
-        while exponent > T::from(0) {
+        while exponent != T::from(0) {
             if exponent & T::from(1) == T::from(1) {
                 result = Self::operate_with(&result, &base);
             }

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -102,28 +102,50 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
                 if u1 != u2 || *py == FieldElement::zero() {
                     Self::neutral_element()
                 } else {
-                    let eight = FieldElement::from(8);
-                    let w = E::a() * pz * pz + FieldElement::from(3) * px * px;
+                    let px_square = px * px;
+                    let three_px_square = &px_square + &px_square + &px_square;
+                    let w = E::a() * pz * pz + three_px_square;
                     let w_square = &w * &w;
+
                     let s = py * pz;
                     let s_square = &s * &s;
+                    let s_cube = &s * &s_square;
+                    let two_s_cube = &s_cube + &s_cube;
+                    let four_s_cube = &two_s_cube + &two_s_cube;
+                    let eight_s_cube = &four_s_cube + &four_s_cube;
+
                     let b = px * py * &s;
-                    let h = &w_square - &eight * &b;
-                    let xp = FieldElement::from(2) * &h * &s;
-                    let yp = w * (FieldElement::from(4) * &b - &h) - &eight * py * py * &s_square;
-                    let zp = &eight * &s * &s_square;
+                    let two_b = &b + &b;
+                    let four_b = &two_b + &two_b;
+                    let eight_b = &four_b + &four_b;
+
+                    let h = &w_square - eight_b;
+                    let hs = &h * &s;
+
+                    let pys_square = py * py * s_square;
+                    let two_pys_square = &pys_square + &pys_square;
+                    let four_pys_square = &two_pys_square + &two_pys_square;
+                    let eight_pys_square = &four_pys_square + &four_pys_square;
+
+                    let xp = &hs + &hs;
+                    let yp = w * (four_b - &h) - eight_pys_square;
+                    let zp = eight_s_cube;
                     Self::new([xp, yp, zp])
                 }
             } else {
                 let u = u1 - &u2;
                 let v = v1 - &v2;
                 let w = pz * qz;
+
                 let u_square = &u * &u;
                 let v_square = &v * &v;
                 let v_cube = &v * &v_square;
-                let a = &u_square * &w - &v_cube - FieldElement::from(2) * &v_square * &v2;
+                let v_square_v2 = &v_square * &v2;
+
+                let a = &u_square * &w - &v_cube - (&v_square_v2 + &v_square_v2);
+
                 let xp = &v * &a;
-                let yp = u * (&v_square * v2 - a) - &v_cube * u2;
+                let yp = u * (&v_square_v2 - a) - &v_cube * u2;
                 let zp = &v_cube * w;
                 Self::new([xp, yp, zp])
             }


### PR DESCRIPTION
- Replace multiplication by small constants with addition chains, as
  their construction in Montgomery is expensive.
- Reduce duplication of operations by storing temporaries.
- Replace an order check by its equivalent inequality check to avoid
  conversion to normal form.

## Type of change

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added/run

## Results:

TL;DR: 5-10% boost in sequential Pippenger, 10-15% boost in parallel Pippenger.

```
MSM benchmarks with size 2/Naive                                                                                                                                                                                                    
                        time:   [970.38 µs 970.63 µs 970.88 µs]
                        change: [-7.1778% -7.1445% -7.1062%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Sequential Pippenger/1
                        time:   [902.67 µs 902.94 µs 903.23 µs]
                        change: [-14.216% -14.187% -14.159%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Parallel Pippenger/1
                        time:   [3.4668 ms 3.4701 ms 3.4734 ms]
                        change: [-14.315% -14.178% -14.035%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Sequential Pippenger/2
                        time:   [939.33 µs 939.63 µs 939.98 µs]
                        change: [-10.855% -10.812% -10.768%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Parallel Pippenger/2
                        time:   [2.2428 ms 2.2455 ms 2.2482 ms]
                        change: [-13.636% -13.475% -13.322%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Sequential Pippenger/4
                        time:   [1.2623 ms 1.2626 ms 1.2630 ms]
                        change: [-11.482% -11.427% -11.375%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Parallel Pippenger/4
                        time:   [1.3713 ms 1.3741 ms 1.3771 ms]
                        change: [-13.102% -12.809% -12.518%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Sequential Pippenger/8
                        time:   [6.5765 ms 6.5786 ms 6.5808 ms]
                        change: [-10.967% -10.933% -10.895%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Parallel Pippenger/8
                        time:   [1.3462 ms 1.3486 ms 1.3509 ms]
                        change: [-11.371% -11.000% -10.646%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Sequential Pippenger/12                                                                                                                                                                                  
                        time:   [72.297 ms 72.323 ms 72.349 ms]
                        change: [-6.8481% -6.8087% -6.7683%] (p = 0.00 < 0.05)
MSM benchmarks with size 2/Parallel Pippenger/12
                        time:   [6.1227 ms 6.1352 ms 6.1476 ms]
                        change: [-8.8000% -8.5380% -8.2888%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Naive
                        time:   [1.9780 ms 1.9783 ms 1.9785 ms]
                        change: [-5.7835% -5.7629% -5.7436%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Sequential Pippenger/1
                        time:   [1.1846 ms 1.1848 ms 1.1851 ms]
                        change: [-8.0835% -8.0570% -8.0295%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Parallel Pippenger/1
                        time:   [4.1614 ms 4.1643 ms 4.1674 ms]
                        change: [-14.003% -13.895% -13.794%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Sequential Pippenger/2
                        time:   [1.2051 ms 1.2054 ms 1.2057 ms]
                        change: [-4.4342% -4.4016% -4.3682%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Parallel Pippenger/2
                        time:   [2.3716 ms 2.3743 ms 2.3771 ms]
                        change: [-13.745% -13.597% -13.444%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Sequential Pippenger/4
                        time:   [1.5070 ms 1.5072 ms 1.5074 ms]
                        change: [-10.065% -10.011% -9.9558%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Parallel Pippenger/4
                        time:   [1.3951 ms 1.3976 ms 1.4002 ms]
                        change: [-13.029% -12.764% -12.525%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Parallel Pippenger/8                                                                                                                                                                                     
                        time:   [1.4002 ms 1.4027 ms 1.4052 ms]
                        change: [-11.491% -11.070% -10.626%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Sequential Pippenger/12
                        time:   [75.170 ms 75.201 ms 75.232 ms]
                        change: [-10.827% -10.670% -10.503%] (p = 0.00 < 0.05)
MSM benchmarks with size 4/Parallel Pippenger/12
                        time:   [6.2731 ms 6.2906 ms 6.3083 ms]
                        change: [-8.9979% -8.6732% -8.3630%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Naive
                        time:   [3.8215 ms 3.8285 ms 3.8361 ms]
                        change: [-5.9604% -5.7752% -5.5897%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Sequential Pippenger/1
                        time:   [1.5835 ms 1.5838 ms 1.5842 ms]
                        change: [-5.3763% -5.3393% -5.3023%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Parallel Pippenger/1
                        time:   [4.5077 ms 4.5105 ms 4.5134 ms]
                        change: [-13.731% -13.637% -13.543%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Sequential Pippenger/2
                        time:   [1.5885 ms 1.5941 ms 1.5986 ms]
                        change: [-10.898% -10.677% -10.444%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Parallel Pippenger/2
                        time:   [2.4458 ms 2.4482 ms 2.4508 ms]
                        change: [-13.743% -13.596% -13.453%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Sequential Pippenger/4
                        time:   [1.8320 ms 1.8323 ms 1.8328 ms]
                        change: [-9.0402% -9.0003% -8.9623%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Parallel Pippenger/4
                        time:   [1.4443 ms 1.4465 ms 1.4487 ms]
                        change: [-12.923% -12.633% -12.308%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Sequential Pippenger/8                                                                                                                                                                                   
                        time:   [8.3457 ms 8.3477 ms 8.3498 ms]
                        change: [-7.5832% -7.5484% -7.5161%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Parallel Pippenger/8
                        time:   [1.4764 ms 1.4795 ms 1.4828 ms]
                        change: [-11.081% -10.763% -10.395%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Sequential Pippenger/12
                        time:   [84.819 ms 84.847 ms 84.874 ms]
                        change: [-7.3304% -7.1511% -6.9609%] (p = 0.00 < 0.05)
MSM benchmarks with size 8/Parallel Pippenger/12
                        time:   [6.3523 ms 6.3672 ms 6.3825 ms]
                        change: [-8.4695% -8.1710% -7.8587%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Naive
                        time:   [7.8875 ms 7.8890 ms 7.8906 ms]
                        change: [-8.2482% -8.2166% -8.1858%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Sequential Pippenger/1
                        time:   [2.3794 ms 2.3798 ms 2.3803 ms]
                        change: [-9.2170% -9.1917% -9.1653%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Parallel Pippenger/1
                        time:   [4.5809 ms 4.5852 ms 4.5896 ms]
                        change: [-13.695% -13.584% -13.477%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Sequential Pippenger/2
                        time:   [2.4356 ms 2.4361 ms 2.4366 ms]
                        change: [-8.0804% -8.0519% -8.0259%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Parallel Pippenger/2
                        time:   [2.5037 ms 2.5064 ms 2.5093 ms]
                        change: [-13.851% -13.706% -13.567%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Sequential Pippenger/4
                        time:   [2.3627 ms 2.3632 ms 2.3637 ms]
                        change: [-7.9262% -7.8990% -7.8719%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Parallel Pippenger/4
                        time:   [1.4826 ms 1.4847 ms 1.4868 ms]
                        change: [-13.107% -12.826% -12.540%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Sequential Pippenger/8                                                                                                                                                                                  
                        time:   [9.0750 ms 9.0771 ms 9.0793 ms]
                        change: [-7.8345% -7.8049% -7.7777%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Parallel Pippenger/8
                        time:   [1.5404 ms 1.5434 ms 1.5466 ms]
                        change: [-10.907% -10.611% -10.315%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Sequential Pippenger/12
                        time:   [87.910 ms 87.930 ms 87.951 ms]
                        change: [-8.8528% -8.8162% -8.7772%] (p = 0.00 < 0.05)
MSM benchmarks with size 16/Parallel Pippenger/12
                        time:   [6.5349 ms 6.5521 ms 6.5703 ms]
                        change: [-8.1327% -7.8077% -7.5148%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Naive
                        time:   [15.315 ms 15.317 ms 15.319 ms]
                        change: [-9.3957% -9.3753% -9.3562%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Sequential Pippenger/1
                        time:   [3.8739 ms 3.8745 ms 3.8751 ms]
                        change: [-8.9326% -8.9091% -8.8856%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Parallel Pippenger/1
                        time:   [4.7170 ms 4.7203 ms 4.7235 ms]
                        change: [-13.484% -13.390% -13.300%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Sequential Pippenger/2
                        time:   [3.8887 ms 3.8896 ms 3.8905 ms]
                        change: [-9.9059% -9.8803% -9.8588%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Parallel Pippenger/2
                        time:   [2.6024 ms 2.6050 ms 2.6075 ms]
                        change: [-13.436% -13.317% -13.197%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Sequential Pippenger/4
                        time:   [3.4141 ms 3.4148 ms 3.4156 ms]
                        change: [-6.5568% -6.5290% -6.5021%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Parallel Pippenger/4
                        time:   [1.5515 ms 1.5536 ms 1.5556 ms]
                        change: [-13.101% -12.831% -12.557%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Sequential Pippenger/8
                        time:   [9.6965 ms 9.6981 ms 9.6997 ms]
                        change: [-8.0493% -8.0286% -8.0065%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Parallel Pippenger/8                                                                                                                                                                                    
                        time:   [1.5952 ms 1.5983 ms 1.6014 ms]
                        change: [-11.013% -10.643% -10.280%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Sequential Pippenger/12
                        time:   [86.483 ms 86.509 ms 86.536 ms]
                        change: [-10.218% -10.170% -10.121%] (p = 0.00 < 0.05)
MSM benchmarks with size 32/Parallel Pippenger/12
                        time:   [6.6864 ms 6.7018 ms 6.7173 ms]
                        change: [-8.5716% -8.3044% -8.0197%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Naive
                        time:   [30.935 ms 30.940 ms 30.946 ms]
                        change: [-7.0882% -7.0552% -7.0233%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Sequential Pippenger/1
                        time:   [6.9946 ms 6.9955 ms 6.9965 ms]
                        change: [-6.1589% -6.1347% -6.1096%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Parallel Pippenger/1
                        time:   [5.0047 ms 5.0080 ms 5.0111 ms]
                        change: [-12.993% -12.901% -12.811%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Sequential Pippenger/2
                        time:   [6.9312 ms 6.9336 ms 6.9360 ms]
                        change: [-9.8994% -9.8662% -9.8331%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Parallel Pippenger/2
                        time:   [2.8162 ms 2.8202 ms 2.8243 ms]
                        change: [-12.556% -12.398% -12.236%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Sequential Pippenger/4
                        time:   [5.1947 ms 5.1961 ms 5.1976 ms]
                        change: [-9.0793% -9.0511% -9.0218%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Parallel Pippenger/4
                        time:   [1.6894 ms 1.6922 ms 1.6951 ms]
                        change: [-13.390% -13.160% -12.938%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Sequential Pippenger/8
                        time:   [11.117 ms 11.119 ms 11.121 ms]
                        change: [-8.7658% -8.7372% -8.7097%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Parallel Pippenger/8                                                                                                                                                                                    
                        time:   [1.6924 ms 1.6955 ms 1.6985 ms]
                        change: [-11.108% -10.794% -10.492%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Sequential Pippenger/12
                        time:   [91.432 ms 91.455 ms 91.479 ms]
                        change: [-9.2035% -9.1648% -9.1260%] (p = 0.00 < 0.05)
MSM benchmarks with size 64/Parallel Pippenger/12
                        time:   [6.7877 ms 6.8032 ms 6.8188 ms]
                        change: [-8.4679% -8.2019% -7.9161%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Naive
                        time:   [62.069 ms 62.080 ms 62.092 ms]
                        change: [-6.9251% -6.8916% -6.8579%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Sequential Pippenger/1
                        time:   [13.480 ms 13.482 ms 13.483 ms]
                        change: [-4.3842% -4.3563% -4.3292%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Parallel Pippenger/1
                        time:   [5.5383 ms 5.5424 ms 5.5465 ms]
                        change: [-12.578% -12.481% -12.381%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Sequential Pippenger/2
                        time:   [12.797 ms 12.801 ms 12.804 ms]
                        change: [-11.731% -11.644% -11.539%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Parallel Pippenger/2
                        time:   [3.2189 ms 3.2223 ms 3.2257 ms]
                        change: [-12.371% -12.224% -12.086%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Sequential Pippenger/4
                        time:   [9.1418 ms 9.1429 ms 9.1441 ms]
                        change: [-6.4107% -6.3812% -6.3523%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Parallel Pippenger/4
                        time:   [1.9908 ms 1.9933 ms 1.9958 ms]
                        change: [-10.810% -10.631% -10.457%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Sequential Pippenger/8
                        time:   [13.039 ms 13.064 ms 13.090 ms]
                        change: [-5.0213% -4.8336% -4.6145%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Parallel Pippenger/8                                                                                                                                                                                   
                        time:   [1.8729 ms 1.8758 ms 1.8785 ms]
                        change: [-10.517% -10.231% -9.9588%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Sequential Pippenger/12
                        time:   [90.197 ms 90.213 ms 90.231 ms]
                        change: [-11.553% -11.513% -11.473%] (p = 0.00 < 0.05)
MSM benchmarks with size 128/Parallel Pippenger/12
                        time:   [6.8933 ms 6.9064 ms 6.9197 ms]
                        change: [-8.3609% -8.0741% -7.7961%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Naive
                        time:   [121.92 ms 121.96 ms 122.00 ms]
                        change: [-10.309% -10.269% -10.227%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Sequential Pippenger/1
                        time:   [25.340 ms 25.344 ms 25.348 ms]
                        change: [-9.9669% -9.9468% -9.9272%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Parallel Pippenger/1
                        time:   [6.5877 ms 6.5928 ms 6.5980 ms]
                        change: [-12.194% -12.101% -12.011%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Sequential Pippenger/2
                        time:   [25.390 ms 25.397 ms 25.405 ms]
                        change: [-9.5841% -9.3487% -9.0886%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Parallel Pippenger/2
                        time:   [4.0555 ms 4.0608 ms 4.0660 ms]
                        change: [-11.478% -11.324% -11.181%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Sequential Pippenger/4
                        time:   [17.161 ms 17.163 ms 17.165 ms]
                        change: [-5.4012% -5.3766% -5.3523%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Parallel Pippenger/4
                        time:   [2.5023 ms 2.5061 ms 2.5100 ms]
                        change: [-11.871% -11.646% -11.411%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Sequential Pippenger/8
                        time:   [17.765 ms 17.769 ms 17.773 ms]
                        change: [-1.7809% -1.7526% -1.7254%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Parallel Pippenger/8
                        time:   [2.2171 ms 2.2211 ms 2.2252 ms]
                        change: [-10.906% -10.645% -10.371%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Sequential Pippenger/12                                                                                                                                                                                 
                        time:   [96.051 ms 96.089 ms 96.127 ms]
                        change: [-10.512% -10.467% -10.425%] (p = 0.00 < 0.05)
MSM benchmarks with size 256/Parallel Pippenger/12
                        time:   [7.0569 ms 7.0689 ms 7.0813 ms]
                        change: [-9.0476% -8.7706% -8.5045%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Naive
                        time:   [249.59 ms 249.68 ms 249.77 ms]
                        change: [-9.2055% -9.1635% -9.1228%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Sequential Pippenger/1
                        time:   [51.617 ms 51.627 ms 51.639 ms]
                        change: [-6.4720% -6.4469% -6.4212%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Parallel Pippenger/1
                        time:   [8.7681 ms 8.7752 ms 8.7823 ms]
                        change: [-11.292% -11.194% -11.098%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Sequential Pippenger/2
                        time:   [50.775 ms 50.783 ms 50.792 ms]
                        change: [-6.9359% -6.9126% -6.8896%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Parallel Pippenger/2
                        time:   [5.7225 ms 5.7295 ms 5.7367 ms]
                        change: [-10.436% -10.289% -10.151%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Sequential Pippenger/4
                        time:   [33.125 ms 33.133 ms 33.141 ms]
                        change: [-1.4460% -1.4134% -1.3795%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Parallel Pippenger/4
                        time:   [3.5704 ms 3.5762 ms 3.5821 ms]
                        change: [-10.788% -10.586% -10.393%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Sequential Pippenger/8
                        time:   [25.285 ms 25.293 ms 25.300 ms]
                        change: [-7.2078% -7.1691% -7.1319%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Parallel Pippenger/8
                        time:   [2.9158 ms 2.9219 ms 2.9280 ms]
                        change: [-9.6243% -9.3521% -9.0629%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Sequential Pippenger/12                                                                                                                                                                                 
                        time:   [99.029 ms 99.049 ms 99.070 ms]
                        change: [-12.648% -12.558% -12.448%] (p = 0.00 < 0.05)
MSM benchmarks with size 512/Parallel Pippenger/12
                        time:   [7.4348 ms 7.4505 ms 7.4665 ms]
                        change: [-8.0452% -7.7881% -7.5370%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Naive
                        time:   [495.91 ms 497.01 ms 498.09 ms]
                        change: [-9.1939% -8.9718% -8.7429%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Sequential Pippenger/1
                        time:   [102.27 ms 102.28 ms 102.29 ms]
                        change: [-5.4519% -5.4362% -5.4209%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Parallel Pippenger/1
                        time:   [13.066 ms 13.076 ms 13.086 ms]
                        change: [-10.424% -10.307% -10.195%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Sequential Pippenger/2
                        time:   [98.636 ms 98.655 ms 98.676 ms]
                        change: [-6.8637% -6.8353% -6.8087%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Parallel Pippenger/2
                        time:   [8.9977 ms 9.0081 ms 9.0188 ms]
                        change: [-10.090% -9.9398% -9.7988%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Sequential Pippenger/4
                        time:   [62.610 ms 62.625 ms 62.641 ms]
                        change: [-7.6613% -7.6240% -7.5861%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Parallel Pippenger/4
                        time:   [5.6186 ms 5.6272 ms 5.6360 ms]
                        change: [-9.8881% -9.6847% -9.4790%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Sequential Pippenger/8
                        time:   [42.832 ms 42.836 ms 42.842 ms]
                        change: [-4.5290% -4.5017% -4.4745%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Parallel Pippenger/8
                        time:   [4.2808 ms 4.2865 ms 4.2923 ms]
                        change: [-9.5597% -9.3659% -9.1679%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Sequential Pippenger/12
                        time:   [112.46 ms 112.49 ms 112.53 ms]
                        change: [-9.2461% -9.2171% -9.1810%] (p = 0.00 < 0.05)
MSM benchmarks with size 1024/Parallel Pippenger/12
                        time:   [8.1376 ms 8.1543 ms 8.1740 ms]
                        change: [-9.0163% -8.7533% -8.4571%] (p = 0.00 < 0.05)
```