### PR TITLE
perf/merkle inplace

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,5 +15,17 @@ thiserror = "1.0.38"
 [dependencies.rand]
 version = "0.8"
 
+[dev-dependencies]
+criterion = "0.4"
+iai-callgrind.workspace = true
+
 [features]
 test_fiat_shamir = []
+
+[[bench]]
+name = "criterion_merkle"
+harness = false
+
+[[bench]]
+name = "iai_merkle"
+harness = false

--- a/crypto/benches/criterion_merkle.rs
+++ b/crypto/benches/criterion_merkle.rs
@@ -1,0 +1,35 @@
+use core::hint::black_box;
+use core::time::Duration;
+use criterion::{criterion_group, criterion_main, Criterion};
+use lambdaworks_crypto::{
+    merkle_tree::merkle::MerkleTree,
+    hash::sha3::Sha3Hasher,
+};
+use lambdaworks_math::{
+    field::element::FieldElement,
+    field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
+};
+
+type FE = FieldElement<Stark252PrimeField>;
+
+fn merkle_tree_benchmarks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Merkle Tree");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(30));
+
+    // NOTE: the values to hash don't really matter, so let's go with the easy ones.
+    let unhashed_leaves: Vec<_> = core::iter::successors(Some(FE::zero()), |s| Some(s + FE::one()))
+        // `(1 << 20) + 1` exploits worst cases in terms of rounding up to powers of 2.
+        .take((1 << 20) + 1)
+        .collect();
+
+    group.bench_with_input("build", unhashed_leaves.as_slice(), |bench, unhashed_leaves| {
+        bench.iter_with_large_drop(|| {
+            let hasher = Box::new(Sha3Hasher::new());
+            MerkleTree::build(unhashed_leaves, black_box(hasher))
+        });
+    });
+}
+
+criterion_group!(merkle_tree, merkle_tree_benchmarks);
+criterion_main!(merkle_tree);

--- a/crypto/benches/criterion_merkle.rs
+++ b/crypto/benches/criterion_merkle.rs
@@ -19,10 +19,8 @@ fn merkle_tree_benchmarks(c: &mut Criterion) {
 
     // NOTE: the values to hash don't really matter, so let's go with the easy ones.
     let unhashed_leaves: Vec<_> = core::iter::successors(Some(FE::zero()), |s| Some(s + FE::one()))
-        // `(1 << 10) + 1` exploits worst cases in terms of rounding up to powers of 2.
-        // Typical size should really be about `1 << 20`, but it currently takes too long
-        // to make a single iteration with such numbers.
-        .take((1 << 10) + 1)
+        // `(1 << 20) + 1` exploits worst cases in terms of rounding up to powers of 2.
+        .take((1 << 20) + 1)
         .collect();
 
     group.bench_with_input("build", unhashed_leaves.as_slice(), |bench, unhashed_leaves| {

--- a/crypto/benches/criterion_merkle.rs
+++ b/crypto/benches/criterion_merkle.rs
@@ -1,10 +1,7 @@
 use core::hint::black_box;
 use core::time::Duration;
 use criterion::{criterion_group, criterion_main, Criterion};
-use lambdaworks_crypto::{
-    merkle_tree::merkle::MerkleTree,
-    hash::sha3::Sha3Hasher,
-};
+use lambdaworks_crypto::{hash::sha3::Sha3Hasher, merkle_tree::merkle::MerkleTree};
 use lambdaworks_math::{
     field::element::FieldElement,
     field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
@@ -23,12 +20,16 @@ fn merkle_tree_benchmarks(c: &mut Criterion) {
         .take((1 << 20) + 1)
         .collect();
 
-    group.bench_with_input("build", unhashed_leaves.as_slice(), |bench, unhashed_leaves| {
-        bench.iter_with_large_drop(|| {
-            let hasher = Box::new(Sha3Hasher::new());
-            MerkleTree::build(unhashed_leaves, black_box(hasher))
-        });
-    });
+    group.bench_with_input(
+        "build",
+        unhashed_leaves.as_slice(),
+        |bench, unhashed_leaves| {
+            bench.iter_with_large_drop(|| {
+                let hasher = Box::new(Sha3Hasher::new());
+                MerkleTree::build(unhashed_leaves, black_box(hasher))
+            });
+        },
+    );
 }
 
 criterion_group!(merkle_tree, merkle_tree_benchmarks);

--- a/crypto/benches/criterion_merkle.rs
+++ b/crypto/benches/criterion_merkle.rs
@@ -19,8 +19,10 @@ fn merkle_tree_benchmarks(c: &mut Criterion) {
 
     // NOTE: the values to hash don't really matter, so let's go with the easy ones.
     let unhashed_leaves: Vec<_> = core::iter::successors(Some(FE::zero()), |s| Some(s + FE::one()))
-        // `(1 << 20) + 1` exploits worst cases in terms of rounding up to powers of 2.
-        .take((1 << 20) + 1)
+        // `(1 << 10) + 1` exploits worst cases in terms of rounding up to powers of 2.
+        // Typical size should really be about `1 << 20`, but it currently takes too long
+        // to make a single iteration with such numbers.
+        .take((1 << 10) + 1)
         .collect();
 
     group.bench_with_input("build", unhashed_leaves.as_slice(), |bench, unhashed_leaves| {

--- a/crypto/benches/iai_merkle.rs
+++ b/crypto/benches/iai_merkle.rs
@@ -1,0 +1,42 @@
+use core::hint::black_box;
+use lambdaworks_crypto::{
+    merkle_tree::merkle::MerkleTree,
+    hash::sha3::Sha3Hasher,
+};
+use lambdaworks_math::{
+    field::element::FieldElement,
+    field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
+};
+
+type FE = FieldElement<Stark252PrimeField>;
+
+#[inline(never)]
+#[export_name = "util::build_unhashed_leaves"]
+fn build_unhashed_leaves() -> Vec<FE> {
+    // NOTE: the values to hash don't really matter, so let's go with the easy ones.
+    core::iter::successors(Some(FE::zero()), |s| Some(s + FE::one()))
+        // `(1 << 20) + 1` exploits worst cases in terms of rounding up to powers of 2.
+        .take((1 << 20) + 1)
+        .collect()
+}
+
+
+#[inline(never)]
+#[export_name = "util::build_hasher"]
+fn build_hasher() -> Box<Sha3Hasher> {
+    Box::new(Sha3Hasher::new())
+}
+
+#[inline(never)]
+fn merkle_tree_build_benchmark() {
+    let unhashed_leaves = build_unhashed_leaves();
+    let hasher = build_hasher();
+    let result = black_box(MerkleTree::build(black_box(&unhashed_leaves), black_box(hasher)));
+    // Let's not count `drop` in our timings.
+    core::mem::drop(result);
+}
+
+iai_callgrind::main!(
+    callgrind_args = "toggle-collect=util::*,core::mem::drop";
+    functions = merkle_tree_build_benchmark,
+);

--- a/crypto/benches/iai_merkle.rs
+++ b/crypto/benches/iai_merkle.rs
@@ -1,8 +1,5 @@
 use core::hint::black_box;
-use lambdaworks_crypto::{
-    merkle_tree::merkle::MerkleTree,
-    hash::sha3::Sha3Hasher,
-};
+use lambdaworks_crypto::{hash::sha3::Sha3Hasher, merkle_tree::merkle::MerkleTree};
 use lambdaworks_math::{
     field::element::FieldElement,
     field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
@@ -20,7 +17,6 @@ fn build_unhashed_leaves() -> Vec<FE> {
         .collect()
 }
 
-
 #[inline(never)]
 #[export_name = "util::build_hasher"]
 fn build_hasher() -> Box<Sha3Hasher> {
@@ -31,7 +27,10 @@ fn build_hasher() -> Box<Sha3Hasher> {
 fn merkle_tree_build_benchmark() {
     let unhashed_leaves = build_unhashed_leaves();
     let hasher = build_hasher();
-    let result = black_box(MerkleTree::build(black_box(&unhashed_leaves), black_box(hasher)));
+    let result = black_box(MerkleTree::build(
+        black_box(&unhashed_leaves),
+        black_box(hasher),
+    ));
     // Let's not count `drop` in our timings.
     core::mem::drop(result);
 }

--- a/crypto/benches/iai_merkle.rs
+++ b/crypto/benches/iai_merkle.rs
@@ -15,10 +15,8 @@ type FE = FieldElement<Stark252PrimeField>;
 fn build_unhashed_leaves() -> Vec<FE> {
     // NOTE: the values to hash don't really matter, so let's go with the easy ones.
     core::iter::successors(Some(FE::zero()), |s| Some(s + FE::one()))
-        // `(1 << 10) + 1` exploits worst cases in terms of rounding up to powers of 2.
-        // Typical size should really be about `1 << 20`, but it currently takes too long
-        // to make a single iteration with such numbers.
-        .take((1 << 10) + 1)
+        // `(1 << 20) + 1` exploits worst cases in terms of rounding up to powers of 2.
+        .take((1 << 20) + 1)
         .collect()
 }
 

--- a/crypto/benches/iai_merkle.rs
+++ b/crypto/benches/iai_merkle.rs
@@ -15,8 +15,10 @@ type FE = FieldElement<Stark252PrimeField>;
 fn build_unhashed_leaves() -> Vec<FE> {
     // NOTE: the values to hash don't really matter, so let's go with the easy ones.
     core::iter::successors(Some(FE::zero()), |s| Some(s + FE::one()))
-        // `(1 << 20) + 1` exploits worst cases in terms of rounding up to powers of 2.
-        .take((1 << 20) + 1)
+        // `(1 << 10) + 1` exploits worst cases in terms of rounding up to powers of 2.
+        // Typical size should really be about `1 << 20`, but it currently takes too long
+        // to make a single iteration with such numbers.
+        .take((1 << 10) + 1)
         .collect()
 }
 

--- a/crypto/src/merkle_tree/merkle.rs
+++ b/crypto/src/merkle_tree/merkle.rs
@@ -32,11 +32,11 @@ impl<F: IsField> MerkleTree<F> {
         inner_nodes.extend(hashed_leaves);
 
         //Build the inner nodes of the tree
-        let nodes = build(&mut inner_nodes, ROOT, hasher.as_ref());
+        build(&mut inner_nodes, ROOT, hasher.as_ref());
 
         MerkleTree {
-            root: nodes[ROOT].clone(),
-            nodes,
+            root: inner_nodes[ROOT].clone(),
+            nodes: inner_nodes,
         }
     }
 

--- a/crypto/src/merkle_tree/utils.rs
+++ b/crypto/src/merkle_tree/utils.rs
@@ -49,8 +49,7 @@ pub fn build<F: IsField>(
     nodes: &mut Vec<FieldElement<F>>,
     parent_index: usize,
     hasher: &dyn IsCryptoHash<F>,
-)
-where
+) where
     FieldElement<F>: ByteConversion,
 {
     if is_leaf(nodes.len(), parent_index) {

--- a/crypto/src/merkle_tree/utils.rs
+++ b/crypto/src/merkle_tree/utils.rs
@@ -49,22 +49,21 @@ pub fn build<F: IsField>(
     nodes: &mut Vec<FieldElement<F>>,
     parent_index: usize,
     hasher: &dyn IsCryptoHash<F>,
-) -> Vec<FieldElement<F>>
+)
 where
     FieldElement<F>: ByteConversion,
 {
     if is_leaf(nodes.len(), parent_index) {
-        return nodes.to_vec();
+        return;
     }
 
     let left_child_index = left_child_index(parent_index);
     let right_child_index = right_child_index(parent_index);
 
-    let mut nodes = build(nodes, left_child_index, hasher);
-    nodes = build(&mut nodes, right_child_index, hasher);
+    build(nodes, left_child_index, hasher);
+    build(nodes, right_child_index, hasher);
 
     nodes[parent_index] = hasher.hash_two(&nodes[left_child_index], &nodes[right_child_index]);
-    nodes
 }
 
 pub fn is_leaf(lenght: usize, node_index: usize) -> bool {
@@ -126,7 +125,7 @@ mod tests {
         let mut nodes = vec![FE::zero(); leaves.len() - 1];
         nodes.extend(leaves);
 
-        let tree = build(&mut nodes, ROOT, &TestHasher);
-        assert_eq!(tree[ROOT], FE::new(10));
+        build(&mut nodes, ROOT, &TestHasher);
+        assert_eq!(nodes[ROOT], FE::new(10));
     }
 }


### PR DESCRIPTION
- perf: add benchmark for merkle tree construction
- perf: lower number of elements for merkle bench
- perf: remove allocations in recursive merkle build step
- perf: bump sample size again, as now it can finish

## Type of change

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added

## Results

Before: couldn't finish the warmup with 1M elements.
After:
```
Benchmarking Merkle Tree/build: Warming up for 3.0000 s
Merkle Tree/build       time:   [1.0337 s 1.0367 s 1.0381 s]
```
