### PR TITLE
perf: implement Ruffini rule division for 'x - b' monomials

### DIFF
--- a/math/benches/criterion_polynomial.rs
+++ b/math/benches/criterion_polynomial.rs
@@ -1,6 +1,7 @@
 use const_random::const_random;
 use core::hint::black_box;
 use criterion::{criterion_group, criterion_main, Criterion};
+use lambdaworks_math::polynomial::Polynomial;
 use util::{rand_field_elements, rand_poly, FE};
 
 mod util;
@@ -50,6 +51,29 @@ pub fn polynomial_benchmarks(c: &mut Criterion) {
         bench.iter_batched(
             || (x_poly.clone(), y_poly.clone()),
             |(x_poly, y_poly)| black_box(x_poly) / black_box(y_poly),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("div by 'x - b' with generic div", |bench| {
+        let poly = rand_poly(order);
+        let m = Polynomial::new_monomial(FE::one(), 1) - rand_field_elements(1)[0];
+        bench.iter_batched(
+            || (poly.clone(), m.clone()),
+            |(poly, m)| poly / m,
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("div by 'x - b' with Ruffini", |bench| {
+        let poly = rand_poly(order);
+        let b = rand_field_elements(1)[0];
+        bench.iter_batched(
+            || (poly.clone(), b),
+            |(mut poly, b)| {
+                poly.ruffini_division_inplace(&b);
+                poly
+            },
             criterion::BatchSize::SmallInput,
         );
     });

--- a/math/benches/iai_polynomial.rs
+++ b/math/benches/iai_polynomial.rs
@@ -54,6 +54,14 @@ fn poly_div_benchmarks() {
     let _ = black_box(black_box(x_poly) / black_box(y_poly));
 }
 
+#[inline(never)]
+fn poly_div_ruffini_benchmarks() {
+    let mut x_poly = util::rand_poly(ORDER);
+    let b = util::rand_field_elements(1)[0];
+    black_box(&mut x_poly).ruffini_division_inplace(black_box(&b));
+    let _ = black_box(x_poly);
+}
+
 iai_callgrind::main!(
     callgrind_args = "toggle-collect=util::*";
     functions = poly_evaluate_benchmarks,
@@ -62,5 +70,6 @@ iai_callgrind::main!(
     poly_neg_benchmarks,
     poly_sub_benchmarks,
     poly_mul_benchmarks,
-    poly_div_benchmarks
+    poly_div_benchmarks,
+    poly_div_ruffini_benchmarks,
 );


### PR DESCRIPTION
Use a special-cased division for `P / (x - b)`. It's 20x faster than running the regular
division for this hotspot in provers.
Added property testings to ensure it's equivalent to the regular division.

## Type of change

- [x] New feature
- [x] Optimization

## Checklist
- [x] Unit tests added
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
- [x] This change is an Optimization
  - [x] Benchmarks added/run

## Results on M1

```
Polynomial/div by 'x - b' with generic div
                        time:   [810.69 ns 821.65 ns 835.76 ns]
Polynomial/div by 'x - b' with Ruffini
                        time:   [21.992 ns 22.257 ns 22.496 ns]
```
