### PR TITLE
Require FFT Fields to be PrimeFields

### DIFF
--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -1,4 +1,4 @@
-use crate::field::traits::{IsFFTField, IsField};
+use crate::field::traits::{IsFFTField, IsField, IsPrimeField};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 
@@ -50,6 +50,14 @@ impl<const MODULUS: u32> IsField for U32Field<MODULUS> {
 
     fn from_base_type(x: u32) -> u32 {
         x % MODULUS
+    }
+}
+
+impl<const MODULUS: u32> IsPrimeField for U32Field<MODULUS> {
+    type RepresentativeType = u32;
+
+    fn representative(a: &Self::BaseType) -> u32 {
+        *a
     }
 }
 

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -22,7 +22,7 @@ pub enum RootsConfig {
 /// A two-adic primitive root of unity is a number w that satisfies w^(2^n) = 1
 /// and w^(j) != 1 for every j below 2^n. With this primitive root we can generate
 /// any other root of unity we need to perform FFT.
-pub trait IsFFTField: IsField {
+pub trait IsFFTField: IsPrimeField {
     const TWO_ADICITY: u64;
     const TWO_ADIC_PRIMITVE_ROOT_OF_UNITY: Self::BaseType;
 


### PR DESCRIPTION
# Require FFT Fields to be PrimeFields

## Description

Require FFT Fields to be PrimeFields to have additional methods useful for debugging and working with the fields. It also doesn't make much sense for an extension field to be an FFT Field so this limits the FFT Fields to the scope where they should be used

## Type of change

Please delete options that are not relevant.

- [x] New feature

