### PR TITLE
perf: improve accuracy of field IAI benchmarks

### DIFF
--- a/math/benches/criterion_field.rs
+++ b/math/benches/criterion_field.rs
@@ -1,21 +1,10 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use lambdaworks_math::field::{
-    element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
-};
 
 mod util;
 
 pub fn starkfield_ops_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Stark FP operations");
-
-    let x = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
-    )
-    .unwrap();
-    let y = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x0208a0a10250e382e1e4bbe2880906c2791bf6275695e02fbbc6aeff9cd8b31a",
-    )
-    .unwrap();
+    let (x, y) = util::get_field_elements();
 
     group.bench_with_input("add", &(x.clone(), y.clone()), |bench, (x, y)| {
         bench.iter(|| x + y);

--- a/math/benches/iai_field.rs
+++ b/math/benches/iai_field.rs
@@ -1,105 +1,54 @@
 use criterion::black_box;
-use lambdaworks_math::field::{
-    element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
-};
 
 mod util;
 
 #[inline(never)]
 fn fp_add_benchmarks() {
-    let x = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
-    )
-    .unwrap();
-    let y = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x0208a0a10250e382e1e4bbe2880906c2791bf6275695e02fbbc6aeff9cd8b31a",
-    )
-    .unwrap();
-    let _ = black_box(x) + black_box(y);
+    let (x, y) = util::get_field_elements();
+    let _ = black_box(black_box(x) + black_box(y));
 }
 
 #[inline(never)]
 fn fp_mul_benchmarks() {
-    let x = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
-    )
-    .unwrap();
-    let y = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x0208a0a10250e382e1e4bbe2880906c2791bf6275695e02fbbc6aeff9cd8b31a",
-    )
-    .unwrap();
-
-    let _ = black_box(x) * black_box(y);
+    let (x, y) = util::get_field_elements();
+    let _ = black_box(black_box(x) * black_box(y));
 }
 
 #[inline(never)]
 fn fp_pow_benchmarks() {
-    let x = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
-    )
-    .unwrap();
-
+    let (x, _) = util::get_field_elements();
     let y: u64 = 5;
-    let _ = black_box(x).pow(black_box(y));
+    let _ = black_box(black_box(x).pow(black_box(y)));
 }
 
 #[inline(never)]
 fn fp_sub_benchmarks() {
-    let x = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
-    )
-    .unwrap();
-    let y = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x0208a0a10250e382e1e4bbe2880906c2791bf6275695e02fbbc6aeff9cd8b31a",
-    )
-    .unwrap();
-    let _ = black_box(x) - black_box(y);
+    let (x, y) = util::get_field_elements();
+    let _ = black_box(black_box(x) - black_box(y));
 }
 
 #[inline(never)]
 fn fp_inv_benchmarks() {
-    let x = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
-    )
-    .unwrap();
-
-    let _ = black_box(x).inv();
+    let (x, _) = util::get_field_elements();
+    let _ = black_box(black_box(x).inv());
 }
 
 #[inline(never)]
 fn fp_div_benchmarks() {
-    let x = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
-    )
-    .unwrap();
-    let y = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x0208a0a10250e382e1e4bbe2880906c2791bf6275695e02fbbc6aeff9cd8b31a",
-    )
-    .unwrap();
-    let _ = black_box(x) / black_box(y);
+    let (x, y) = util::get_field_elements();
+    let _ = black_box(black_box(x) / black_box(y));
 }
 
 #[inline(never)]
 fn fp_eq_benchmarks() {
-    let x = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
-    )
-    .unwrap();
-    let y = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x0208a0a10250e382e1e4bbe2880906c2791bf6275695e02fbbc6aeff9cd8b31a",
-    )
-    .unwrap();
-    let _ = black_box(x) == black_box(y);
+    let (x, y) = util::get_field_elements();
+    let _ = black_box(black_box(x) == black_box(y));
 }
 
 #[inline(never)]
 fn fp_sqrt_benchmarks() {
-    let x = FieldElement::<Stark252PrimeField>::from_hex(
-        "0x03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
-    )
-    .unwrap();
     // Make sure it has a square root
-    let x = &x * &x;
+    let x = util::get_squared_field_element();
     let _ = black_box(black_box(x).sqrt());
 }
 

--- a/math/benches/util.rs
+++ b/math/benches/util.rs
@@ -1,5 +1,11 @@
 use const_random::const_random;
-use lambdaworks_math::{field::fields::u64_prime_field::U64FieldElement, polynomial::Polynomial};
+use lambdaworks_math::{
+    field::element::FieldElement,
+    field::fields::{
+        fft_friendly::stark_252_prime_field::Stark252PrimeField, u64_prime_field::U64FieldElement,
+    },
+    polynomial::Polynomial,
+};
 use rand::random;
 
 // Mersenne prime numbers
@@ -12,6 +18,30 @@ const PRIMES: [u64; 39] = [
 
 const MODULUS: u64 = PRIMES[const_random!(usize) % PRIMES.len()];
 pub type FE = U64FieldElement<MODULUS>;
+
+#[inline(never)]
+#[export_name = "util::fp_get_primes"]
+pub fn get_field_elements() -> (
+    FieldElement<Stark252PrimeField>,
+    FieldElement<Stark252PrimeField>,
+) {
+    let x = FieldElement::<Stark252PrimeField>::from_hex(
+        "0x03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
+    )
+    .unwrap();
+    let y = FieldElement::<Stark252PrimeField>::from_hex(
+        "0x0208a0a10250e382e1e4bbe2880906c2791bf6275695e02fbbc6aeff9cd8b31a",
+    )
+    .unwrap();
+    (x, y)
+}
+
+#[inline(never)]
+#[export_name = "util::fp_squared_prime"]
+pub fn get_squared_field_element() -> FieldElement<Stark252PrimeField> {
+    let (x, _) = get_field_elements();
+    &x * &x
+}
 
 #[allow(dead_code)]
 pub fn rand_field_elements(order: u64) -> Vec<FE> {


### PR DESCRIPTION
- Extract FP element sample creation into a `util` function to allow
  exclusion from measurement.
- Likewise for getting a quadratic residue by squaring the sample.
- Replace the appropriate call in IAI and Criterion benches.

## Type of change

- [x] Bug fix
