### PR TITLE
Implement Square Separated Operand Scanning

### DIFF
--- a/math/benches/criterion_field.rs
+++ b/math/benches/criterion_field.rs
@@ -1,7 +1,16 @@
-use criterion::{criterion_group, criterion_main, Criterion, black_box};
-use lambdaworks_math::{field::{
-    element::FieldElement, fields::{fft_friendly::stark_252_prime_field::{Stark252PrimeField, MontgomeryConfigStark252PrimeField}, montgomery_backed_prime_fields::IsModulus},
-}, unsigned_integer::{montgomery::MontgomeryAlgorithms, element::U256}};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use lambdaworks_math::{
+    field::{
+        element::FieldElement,
+        fields::{
+            fft_friendly::stark_252_prime_field::{
+                MontgomeryConfigStark252PrimeField, Stark252PrimeField,
+            },
+            montgomery_backed_prime_fields::IsModulus,
+        },
+    },
+    unsigned_integer::{element::U256, montgomery::MontgomeryAlgorithms},
+};
 
 mod util;
 
@@ -26,11 +35,23 @@ pub fn starkfield_ops_benchmarks(c: &mut Criterion) {
     });
 
     group.bench_with_input("sos_square", &x.clone(), |bench, x| {
-        bench.iter(|| MontgomeryAlgorithms::sos_square(&x.value(), &<MontgomeryConfigStark252PrimeField as IsModulus<U256>>::MODULUS, &Stark252PrimeField::MU));
+        bench.iter(|| {
+            MontgomeryAlgorithms::sos_square(
+                &x.value(),
+                &<MontgomeryConfigStark252PrimeField as IsModulus<U256>>::MODULUS,
+                &Stark252PrimeField::MU,
+            )
+        });
     });
 
     group.bench_with_input("sos_square_black_box", &x.clone(), |bench, x| {
-        bench.iter(|| MontgomeryAlgorithms::sos_square(black_box(&x.value()), black_box(&<MontgomeryConfigStark252PrimeField as IsModulus<U256>>::MODULUS), black_box(&Stark252PrimeField::MU)));
+        bench.iter(|| {
+            MontgomeryAlgorithms::sos_square(
+                black_box(&x.value()),
+                &<MontgomeryConfigStark252PrimeField as IsModulus<U256>>::MODULUS,
+                &Stark252PrimeField::MU,
+            )
+        });
     });
 
     group.bench_with_input("noop", &x.clone(), |bench, x| {

--- a/math/benches/criterion_field.rs
+++ b/math/benches/criterion_field.rs
@@ -1,9 +1,18 @@
 use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use lambdaworks_math::{field::{
-    element::FieldElement, fields::{fft_friendly::stark_252_prime_field::{Stark252PrimeField, MontgomeryConfigStark252PrimeField}, montgomery_backed_prime_fields::IsModulus},
-}, unsigned_integer::{montgomery::MontgomeryAlgorithms, element::U256}};
+use lambdaworks_math::{
+    field::{
+        element::FieldElement,
+        fields::{
+            fft_friendly::stark_252_prime_field::{
+                MontgomeryConfigStark252PrimeField, Stark252PrimeField,
+            },
+            montgomery_backed_prime_fields::IsModulus,
+        },
+    },
+    unsigned_integer::{element::U256, montgomery::MontgomeryAlgorithms},
+};
 
 mod util;
 

--- a/math/benches/criterion_field.rs
+++ b/math/benches/criterion_field.rs
@@ -37,24 +37,14 @@ pub fn starkfield_ops_benchmarks(c: &mut Criterion) {
     group.bench_with_input("sos_square", &x.clone(), |bench, x| {
         bench.iter(|| {
             MontgomeryAlgorithms::sos_square(
-                &x.value(),
+                black_box(x.value()),
                 &<MontgomeryConfigStark252PrimeField as IsModulus<U256>>::MODULUS,
                 &Stark252PrimeField::MU,
             )
         });
     });
 
-    group.bench_with_input("sos_square_black_box", &x.clone(), |bench, x| {
-        bench.iter(|| {
-            MontgomeryAlgorithms::sos_square(
-                black_box(&x.value()),
-                &<MontgomeryConfigStark252PrimeField as IsModulus<U256>>::MODULUS,
-                &Stark252PrimeField::MU,
-            )
-        });
-    });
-
-    group.bench_with_input("noop", &x.clone(), |bench, x| {
+    group.bench_with_input("pow by 1", &x.clone(), |bench, x| {
         bench.iter(|| x.pow(1_u64));
     });
 

--- a/math/benches/criterion_field.rs
+++ b/math/benches/criterion_field.rs
@@ -1,16 +1,9 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use lambdaworks_math::{
-    field::{
-        element::FieldElement,
-        fields::{
-            fft_friendly::stark_252_prime_field::{
-                MontgomeryConfigStark252PrimeField, Stark252PrimeField,
-            },
-            montgomery_backed_prime_fields::IsModulus,
-        },
-    },
-    unsigned_integer::{element::U256, montgomery::MontgomeryAlgorithms},
-};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use lambdaworks_math::{field::{
+    element::FieldElement, fields::{fft_friendly::stark_252_prime_field::{Stark252PrimeField, MontgomeryConfigStark252PrimeField}, montgomery_backed_prime_fields::IsModulus},
+}, unsigned_integer::{montgomery::MontgomeryAlgorithms, element::U256}};
 
 mod util;
 
@@ -34,6 +27,10 @@ pub fn starkfield_ops_benchmarks(c: &mut Criterion) {
         bench.iter(|| x * y);
     });
 
+    group.bench_with_input("pow by 1", &x.clone(), |bench, x| {
+        bench.iter(|| x.pow(1_u64));
+    });
+
     group.bench_with_input("sos_square", &x.clone(), |bench, x| {
         bench.iter(|| {
             MontgomeryAlgorithms::sos_square(
@@ -44,8 +41,8 @@ pub fn starkfield_ops_benchmarks(c: &mut Criterion) {
         });
     });
 
-    group.bench_with_input("pow by 1", &x.clone(), |bench, x| {
-        bench.iter(|| x.pow(1_u64));
+    group.bench_with_input("square", &x.clone(), |bench, x| {
+        bench.iter(|| x.square());
     });
 
     group.bench_with_input("square with pow", &x.clone(), |bench, x| {

--- a/math/benches/criterion_field.rs
+++ b/math/benches/criterion_field.rs
@@ -40,6 +40,8 @@ pub fn starkfield_ops_benchmarks(c: &mut Criterion) {
         bench.iter(|| x.pow(1_u64));
     });
 
+    // The non-boxed constants are intentional as they are
+    // normally computed at compile time.
     group.bench_with_input("sos_square", &x.clone(), |bench, x| {
         bench.iter(|| {
             MontgomeryAlgorithms::sos_square(

--- a/math/benches/criterion_field.rs
+++ b/math/benches/criterion_field.rs
@@ -1,7 +1,7 @@
-use criterion::{criterion_group, criterion_main, Criterion};
-use lambdaworks_math::field::{
-    element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
-};
+use criterion::{criterion_group, criterion_main, Criterion, black_box};
+use lambdaworks_math::{field::{
+    element::FieldElement, fields::{fft_friendly::stark_252_prime_field::{Stark252PrimeField, MontgomeryConfigStark252PrimeField}, montgomery_backed_prime_fields::IsModulus},
+}, unsigned_integer::{montgomery::MontgomeryAlgorithms, element::U256}};
 
 mod util;
 
@@ -23,6 +23,26 @@ pub fn starkfield_ops_benchmarks(c: &mut Criterion) {
 
     group.bench_with_input("mul", &(x.clone(), y.clone()), |bench, (x, y)| {
         bench.iter(|| x * y);
+    });
+
+    group.bench_with_input("sos_square", &x.clone(), |bench, x| {
+        bench.iter(|| MontgomeryAlgorithms::sos_square(&x.value(), &<MontgomeryConfigStark252PrimeField as IsModulus<U256>>::MODULUS, &Stark252PrimeField::MU));
+    });
+
+    group.bench_with_input("sos_square_black_box", &x.clone(), |bench, x| {
+        bench.iter(|| MontgomeryAlgorithms::sos_square(black_box(&x.value()), black_box(&<MontgomeryConfigStark252PrimeField as IsModulus<U256>>::MODULUS), black_box(&Stark252PrimeField::MU)));
+    });
+
+    group.bench_with_input("noop", &x.clone(), |bench, x| {
+        bench.iter(|| x.pow(1_u64));
+    });
+
+    group.bench_with_input("square with pow", &x.clone(), |bench, x| {
+        bench.iter(|| x.pow(2_u64));
+    });
+
+    group.bench_with_input("square with mul", &x.clone(), |bench, x| {
+        bench.iter(|| x * x);
     });
 
     group.bench_with_input("pow", &(x.clone(), 5u64), |bench, (x, y)| {

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -46,6 +46,13 @@ impl IsField for Degree2ExtensionField {
         [&a0b0 - &a1b1, z - a0b0 - a1b1]
     }
 
+    fn square(a: &Self::BaseType) -> Self::BaseType {
+        let [a0, a1] = a;
+        let v0 = a0 * a1;
+        let c0 = (a0 + a1) * (a0 - a1);
+        let c1 = &v0 + &v0;
+        [c0, c1]
+    }
     /// Returns the component wise subtraction of `a` and `b`
     fn sub(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         [&a[0] - &b[0], &a[1] - &b[1]]
@@ -94,16 +101,6 @@ impl IsField for Degree2ExtensionField {
     /// already have correct representations.
     fn from_base_type(x: Self::BaseType) -> Self::BaseType {
         x
-    }
-}
-
-impl FieldElement<Degree2ExtensionField> {
-    pub fn square(&self) -> Self {
-        let [a0, a1] = self.value();
-        let v0 = a0 * a1;
-        let c0 = (a0 + a1) * (a0 - a1);
-        let c1 = &v0 + &v0;
-        Self::new([c0, c1])
     }
 }
 

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -341,6 +341,7 @@ where
     F: IsField,
 {
     /// Creates a field element from `value`
+    #[inline(always)]
     pub fn new(value: F::BaseType) -> Self {
         Self {
             value: F::from_base_type(value),
@@ -348,17 +349,21 @@ where
     }
 
     /// Returns the underlying `value`
+    #[inline(always)]
     pub fn value(&self) -> &F::BaseType {
         &self.value
     }
 
     /// Returns the multiplicative inverse of `self`
+    #[inline(always)]
     pub fn inv(&self) -> Self {
         Self {
             value: F::inv(&self.value),
         }
     }
 
+    /// Returns the square of `self`
+    #[inline(always)]
     pub fn square(&self) -> Self {
         Self {
             value: F::square(&self.value)
@@ -366,6 +371,7 @@ where
     }
 
     /// Returns `self` raised to the power of `exponent`
+    #[inline(always)]
     pub fn pow<T>(&self, exponent: T) -> Self
     where
         T: IsUnsignedInteger,
@@ -376,11 +382,13 @@ where
     }
 
     /// Returns the multiplicative neutral element of the field.
+    #[inline(always)]
     pub fn one() -> Self {
         Self { value: F::one() }
     }
 
     /// Returns the additive neutral element of the field.
+    #[inline(always)]
     pub fn zero() -> Self {
         Self { value: F::zero() }
     }

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -366,7 +366,7 @@ where
     #[inline(always)]
     pub fn square(&self) -> Self {
         Self {
-            value: F::square(&self.value)
+            value: F::square(&self.value),
         }
     }
 

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -359,6 +359,12 @@ where
         }
     }
 
+    pub fn square(&self) -> Self {
+        Self {
+            value: F::square(&self.value)
+        }
+    }
+
     /// Returns `self` raised to the power of `exponent`
     pub fn pow<T>(&self, exponent: T) -> Self
     where

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -60,6 +60,14 @@ where
         [&a0b0 + &a1b1 * q, z - a0b0 - a1b1]
     }
 
+    fn square(a: &[FieldElement<Q::BaseField>; 2]) -> [FieldElement<Q::BaseField>; 2] {
+        let [a0, a1] = a;
+        let v0 = a0 * a1;
+        let c0 = (a0 + a1) * (a0 + Q::residue() * a1) - &v0 - Q::residue() * &v0;
+        let c1 = &v0 + &v0;
+        [c0, c1]
+    }
+
     /// Returns the component wise subtraction of `a` and `b`
     fn sub(
         a: &[FieldElement<Q::BaseField>; 2],
@@ -118,13 +126,6 @@ where
 }
 
 impl<Q: Clone + Debug + HasQuadraticNonResidue> FieldElement<QuadraticExtensionField<Q>> {
-    pub fn square(&self) -> Self {
-        let [a0, a1] = self.value();
-        let v0 = a0 * a1;
-        let c0 = (a0 + a1) * (a0 + Q::residue() * a1) - &v0 - Q::residue() * &v0;
-        let c1 = &v0 + &v0;
-        Self::new([c0, c1])
-    }
 }
 
 #[cfg(test)]

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -125,8 +125,7 @@ where
     }
 }
 
-impl<Q: Clone + Debug + HasQuadraticNonResidue> FieldElement<QuadraticExtensionField<Q>> {
-}
+impl<Q: Clone + Debug + HasQuadraticNonResidue> FieldElement<QuadraticExtensionField<Q>> {}
 
 #[cfg(test)]
 mod tests {

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -252,7 +252,7 @@ where
             let mut base = result;
             exponent = exponent >> 1;
 
-            while exponent > zero {
+            while exponent != zero {
                 base = Self::square(&base);
                 if exponent & one == one {
                     result = Self::mul(&result, &base);

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -234,18 +234,34 @@ where
     where
         T: IsUnsignedInteger,
     {
-        let mut result = Self::one();
-        let mut base = a.clone();
         let zero = T::from(0);
+        if exponent == zero {
+            return Self::one();
+        }
+
         let one = T::from(1);
+        if exponent == one {
+            return *a;
+        }
+
+        let mut result = a.clone();
+        while exponent & one == zero {
+            result = Self::square(&result);
+            exponent = exponent >> 1;
+        }
+
+        let mut base = result.clone();
+        exponent = exponent >> 1;
+
         while exponent > zero {
+            base = Self::square(&base);
             if exponent & one == one {
                 result = Self::mul(&result, &base);
             }
-            base = Self::square(&base);
             exponent = exponent >> 1;
         }
-        result
+
+        return result;
     }
 }
 

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -244,13 +244,13 @@ where
             return *a;
         }
 
-        let mut result = a.clone();
+        let mut result = *a;
         while exponent & one == zero {
             result = Self::square(&result);
             exponent = exponent >> 1;
         }
 
-        let mut base = result.clone();
+        let mut base = result;
         exponent = exponent >> 1;
 
         while exponent > zero {
@@ -261,7 +261,7 @@ where
             exponent = exponent >> 1;
         }
 
-        return result;
+        result
     }
 }
 

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -235,33 +235,34 @@ where
         T: IsUnsignedInteger,
     {
         let zero = T::from(0);
-        if exponent == zero {
-            return Self::one();
-        }
-
         let one = T::from(1);
-        if exponent == one {
-            return *a;
-        }
 
-        let mut result = *a;
-        while exponent & one == zero {
-            result = Self::square(&result);
-            exponent = exponent >> 1;
-        }
+        if exponent == zero {
+            Self::one()
+        } else if exponent == one {
+            *a
+        } else {
+            let mut result = *a;
 
-        let mut base = result;
-        exponent = exponent >> 1;
-
-        while exponent > zero {
-            base = Self::square(&base);
-            if exponent & one == one {
-                result = Self::mul(&result, &base);
+            while exponent & one == zero {
+                result = Self::square(&result);
+                exponent = exponent >> 1;
             }
+
+            let mut base = result;
             exponent = exponent >> 1;
+
+            while exponent > zero {
+                base = Self::square(&base);
+                if exponent & one == one {
+                    result = Self::mul(&result, &base);
+                }
+                exponent = exponent >> 1;
+            }
+
+            result
         }
 
-        result
     }
 }
 

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -1,7 +1,6 @@
 use crate::field::element::FieldElement;
 use crate::field::traits::IsPrimeField;
 use crate::traits::ByteConversion;
-use crate::unsigned_integer::traits::IsUnsignedInteger;
 use crate::{
     field::traits::IsField, unsigned_integer::element::UnsignedInteger,
     unsigned_integer::montgomery::MontgomeryAlgorithms,
@@ -83,10 +82,6 @@ where
         }
         c
     }
-
-    fn square(a: &UnsignedInteger<NUM_LIMBS>) -> UnsignedInteger<NUM_LIMBS> {
-        MontgomeryAlgorithms::sos_square(a, &M::MODULUS, &Self::MU)
-    }
 }
 
 impl<M, const NUM_LIMBS: usize> IsField for MontgomeryBackendPrimeField<M, NUM_LIMBS>
@@ -111,6 +106,10 @@ where
 
     fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         MontgomeryAlgorithms::cios(a, b, &M::MODULUS, &Self::MU)
+    }
+
+    fn square(a: &UnsignedInteger<NUM_LIMBS>) -> UnsignedInteger<NUM_LIMBS> {
+        MontgomeryAlgorithms::sos_square(a, &M::MODULUS, &Self::MU)
     }
 
     fn sub(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
@@ -230,39 +229,6 @@ where
         MontgomeryAlgorithms::cios(&x, &Self::R2, &M::MODULUS, &Self::MU)
     }
 
-    fn pow<T>(a: &Self::BaseType, mut exponent: T) -> Self::BaseType
-    where
-        T: IsUnsignedInteger,
-    {
-        let zero = T::from(0);
-        let one = T::from(1);
-
-        if exponent == zero {
-            Self::one()
-        } else if exponent == one {
-            *a
-        } else {
-            let mut result = *a;
-
-            while exponent & one == zero {
-                result = Self::square(&result);
-                exponent = exponent >> 1;
-            }
-
-            let mut base = result;
-            exponent = exponent >> 1;
-
-            while exponent != zero {
-                base = Self::square(&base);
-                if exponent & one == one {
-                    result = Self::mul(&result, &base);
-                }
-                exponent = exponent >> 1;
-            }
-
-            result
-        }
-    }
 }
 
 impl<M, const NUM_LIMBS: usize> IsPrimeField for MontgomeryBackendPrimeField<M, NUM_LIMBS>

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -30,6 +30,12 @@ where
     pub const R2: UnsignedInteger<NUM_LIMBS> = Self::compute_r2_parameter(&M::MODULUS);
     pub const MU: u64 = Self::compute_mu_parameter(&M::MODULUS);
     pub const ZERO: UnsignedInteger<NUM_LIMBS> = UnsignedInteger::from_u64(0);
+    pub const ONE: UnsignedInteger<NUM_LIMBS> = MontgomeryAlgorithms::cios(
+        &UnsignedInteger::from_u64(1),
+        &Self::R2,
+        &M::MODULUS,
+        &Self::MU,
+    );
 
     /// Computes `- modulus^{-1} mod 2^{64}`
     /// This algorithm is given  by Dussé and Kaliski Jr. in
@@ -90,6 +96,7 @@ where
 {
     type BaseType = UnsignedInteger<NUM_LIMBS>;
 
+    #[inline(always)]
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         let (sum, overflow) = UnsignedInteger::add(a, b);
         if !overflow {
@@ -104,14 +111,17 @@ where
         }
     }
 
+    #[inline(always)]
     fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         MontgomeryAlgorithms::cios(a, b, &M::MODULUS, &Self::MU)
     }
 
+    #[inline(always)]
     fn square(a: &UnsignedInteger<NUM_LIMBS>) -> UnsignedInteger<NUM_LIMBS> {
         MontgomeryAlgorithms::sos_square(a, &M::MODULUS, &Self::MU)
     }
 
+    #[inline(always)]
     fn sub(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         if b <= a {
             a - b
@@ -120,6 +130,7 @@ where
         }
     }
 
+    #[inline(always)]
     fn neg(a: &Self::BaseType) -> Self::BaseType {
         if a == &Self::ZERO {
             *a
@@ -128,6 +139,7 @@ where
         }
     }
 
+    #[inline(always)]
     fn inv(a: &Self::BaseType) -> Self::BaseType {
         if a == &Self::ZERO {
             panic!("Division by zero error.")
@@ -200,22 +212,27 @@ where
         }
     }
 
+    #[inline(always)]
     fn div(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         Self::mul(a, &Self::inv(b))
     }
 
+    #[inline(always)]
     fn eq(a: &Self::BaseType, b: &Self::BaseType) -> bool {
         a == b
     }
 
+    #[inline(always)]
     fn zero() -> Self::BaseType {
         Self::ZERO
     }
 
+    #[inline(always)]
     fn one() -> Self::BaseType {
-        Self::from_u64(1)
+        Self::ONE
     }
 
+    #[inline(always)]
     fn from_u64(x: u64) -> Self::BaseType {
         MontgomeryAlgorithms::cios(
             &UnsignedInteger::from_u64(x),
@@ -225,10 +242,10 @@ where
         )
     }
 
+    #[inline(always)]
     fn from_base_type(x: Self::BaseType) -> Self::BaseType {
         MontgomeryAlgorithms::cios(&x, &Self::R2, &M::MODULUS, &Self::MU)
     }
-
 }
 
 impl<M, const NUM_LIMBS: usize> IsPrimeField for MontgomeryBackendPrimeField<M, NUM_LIMBS>

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -262,7 +262,6 @@ where
 
             result
         }
-
     }
 }
 

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -83,6 +83,10 @@ where
         }
         c
     }
+
+    fn square(a: &UnsignedInteger<NUM_LIMBS>) -> UnsignedInteger<NUM_LIMBS> {
+        MontgomeryAlgorithms::sos_square(a, &M::MODULUS, &Self::MU)
+    }
 }
 
 impl<M, const NUM_LIMBS: usize> IsField for MontgomeryBackendPrimeField<M, NUM_LIMBS>
@@ -238,7 +242,7 @@ where
             if exponent & one == one {
                 result = Self::mul(&result, &base);
             }
-            base = MontgomeryAlgorithms::sos_square(&base, &M::MODULUS, &Self::MU);
+            base = Self::square(&base);
             exponent = exponent >> 1;
         }
         result

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -1,6 +1,7 @@
 use crate::field::element::FieldElement;
 use crate::field::traits::IsPrimeField;
 use crate::traits::ByteConversion;
+use crate::unsigned_integer::traits::IsUnsignedInteger;
 use crate::{
     field::traits::IsField, unsigned_integer::element::UnsignedInteger,
     unsigned_integer::montgomery::MontgomeryAlgorithms,
@@ -223,6 +224,24 @@ where
 
     fn from_base_type(x: Self::BaseType) -> Self::BaseType {
         MontgomeryAlgorithms::cios(&x, &Self::R2, &M::MODULUS, &Self::MU)
+    }
+
+    fn pow<T>(a: &Self::BaseType, mut exponent: T) -> Self::BaseType
+    where
+        T: IsUnsignedInteger,
+    {
+        let mut result = Self::one();
+        let mut base = a.clone();
+        let zero = T::from(0);
+        let one = T::from(1);
+        while exponent > zero {
+            if exponent & one == one {
+                result = Self::mul(&result, &base);
+            }
+            base = MontgomeryAlgorithms::sos_square(&base, &M::MODULUS, &Self::MU);
+            exponent = exponent >> 1;
+        }
+        result
     }
 }
 

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -1,4 +1,6 @@
 use crate::unsigned_integer::traits::IsUnsignedInteger;
+
+
 use std::{fmt::Debug, hash::Hash};
 
 use super::{element::FieldElement, errors::FieldError};

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -64,23 +64,47 @@ pub trait IsField: Debug + Clone {
     /// Returns the multiplication of `a` and `b`.
     fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType;
 
-    /// Returns`a` raised to the power of `exponent`.
+    /// Returns the multiplication of `a` and `a`.
+    fn square(a: &Self::BaseType) -> Self::BaseType {
+        Self::mul(a, a)
+    }
+
     fn pow<T>(a: &Self::BaseType, mut exponent: T) -> Self::BaseType
     where
         T: IsUnsignedInteger,
     {
-        let mut result = Self::one();
-        let mut base = a.clone();
         let zero = T::from(0);
         let one = T::from(1);
-        while exponent > zero {
-            if exponent & one == one {
-                result = Self::mul(&result, &base);
+
+        if exponent == zero {
+            Self::one()
+        } else if exponent == one {
+            a.clone()
+        } else {
+            let mut result = a.clone();
+
+            while exponent & one == zero {
+                result = Self::square(&result);
+                exponent = exponent >> 1;
             }
-            base = Self::mul(&base, &base);
-            exponent = exponent >> 1;
+
+            if exponent == zero {
+                result
+            } else {
+                let mut base = result.clone();
+                exponent = exponent >> 1;
+
+                while exponent != zero {
+                    base = Self::square(&base);
+                    if exponent & one == one {
+                        result = Self::mul(&result, &base);
+                    }
+                    exponent = exponent >> 1;
+                }
+
+                result
+            }
         }
-        result
     }
 
     /// Returns the subtraction of `a` and `b`.

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -1,6 +1,5 @@
 use crate::unsigned_integer::traits::IsUnsignedInteger;
 
-
 use std::{fmt::Debug, hash::Hash};
 
 use super::{element::FieldElement, errors::FieldError};

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -553,30 +553,23 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         let mut lo = [0u64; NUM_LIMBS];
 
         // Compute products between a[i] and a[j] when i != j.
-        for i in 0..(NUM_LIMBS - 1) {
+        for i in (1..NUM_LIMBS).rev() {
             let mut c: u128 = 0;
-            for j in (i + 1)..NUM_LIMBS {
-                if i != j {
-                    let mut k = i + j;
-                    if k <= NUM_LIMBS - 1 {
-                        let cs = lo[NUM_LIMBS - 1 - k] as u128
-                            + a.limbs[NUM_LIMBS - 1 - i] as u128
-                                * a.limbs[NUM_LIMBS - 1 - j] as u128
-                            + c;
-                        c = cs >> 64;
-                        lo[NUM_LIMBS - 1 - k] = cs as u64;
-                    } else {
-                        k -= NUM_LIMBS;
-                        let cs = hi[NUM_LIMBS - 1 - k] as u128
-                            + a.limbs[NUM_LIMBS - 1 - i] as u128
-                                * a.limbs[NUM_LIMBS - 1 - j] as u128
-                            + c;
-                        c = cs >> 64;
-                        hi[NUM_LIMBS - 1 - k] = cs as u64;
-                    }
+            for j in (0..i).rev() {
+                let k = i + j;
+                if k >= NUM_LIMBS - 1 {
+                    let lo_index = k + 1 - NUM_LIMBS;
+                    let cs = lo[lo_index] as u128 + a.limbs[i] as u128 * a.limbs[j] as u128 + c;
+                    c = cs >> 64;
+                    lo[lo_index] = cs as u64;
+                } else {
+                    let hi_index = k + 1;
+                    let cs = hi[hi_index] as u128 + a.limbs[i] as u128 * a.limbs[j] as u128 + c;
+                    c = cs >> 64;
+                    hi[hi_index] = cs as u64;
                 }
             }
-            hi[NUM_LIMBS - 1 - i] = c as u64;
+            hi[i] = c as u64;
         }
 
         // These terms appear twice each, so we have to multiple by two.

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -546,9 +546,13 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         (Self { limbs: hi }, Self { limbs: lo })
     }
 
+    #[inline(always)]
     pub fn square(
         a: &UnsignedInteger<NUM_LIMBS>,
     ) -> (UnsignedInteger<NUM_LIMBS>, UnsignedInteger<NUM_LIMBS>) {
+        // NOTE: we use explicit `while` loops in this function because profiling pointed
+        // at iterators of the form `(<x>..<y>).rev()` as the main performance bottleneck.
+
         let mut hi = Self {
             limbs: [0u64; NUM_LIMBS],
         };
@@ -559,9 +563,13 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         // Compute products between a[i] and a[j] when i != j.
         // The variable `index` below is the index of `lo` or
         // `hi` to update
-        for i in (1..NUM_LIMBS).rev() {
+        let mut i = NUM_LIMBS;
+        while i > 1 {
+            i -= 1;
             let mut c: u128 = 0;
-            for j in (0..i).rev() {
+            let mut j = i;
+            while j > 0 {
+                j -= 1;
                 let k = i + j;
                 if k >= NUM_LIMBS - 1 {
                     let index = k + 1 - NUM_LIMBS;
@@ -589,7 +597,9 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         // The variable `index` below is the index of `lo` or
         // `hi` to update
         let mut c = 0;
-        for i in (0..NUM_LIMBS).rev() {
+        let mut i = NUM_LIMBS;
+        while i > 0 {
+            i -= 1;
             if NUM_LIMBS - 1 <= i * 2 {
                 let index = 2 * i - NUM_LIMBS + 1;
                 let cs = lo.limbs[index] as u128 + a.limbs[i] as u128 * a.limbs[i] as u128 + c;

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -553,8 +553,8 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         let mut lo = [0u64; NUM_LIMBS];
 
         // Compute products between a[i] and a[j] when i != j.
-        let mut c: u128 = 0;
         for i in 0..(NUM_LIMBS - 1) {
+            let mut c: u128 = 0;
             for j in (i + 1)..NUM_LIMBS {
                 if i != j {
                     let mut k = i + j;
@@ -576,20 +576,16 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
                     }
                 }
             }
+            hi[NUM_LIMBS - 1 - i] = c as u64;
         }
 
-        hi[1] = hi[1] + c as u64;
         // These terms appear twice each, so we have to multiple by two.
         let mut hi = Self { limbs: hi };
         let mut lo = Self { limbs: lo };
-        println!("Solo multiplicación cruzada");
-        println!("{} {}", &hi, &lo);
         let carry = lo.limbs[0] >> 63;
         lo = lo << 1;
         hi = hi << 1;
         hi.limbs[NUM_LIMBS - 1] = hi.limbs[NUM_LIMBS - 1] | carry;
-
-        println!("{} {}", hi, lo);
 
         // The only remaning terms are the squares a[i] * a[i].
         let mut c = 0;
@@ -1509,9 +1505,7 @@ mod tests_u384 {
     fn test_square() {
         let a = U384::from_hex_unchecked("362e35606447fb568704026c25da7a304bc7bd0aea36a61d77d4151395078cfa332b9d4928a60721eece725bbc81e158");
         let (hi, lo) = U384::square(&a);
-        println!("{} {}", &hi, &lo);
         assert_eq!(lo, U384::from_hex_unchecked("11724caeb10c4bce5319097d74aed2246e2942b56b7365b5b2f8ceb3bb847db4828862043299d798577996e210bce40"));
-        //        assert_eq!(hi, U384::from_hex_unchecked("b7786dbe41375b7ff64dbdc65152ef7d3fdbf499485e26486201cdbfb71b5673c77eb355a1274d08cbfbc1a4cdfdfad"));
     }
 
     #[test]
@@ -1590,7 +1584,6 @@ mod tests_u384 {
     fn test_square_7() {
         let a = U384::from_limbs([u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX]);
         let (hi, lo) = U384::square(&a);
-        println!("{} {}", &hi, &lo);
         assert_eq!(lo, U384::from_hex_unchecked("1"));
         assert_eq!(hi, U384::from_hex_unchecked("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"));
     }

--- a/math/src/unsigned_integer/montgomery.rs
+++ b/math/src/unsigned_integer/montgomery.rs
@@ -77,13 +77,12 @@ impl MontgomeryAlgorithms {
 
     // Separated Operand Scanning Method (2.3.1)
     #[inline(always)]
-    pub fn sos<const NUM_LIMBS: usize>(
+    pub fn sos_square<const NUM_LIMBS: usize>(
         a: &UnsignedInteger<NUM_LIMBS>,
-        b: &UnsignedInteger<NUM_LIMBS>,
         q: &UnsignedInteger<NUM_LIMBS>,
         mu: &u64,
     ) -> UnsignedInteger<NUM_LIMBS> {
-        let (mut t_high, mut t_low) = UnsignedInteger::mul(a, b);
+        let (mut t_high, mut t_low) = UnsignedInteger::square(a);
 
         let mut c: u128 = 0;
         for i in 0..NUM_LIMBS {
@@ -161,9 +160,8 @@ mod tests {
     fn sos_mulitplication_works() {
         let x = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc");
         let m = U384::from_hex_unchecked("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
-        let r_mod_m = U384::from_hex_unchecked("58dfb0e1b3dd5e674bdcde4f42eb5533b8759d33");
         let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
         let c = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc");
-        assert_eq!(MontgomeryAlgorithms::sos(&x, &r_mod_m, &m, &mu), c);
+        assert_eq!(MontgomeryAlgorithms::sos_square(&x, &m, &mu), c);
     }
 }

--- a/math/src/unsigned_integer/montgomery.rs
+++ b/math/src/unsigned_integer/montgomery.rs
@@ -116,7 +116,7 @@ impl MontgomeryAlgorithms {
             }
         }
 
-        // Step 3: At this point `overflow * 2^{2 * NUM_LIMBS * 64} + (hi, lo)` is multiple
+        // Step 3: At this point `overflow * 2^{2 * NUM_LIMBS * 64} + (hi, lo)` is a multiple
         // of `2^{NUM_LIMBS * 64}` and the result is obtained by dividing it by `2^{NUM_LIMBS * 64}`.
         // In other words, `lo` is zero and the result is
         // `overflow * 2^{NUM_LIMBS * 64} + hi`.

--- a/math/src/unsigned_integer/montgomery.rs
+++ b/math/src/unsigned_integer/montgomery.rs
@@ -155,13 +155,4 @@ mod tests {
         let c = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc");
         assert_eq!(MontgomeryAlgorithms::cios(&x, &r_mod_m, &m, &mu), c);
     }
-
-    #[test]
-    fn sos_mulitplication_works() {
-        let x = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc");
-        let m = U384::from_hex_unchecked("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
-        let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
-        let c = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc");
-        assert_eq!(MontgomeryAlgorithms::sos_square(&x, &m, &mu), c);
-    }
 }


### PR DESCRIPTION
# Optimize square

## Description
This PR adds an implementation of the SOS square algorithm ( 2.3.1 [here](https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf) ) and incorporates it to the square and multiply algorithm `pow`.

```
Stark FP operations/sos_square                            
                        time:   [9.8666 ns 9.8868 ns 9.9065 ns]
Stark FP operations/square with mul                       
                        time:   [12.203 ns 12.206 ns 12.209 ns]
```

- [x] Optimization
