### PR TITLE
chore: uncomment code for metal

### DIFF
--- a/fft/benches/iai_fft.rs
+++ b/fft/benches/iai_fft.rs
@@ -1,4 +1,4 @@
-//#![allow(dead_code)] // clippy has false positive in benchmarks
+#![allow(dead_code)] // clippy has false positive in benchmarks
 use core::hint::black_box;
 use lambdaworks_math::field::traits::RootsConfig;
 


### PR DESCRIPTION
Leftover commented lint that was actually needed for some configs.

## Type of change

- [x] Cleanup
