### PR TITLE
perf: improve accuracy of FFT benches

### DIFF
--- a/fft/benches/functions/mod.rs
+++ b/fft/benches/functions/mod.rs
@@ -1,4 +1,7 @@
-#![allow(dead_code)] // clippy has false positive in benchmarks
+//#![allow(dead_code)] // clippy has false positive in benchmarks
+
+use core::hint::black_box;
+
 use lambdaworks_fft::{
     bit_reversing::in_place_bit_reverse_permute,
     fft_iterative::{in_place_nr_2radix_fft, in_place_rn_2radix_fft},
@@ -10,29 +13,24 @@ use lambdaworks_math::{field::traits::RootsConfig, polynomial::Polynomial};
 
 use crate::util::{F, FE};
 
-pub fn ordered_fft_nr(input: &[FE], twiddles: &[FE]) {
-    let mut input = input.to_vec();
-    in_place_nr_2radix_fft(&mut input, twiddles);
-    in_place_bit_reverse_permute(&mut input);
+pub fn ordered_fft_nr(input: &mut [FE], twiddles: &[FE]) {
+    in_place_nr_2radix_fft(input, twiddles);
 }
 
-pub fn ordered_fft_rn(input: &[FE], twiddles: &[FE]) {
-    let mut input = input.to_vec();
-    in_place_bit_reverse_permute(&mut input);
-    in_place_rn_2radix_fft(&mut input, twiddles);
+pub fn ordered_fft_rn(input: &mut [FE], twiddles: &[FE]) {
+    in_place_rn_2radix_fft(input, twiddles);
 }
 
 pub fn twiddles_generation(order: u64, config: RootsConfig) {
     get_twiddles::<F>(order, config).unwrap();
 }
 
-pub fn bitrev_permute(input: &[FE]) {
-    let mut input = input.to_vec();
-    in_place_bit_reverse_permute(&mut input);
+pub fn bitrev_permute(input: &mut [FE]) {
+    in_place_bit_reverse_permute(input);
 }
 
-pub fn poly_evaluate_fft(poly: &Polynomial<FE>) {
-    poly.evaluate_fft(1, None).unwrap();
+pub fn poly_evaluate_fft(poly: &Polynomial<FE>) -> Vec<FE> {
+    poly.evaluate_fft(black_box(1), black_box(None)).unwrap()
 }
 pub fn poly_interpolate_fft(evals: &[FE]) {
     Polynomial::interpolate_fft(evals).unwrap();

--- a/fft/benches/iai_fft.rs
+++ b/fft/benches/iai_fft.rs
@@ -1,6 +1,5 @@
-#![allow(dead_code)] // clippy has false positive in benchmarks
-use iai_callgrind::black_box;
-use lambdaworks_fft::roots_of_unity::get_twiddles;
+//#![allow(dead_code)] // clippy has false positive in benchmarks
+use core::hint::black_box;
 use lambdaworks_math::field::traits::RootsConfig;
 
 mod functions;
@@ -9,45 +8,57 @@ mod util;
 const SIZE_ORDER: u64 = 10;
 
 #[inline(never)]
-fn seq_fft_benchmarks() {
-    let input = util::rand_field_elements(SIZE_ORDER);
-    let twiddles_bitrev = get_twiddles(SIZE_ORDER, RootsConfig::BitReverse).unwrap();
-    let twiddles_nat = get_twiddles(SIZE_ORDER, RootsConfig::Natural).unwrap();
+fn seq_fft_benchmarks_rn() {
+    let mut input = util::rand_field_elements(SIZE_ORDER);
+    let twiddles_nat = util::twiddles(SIZE_ORDER, RootsConfig::Natural);
 
-    functions::ordered_fft_nr(black_box(&input), black_box(&twiddles_bitrev));
-    functions::ordered_fft_rn(black_box(&input), black_box(&twiddles_nat));
+    functions::ordered_fft_rn(black_box(&mut input), black_box(&twiddles_nat));
+}
+
+#[inline(never)]
+fn seq_fft_benchmarks_nr() {
+    let mut input = util::rand_field_elements(SIZE_ORDER);
+    let twiddles_bitrev = util::twiddles(SIZE_ORDER, RootsConfig::BitReverse);
+
+    functions::ordered_fft_nr(black_box(&mut input), black_box(&twiddles_bitrev));
 }
 
 #[inline(never)]
 fn seq_twiddles_generation_natural_benchmarks() {
-    functions::twiddles_generation(black_box(SIZE_ORDER), RootsConfig::Natural);
+    functions::twiddles_generation(black_box(SIZE_ORDER), black_box(RootsConfig::Natural));
 }
 
 #[inline(never)]
 fn seq_twiddles_generation_natural_inversed_benchmarks() {
-    functions::twiddles_generation(black_box(SIZE_ORDER), RootsConfig::NaturalInversed);
+    functions::twiddles_generation(
+        black_box(SIZE_ORDER),
+        black_box(RootsConfig::NaturalInversed),
+    );
 }
 
 #[inline(never)]
 fn seq_twiddles_generation_bitrev_benchmarks() {
-    functions::twiddles_generation(black_box(SIZE_ORDER), RootsConfig::BitReverse);
+    functions::twiddles_generation(black_box(SIZE_ORDER), black_box(RootsConfig::BitReverse));
 }
 
 #[inline(never)]
 fn seq_twiddles_generation_bitrev_inversed_benchmarks() {
-    functions::twiddles_generation(black_box(SIZE_ORDER), RootsConfig::BitReverseInversed);
+    functions::twiddles_generation(
+        black_box(SIZE_ORDER),
+        black_box(RootsConfig::BitReverseInversed),
+    );
 }
 
 #[inline(never)]
 fn seq_bitrev_permutation_benchmarks() {
-    let input = util::rand_field_elements(SIZE_ORDER);
-    functions::bitrev_permute(black_box(&input));
+    let mut input = util::rand_field_elements(SIZE_ORDER);
+    functions::bitrev_permute(black_box(&mut input));
 }
 
 #[inline(never)]
 fn seq_poly_evaluation_benchmarks() {
     let poly = util::rand_poly(SIZE_ORDER);
-    functions::poly_evaluate_fft(black_box(&poly));
+    let _ = black_box(functions::poly_evaluate_fft(black_box(&poly)));
 }
 
 #[inline(never)]
@@ -59,7 +70,8 @@ fn seq_poly_interpolation_benchmarks() {
 #[cfg(not(any(feature = "metal", feature = "cuda")))]
 iai_callgrind::main!(
     callgrind_args = "toggle-collect=util::*";
-    functions = seq_fft_benchmarks,
+    functions = seq_fft_benchmarks_nr,
+    seq_fft_benchmarks_rn,
     seq_twiddles_generation_natural_benchmarks,
     seq_twiddles_generation_natural_inversed_benchmarks,
     seq_twiddles_generation_bitrev_benchmarks,
@@ -72,7 +84,8 @@ iai_callgrind::main!(
 #[cfg(any(feature = "metal", feature = "cuda"))]
 iai_callgrind::main!(
     callgrind_args = "toggle-collect=util::*";
-    functions = seq_fft_benchmarks,
+    functions = seq_fft_benchmarks_nr,
+    seq_fft_benchmarks_rn,
     seq_twiddles_generation_natural_benchmarks,
     seq_twiddles_generation_natural_inversed_benchmarks,
     seq_twiddles_generation_bitrev_benchmarks,

--- a/fft/benches/util.rs
+++ b/fft/benches/util.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)] // clippy has false positive in benchmarks
+use lambdaworks_fft::bit_reversing::in_place_bit_reverse_permute;
 use lambdaworks_math::{
     field::{
         element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
+        traits::RootsConfig,
     },
     polynomial::Polynomial,
     unsigned_integer::element::UnsignedInteger,
@@ -11,6 +13,17 @@ use rand::random;
 pub type F = Stark252PrimeField;
 pub type FE = FieldElement<F>;
 
+// NOTE: intentional duplicate to help IAI skip setup code
+#[inline(never)]
+#[no_mangle]
+#[export_name = "util::bitrev_permute"]
+pub fn bitrev_permute(input: &mut [FE]) {
+    in_place_bit_reverse_permute(input);
+}
+
+#[inline(never)]
+#[no_mangle]
+#[export_name = "util::rand_field_elements"]
 pub fn rand_field_elements(order: u64) -> Vec<FE> {
     let mut result = Vec::with_capacity(1 << order);
     for _ in 0..result.capacity() {
@@ -20,6 +33,16 @@ pub fn rand_field_elements(order: u64) -> Vec<FE> {
     result
 }
 
+#[inline(never)]
+#[no_mangle]
+#[export_name = "util::rand_poly"]
 pub fn rand_poly(order: u64) -> Polynomial<FE> {
     Polynomial::new(&rand_field_elements(order))
+}
+
+#[inline(never)]
+#[no_mangle]
+#[export_name = "util::get_twiddles"]
+pub fn twiddles(order: u64, config: RootsConfig) -> Vec<FE> {
+    lambdaworks_fft::roots_of_unity::get_twiddles(order, config).unwrap()
 }


### PR DESCRIPTION
- Use `iter_batched` rather than cloning input inside the benchmarked
  functions
- Properly fix symbol names and exclude from inlining the helper
  functions to help IAI exclude them from the measurement
- Exclude bit reversal from ordered FFT benchmarks, as that's measured
  separately

## Type of change

- [x] Bug fix
