### PR TITLE
perf: flip `if` condition in `MontgomeryBackendPrimeField::add`

### DIFF
--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -100,10 +100,10 @@ where
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         let (sum, overflow) = UnsignedInteger::add(a, b);
         if !overflow {
-            if sum < M::MODULUS {
-                sum
-            } else {
+            if sum >= M::MODULUS {
                 sum - M::MODULUS
+            } else {
+                sum
             }
         } else {
             let (diff, _) = UnsignedInteger::sub(&sum, &M::MODULUS);


### PR DESCRIPTION
## Description

While looking for bottlenecks in cairo-rs, I found that a lot of time is spent in `PartialOrd::lt` when comparing `UnsignedIntegers` in this `if`. Don't really know _why_, but this little trick gives ~14% increase in performance.

```
Stark FP operations/add time:   [3.2460 ns 3.2553 ns 3.2658 ns]                                     
                        change: [-14.961% -14.702% -14.388%] (p = 0.00 < 0.05)
                        Performance has improved.
Stark FP operations/mul time:   [12.032 ns 12.044 ns 12.056 ns]                                     
                        change: [-0.4833% -0.2105% +0.0573%] (p = 0.13 > 0.05)
                        No change in performance detected.
Stark FP operations/pow by 1                                                                             
                        time:   [1.5932 ns 1.5943 ns 1.5954 ns]
                        change: [+0.7118% +0.9644% +1.2187%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Stark FP operations/sos_square                                                                             
                        time:   [10.843 ns 10.868 ns 10.892 ns]
                        change: [-0.3470% -0.0206% +0.2849%] (p = 0.90 > 0.05)
                        No change in performance detected.
Stark FP operations/square                                                                             
                        time:   [5.2299 ns 5.2349 ns 5.2400 ns]
                        change: [-0.3623% -0.1059% +0.1309%] (p = 0.42 > 0.05)
                        No change in performance detected.
Stark FP operations/square with pow                                                                             
                        time:   [12.269 ns 12.297 ns 12.321 ns]
                        change: [+0.2789% +0.5664% +0.8488%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Stark FP operations/square with mul                                                                             
                        time:   [12.099 ns 12.122 ns 12.146 ns]
                        change: [+0.0634% +0.3496% +0.6359%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Stark FP operations/pow time:   [37.498 ns 37.540 ns 37.585 ns]                                     
                        change: [-0.4848% -0.1943% +0.1080%] (p = 0.19 > 0.05)
                        No change in performance detected.
Stark FP operations/sub time:   [2.7896 ns 2.7955 ns 2.8014 ns]                                     
                        change: [-0.4070% -0.0823% +0.2186%] (p = 0.60 > 0.05)
                        No change in performance detected.
Stark FP operations/inv time:   [1.7539 µs 1.7580 µs 1.7622 µs]                                     
                        change: [-0.6393% -0.3577% -0.0594%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Stark FP operations/div time:   [1.7647 µs 1.7687 µs 1.7726 µs]                                     
                        change: [-0.1352% +0.1923% +0.5116%] (p = 0.24 > 0.05)
                        No change in performance detected.
Stark FP operations/eq  time:   [314.84 ps 315.49 ps 316.18 ps]                                   
                        change: [-0.4092% -0.0766% +0.2480%] (p = 0.65 > 0.05)
                        No change in performance detected.
Stark FP operations/sqrt                                                                             
                        time:   [3.0650 µs 3.0688 µs 3.0730 µs]
                        change: [-0.0470% +0.2590% +0.6298%] (p = 0.12 > 0.05)
                        No change in performance detected.
Stark FP operations/sqrt squared                                                                            
                        time:   [142.12 µs 142.26 µs 142.41 µs]
                        change: [-0.2599% +0.0019% +0.2614%] (p = 0.99 > 0.05)
                        No change in performance detected.
```

## Type of change

Please delete options that are not relevant.

- [X] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [X] This change is an Optimization
  - [X] Benchmarks added/run
