### PR TITLE
perf: keep a running power for scale

### DIFF
--- a/math/src/polynomial.rs
+++ b/math/src/polynomial.rs
@@ -196,8 +196,10 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
         let scaled_coefficients = self
             .coefficients
             .iter()
-            .enumerate()
-            .map(|(i, coeff)| factor.pow(i) * coeff)
+            .zip(core::iter::successors(Some(FieldElement::one()), |x| {
+                Some(x * factor)
+            }))
+            .map(|(coeff, power)| power * coeff)
             .collect();
         Self {
             coefficients: scaled_coefficients,


### PR DESCRIPTION
Weaken power in iterator into products.

## Type of change

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added/run

## Results on M1

Specs:
```
Apple MacBook Pro M1 2020 16GB
```

```
Polynomial/evaluate     time:   [121.75 ns 123.35 ns 125.24 ns]                                                                                                                                                                        [4/541]
                        change: [-89.674% -89.594% -89.493%] (p = 0.00 < 0.05)
Polynomial/evaluate_slice                                  
                        time:   [2.0378 µs 2.0502 µs 2.0624 µs]
                        change: [-98.821% -98.815% -98.809%] (p = 0.00 < 0.05)
Polynomial/add          time:   [180.87 ns 181.32 ns 181.72 ns]
                        change: [-75.843% -75.756% -75.673%] (p = 0.00 < 0.05)
Polynomial/neg          time:   [102.74 ns 103.08 ns 103.47 ns]
                        change: [-69.216% -69.072% -68.928%] (p = 0.00 < 0.05)
Polynomial/sub          time:   [283.17 ns 283.85 ns 284.56 ns]
                        change: [-73.920% -73.790% -73.675%] (p = 0.00 < 0.05)
Polynomial/mul          time:   [1.5728 µs 1.5797 µs 1.5867 µs]
                        change: [-98.711% -98.707% -98.703%] (p = 0.00 < 0.05)
Polynomial/div          time:   [647.02 ns 650.00 ns 654.31 ns]
                        change: [-73.451% -73.281% -73.072%] (p = 0.00 < 0.05)
```

## Results on Intel server

Specs:
```
Model name:            AMD Ryzen 9 5950X 16-Core Processor
  CPU family:          25
  Model:               33
  Thread(s) per core:  2
  Core(s) per socket:  16   
  Socket(s):           1
  Stepping:            0                     
  Frequency boost:     enabled               
  CPU(s) scaling MHz:  51%                 
  CPU max MHz:         5083.3979           
  CPU min MHz:         2200.0000

RAM 128GB
```

```
Polynomial/evaluate     time:   [16.188 ns 16.190 ns 16.193 ns]
                        change: [-90.685% -90.678% -90.669%] (p = 0.00 < 0.05)
Polynomial/evaluate_slice                                  
                        time:   [67.644 ns 68.675 ns 69.548 ns]
                        change: [-98.882% -98.867% -98.852%] (p = 0.00 < 0.05)
Polynomial/add          time:   [50.446 ns 50.487 ns 50.534 ns]
                        change: [-78.564% -78.535% -78.506%] (p = 0.00 < 0.05)
Polynomial/neg          time:   [23.940 ns 23.952 ns 23.970 ns]
                        change: [-80.519% -80.486% -80.455%] (p = 0.00 < 0.05)
Polynomial/sub          time:   [75.671 ns 75.723 ns 75.783 ns]
                        change: [-76.584% -76.557% -76.530%] (p = 0.00 < 0.05)
Polynomial/mul          time:   [110.71 ns 110.77 ns 110.85 ns]
                        change: [-97.429% -97.427% -97.425%] (p = 0.00 < 0.05)
Polynomial/div          time:   [209.08 ns 209.35 ns 209.68 ns]
                        change: [-80.832% -78.242% -76.638%] (p = 0.00 < 0.05)
```
