### PR TITLE
perf: perform reversal of roots of unity in-place

### DIFF
--- a/fft/src/roots_of_unity.rs
+++ b/fft/src/roots_of_unity.rs
@@ -3,7 +3,7 @@ use lambdaworks_math::field::{
     traits::{IsFFTField, RootsConfig},
 };
 
-use crate::{bit_reversing::reverse_index, errors::FFTError};
+use crate::{bit_reversing::in_place_bit_reverse_permute, errors::FFTError};
 
 /// Returns a `Vec` of the powers of a `2^n`th primitive root of unity in some configuration
 /// `config`. For example, in a `Natural` config this would yield: w^0, w^1, w^2...
@@ -38,9 +38,7 @@ pub fn get_powers_of_primitive_root<F: IsFFTField>(
         config,
         RootsConfig::BitReverse | RootsConfig::BitReverseInversed
     ) {
-        let mut reversed = Vec::with_capacity(count);
-        reversed.extend((0..count).map(|i| results[reverse_index(&i, count as u64)].clone()));
-        results = reversed;
+        in_place_bit_reverse_permute(&mut results);
     }
 
     Ok(results)


### PR DESCRIPTION
An oversight of the pre-existent function to sort by reversed bit indices in a previous optimization meant we allocated a new vec instead to do that ad-hoc.
This PR refactors to use that function and avoid the allocation.

## Type of change

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added/run

## Results on M1

```
FFT twiddles generation/bit-reversed                                                                                   
                        time:   [27.865 ms 27.867 ms 27.873 ms]               
                        thrpt:  [37.620 Melem/s 37.628 Melem/s 37.631 Melem/s]
                 change:                                                                                               
                        time:   [-7.1438% -6.1310% -5.4770%] (p = 0.00 < 0.05)
                        thrpt:  [+5.7944% +6.5314% +7.6934%]
FFT twiddles generation/bit-reversed inversed
                        time:   [27.964 ms 27.972 ms 27.987 ms]
                        thrpt:  [37.466 Melem/s 37.487 Melem/s 37.498 Melem/s]
                 change:
                        time:   [-5.5664% -5.0293% -4.4479%] (p = 0.00 < 0.05)
                        thrpt:  [+4.6549% +5.2957% +5.8945%]
```

## Results on x86\_64 server

```
FFT twiddles generation/bit-reversed
                        time:   [26.537 ms 26.557 ms 26.579 ms]
                        thrpt:  [39.452 Melem/s 39.484 Melem/s 39.513 Melem/s]
                 change:
                        time:   [-40.480% -40.397% -40.322%] (p = 0.00 < 0.05)
                        thrpt:  [+67.565% +67.777% +68.010%]
FFT twiddles generation/bit-reversed inversed
                        time:   [26.242 ms 26.247 ms 26.253 ms]
                        thrpt:  [39.941 Melem/s 39.951 Melem/s 39.959 Melem/s]
                 change:
                        time:   [-41.218% -41.191% -41.164%] (p = 0.00 < 0.05)
                        thrpt:  [+69.963% +70.042% +70.121%]
```

I'd attribute the difference to the speed of each system's allocator.
