### PR TITLE
Add bit len to prime fields

### DIFF
--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -257,6 +257,18 @@ where
     fn representative(x: &Self::BaseType) -> Self::RepresentativeType {
         MontgomeryAlgorithms::cios(x, &UnsignedInteger::from_u64(1), &M::MODULUS, &Self::MU)
     }
+
+    fn field_bit_size() -> usize {
+        let mut evaluated_bit = NUM_LIMBS * 64 - 1;
+        let max_element = M::MODULUS - UnsignedInteger::<NUM_LIMBS>::from_u128(1);
+        let one = UnsignedInteger::from_u128(1);
+
+        while ((max_element >> evaluated_bit) & one) != one {
+            evaluated_bit -= 1;
+        }
+
+        evaluated_bit + 1
+    }
 }
 
 impl<M, const NUM_LIMBS: usize> ByteConversion
@@ -298,12 +310,15 @@ where
 #[cfg(test)]
 mod tests_u384_prime_fields {
     use crate::field::element::FieldElement;
-    use crate::field::fields::montgomery_backed_prime_fields::{IsModulus, U384PrimeField};
+    use crate::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
+    use crate::field::fields::montgomery_backed_prime_fields::{
+        IsModulus, U256PrimeField, U384PrimeField,
+    };
     use crate::field::traits::IsField;
     use crate::field::traits::IsPrimeField;
     use crate::traits::ByteConversion;
-    use crate::unsigned_integer::element::UnsignedInteger;
     use crate::unsigned_integer::element::U384;
+    use crate::unsigned_integer::element::{UnsignedInteger, U256};
 
     #[derive(Clone, Debug)]
     struct U384Modulus23;
@@ -313,6 +328,40 @@ mod tests_u384_prime_fields {
 
     type U384F23 = U384PrimeField<U384Modulus23>;
     type U384F23Element = FieldElement<U384F23>;
+
+    #[test]
+    fn u384_mod_23_uses_5_bits() {
+        assert_eq!(U384F23::field_bit_size(), 5);
+    }
+
+    #[test]
+    fn stark_252_prime_field_uses_252_bits() {
+        assert_eq!(Stark252PrimeField::field_bit_size(), 252);
+    }
+
+    #[test]
+    fn u256_mod_2_uses_1_bit() {
+        #[derive(Clone, Debug)]
+        struct U256Modulus1;
+        impl IsModulus<U256> for U256Modulus1 {
+            const MODULUS: U256 = UnsignedInteger::from_u64(2);
+        }
+        type U256OneField = U256PrimeField<U256Modulus1>;
+        assert_eq!(U256OneField::field_bit_size(), 1);
+    }
+
+    #[test]
+    fn u256_with_first_bit_set_uses_256_bit() {
+        #[derive(Clone, Debug)]
+        struct U256ModulusBig;
+        impl IsModulus<U256> for U256ModulusBig {
+            const MODULUS: U256 = UnsignedInteger::from_hex_unchecked(
+                "F0000000F0000000F0000000F0000000F0000000F0000000F0000000F0000000",
+            );
+        }
+        type U256OneField = U256PrimeField<U256ModulusBig>;
+        assert_eq!(U256OneField::field_bit_size(), 256);
+    }
 
     #[test]
     fn montgomery_backend_primefield_compute_r2_parameter() {

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -74,6 +74,16 @@ impl<const MODULUS: u64> IsPrimeField for U64PrimeField<MODULUS> {
     fn representative(x: &u64) -> u64 {
         *x
     }
+
+    fn field_bit_size() -> usize {
+        let max_element = (MODULUS - 1) as usize;
+        let mut evaluated_bit = 63;
+
+        while ((max_element >> evaluated_bit) & 1) != 1 {
+            evaluated_bit -= 1;
+        }
+        evaluated_bit + 1
+    }
 }
 
 /// Represents an element in Fp. (E.g: 0, 1, 2 are the elements of F3)
@@ -116,6 +126,32 @@ mod tests {
     use super::*;
     const MODULUS: u64 = 13;
     type FE = FieldElement<U64PrimeField<MODULUS>>;
+
+    #[test]
+    fn bit_size_of_mod_13_field_is_4() {
+        assert_eq!(
+            <U64PrimeField<MODULUS> as crate::field::traits::IsPrimeField>::field_bit_size(),
+            4
+        );
+    }
+
+    #[test]
+    fn bit_size_of_big_mod_field_is_64() {
+        const MODULUS: u64 = 10000000000000000000;
+        assert_eq!(
+            <U64PrimeField<MODULUS> as crate::field::traits::IsPrimeField>::field_bit_size(),
+            64
+        );
+    }
+
+    #[test]
+    fn bit_size_of_63_bit_mod_field_is_63() {
+        const MODULUS: u64 = 9000000000000000000;
+        assert_eq!(
+            <U64PrimeField<MODULUS> as crate::field::traits::IsPrimeField>::field_bit_size(),
+            63
+        );
+    }
 
     #[test]
     fn two_plus_one_is_three() {

--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -59,6 +59,16 @@ impl<const MODULUS: u32> IsPrimeField for U32Field<MODULUS> {
     fn representative(a: &Self::BaseType) -> u32 {
         *a
     }
+
+    fn field_bit_size() -> usize {
+        let max_element = MODULUS - 1;
+        let mut evaluated_bit = 31;
+
+        while ((max_element >> evaluated_bit) & 1) != 1 {
+            evaluated_bit -= 1;
+        }
+        evaluated_bit + 1
+    }
 }
 
 // 15 * 2^27 + 1;
@@ -68,4 +78,17 @@ pub type U32TestField = U32Field<2013265921>;
 impl IsFFTField for U32TestField {
     const TWO_ADICITY: u64 = 27;
     const TWO_ADIC_PRIMITVE_ROOT_OF_UNITY: u32 = 440532289;
+}
+
+#[cfg(test)]
+mod tests_u32_test_field {
+    use crate::field::test_fields::u32_test_field::U32TestField;
+
+    #[test]
+    fn bit_size_of_test_field_is_31() {
+        assert_eq!(
+            <U32TestField as crate::field::traits::IsPrimeField>::field_bit_size(),
+            31
+        );
+    }
 }

--- a/math/src/field/test_fields/u64_test_field.rs
+++ b/math/src/field/test_fields/u64_test_field.rs
@@ -58,6 +58,16 @@ impl<const MODULUS: u64> IsPrimeField for U64Field<MODULUS> {
     fn representative(x: &u64) -> u64 {
         *x
     }
+
+    fn field_bit_size() -> usize {
+        let max_element = (MODULUS - 1) as usize;
+        let mut evaluated_bit = 63;
+
+        while ((max_element >> evaluated_bit) & 1) != 1 {
+            evaluated_bit -= 1;
+        }
+        evaluated_bit + 1
+    }
 }
 
 pub type U64TestField = U64Field<18446744069414584321>;
@@ -66,4 +76,17 @@ pub type U64TestField = U64Field<18446744069414584321>;
 impl IsFFTField for U64TestField {
     const TWO_ADICITY: u64 = 32;
     const TWO_ADIC_PRIMITVE_ROOT_OF_UNITY: u64 = 1753635133440165772;
+}
+
+#[cfg(test)]
+mod tests_u64_test_field {
+    use crate::field::test_fields::u64_test_field::U64TestField;
+
+    #[test]
+    fn bit_size_of_test_field_is_64() {
+        assert_eq!(
+            <U64TestField as crate::field::traits::IsPrimeField>::field_bit_size(),
+            64
+        );
+    }
 }

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -154,6 +154,8 @@ pub trait IsPrimeField: IsField {
         Self::representative(&Self::neg(&Self::one()))
     }
 
+    fn field_bit_size() -> usize;
+
     fn legendre_symbol(a: &Self::BaseType) -> LegendreSymbol {
         let symbol = Self::pow(a, Self::modulus_minus_one() >> 1);
 


### PR DESCRIPTION
# Add bit len to prime fields

## Description

Add a function to calculate the amount of bits a prime fields has in their representation. This is needed to update the transcript hash to field function

## Type of change

- [x] New feature
