### PR TITLE
FFT Bench: Winterfell vs Lambdaworks

### DIFF
--- a/fft/Cargo.toml
+++ b/fft/Cargo.toml
@@ -8,6 +8,7 @@ rand = "0.8.5"
 thiserror = "1.0.38"
 lambdaworks-math = { path = "../math" }
 lambdaworks-gpu = { path = "../gpu", optional = true }
+winter-math = { git = "https://github.com/facebook/winterfell.git", rev="18dfc30"}
 
 [dev-dependencies]
 proptest = "1.1.0"
@@ -25,4 +26,8 @@ harness = false
 
 [[bench]]
 name = "iai_fft"
+harness = false
+
+[[bench]]
+name = "criterion_wf_vs_lw_fft"
 harness = false

--- a/fft/benches/criterion_wf_vs_lw_fft.rs
+++ b/fft/benches/criterion_wf_vs_lw_fft.rs
@@ -1,0 +1,138 @@
+use criterion::{Criterion, criterion_group, criterion_main, black_box};
+use lambdaworks_fft::polynomial::evaluate_fft_cpu;
+use lambdaworks_math::field::element::FieldElement as LambdaFieldElement;
+use lambdaworks_math::field::traits::IsField;
+use lambdaworks_math::field::traits::{IsFFTField, IsPrimeField};
+use winter_math::fft::evaluate_poly;
+use winter_math::{
+    fft::fft_inputs::FftInputs,
+    get_power_series,
+    {fields::f64::BaseElement, FieldElement, StarkField},
+};
+const MIN_CONCURRENT_SIZE: usize = 1024;
+
+fn permute<E: FieldElement>(v: &mut [E]) {
+    if cfg!(feature = "concurrent") && v.len() >= MIN_CONCURRENT_SIZE {
+        #[cfg(feature = "concurrent")]
+        concurrent::permute(v);
+    } else {
+        FftInputs::permute(v);
+    }
+}
+
+pub fn get_twiddles<B>(domain_size: usize) -> Vec<B>
+where
+    B: StarkField,
+{
+    assert!(
+        domain_size.is_power_of_two(),
+        "domain size must be a power of 2"
+    );
+    assert!(
+        domain_size.ilog2() <= B::TWO_ADICITY,
+        "multiplicative subgroup of size {domain_size} does not exist in the specified base field"
+    );
+    let root = B::get_root_of_unity(domain_size.ilog2());
+    let mut twiddles = get_power_series(root, domain_size / 2);
+    permute(&mut twiddles);
+    twiddles
+}
+
+pub fn run_winterfell(poly: &[BaseElement]) {
+    let mut p = poly.to_vec();
+    let twiddles = get_twiddles::<BaseElement>(p.len());
+    evaluate_poly(&mut p, &twiddles);
+}
+
+pub fn run_lambdaworks(poly: &[LambdaFieldElement<WinterfellFieldWrapper>]) -> Vec<LambdaFieldElement<WinterfellFieldWrapper>> {
+    let p = poly.clone();
+    evaluate_fft_cpu(p).unwrap()
+}
+
+#[derive(Clone, Debug)]
+pub struct WinterfellFieldWrapper;
+
+impl IsFFTField for WinterfellFieldWrapper {
+    const TWO_ADICITY: u64 = 32;
+    const TWO_ADIC_PRIMITVE_ROOT_OF_UNITY: Self::BaseType =
+        Self::BaseType::new(7277203076849721926u64);
+}
+
+impl IsPrimeField for WinterfellFieldWrapper {
+    type RepresentativeType = u64;
+
+    fn representative(a: &Self::BaseType) -> Self::RepresentativeType {
+        a.as_int()
+    }
+
+    fn field_bit_size() -> usize {
+        todo!()
+    }
+}
+
+impl IsField for WinterfellFieldWrapper {
+    type BaseType = BaseElement;
+
+    fn add(a: &BaseElement, b: &BaseElement) -> BaseElement {
+        a.clone() + b.clone()
+    }
+
+    fn sub(a: &BaseElement, b: &BaseElement) -> BaseElement {
+        a.clone() - b.clone()
+    }
+
+    fn neg(a: &BaseElement) -> BaseElement {
+        -a.clone()
+    }
+
+    fn mul(a: &BaseElement, b: &BaseElement) -> BaseElement {
+        a.clone() * b.clone()
+    }
+
+    fn div(a: &BaseElement, b: &BaseElement) -> BaseElement {
+        a.clone() / b.clone()
+    }
+
+    fn inv(a: &BaseElement) -> BaseElement {
+        a.inv()
+    }
+
+    fn eq(a: &BaseElement, b: &BaseElement) -> bool {
+        a == b
+    }
+
+    fn zero() -> BaseElement {
+        BaseElement::from(0u64)
+    }
+
+    fn one() -> BaseElement {
+        BaseElement::from(1u64)
+    }
+
+    fn from_u64(x: u64) -> BaseElement {
+        BaseElement::from(x)
+    }
+
+    fn from_base_type(x: BaseElement) -> BaseElement {
+        x
+    }
+}
+
+fn fft_benches(c: &mut Criterion) {
+let mut group = c.benchmark_group("FFT");
+    let poly_winterfell = &vec![BaseElement::from(3u64); 8192];
+    let poly_lambda = &vec![LambdaFieldElement::<WinterfellFieldWrapper>::from(3u64); 8192];
+    group.bench_function("winterfel_evaluate_fft", |bench| {
+        bench.iter(|| {
+            black_box(run_winterfell(black_box(poly_winterfell)))
+        })
+    });
+    group.bench_function("lambda_evaluate_fft", |bench| {
+        bench.iter(|| {
+            black_box(run_lambdaworks(black_box(poly_lambda)))
+        })
+    });
+}
+
+criterion_group!(benches, fft_benches);
+criterion_main!(benches);

--- a/fft/benches/criterion_wf_vs_lw_fft.rs
+++ b/fft/benches/criterion_wf_vs_lw_fft.rs
@@ -1,3 +1,4 @@
+use rand::Rng;
 use criterion::{Criterion, criterion_group, criterion_main, black_box};
 use lambdaworks_fft::polynomial::evaluate_fft_cpu;
 use lambdaworks_math::field::element::FieldElement as LambdaFieldElement;
@@ -120,16 +121,21 @@ impl IsField for WinterfellFieldWrapper {
 
 fn fft_benches(c: &mut Criterion) {
 let mut group = c.benchmark_group("FFT");
-    let poly_winterfell = &vec![BaseElement::from(3u64); 8192];
-    let poly_lambda = &vec![LambdaFieldElement::<WinterfellFieldWrapper>::from(3u64); 8192];
+    let mut rng = rand::thread_rng();
+    let mut random_u64s: Vec<u64> = Vec::with_capacity(8192);
+    for _ in 0..8192 {
+        random_u64s.push(rng.gen());
+    }
+    let poly_winterfell: Vec<_> = random_u64s.iter().map(|x| BaseElement::from(*x)).collect();
+    let poly_lambda: Vec<_> = random_u64s.iter().map(|x| LambdaFieldElement::<WinterfellFieldWrapper>::from(*x)).collect();
     group.bench_function("winterfel_evaluate_fft", |bench| {
         bench.iter(|| {
-            black_box(run_winterfell(black_box(poly_winterfell)))
+            black_box(run_winterfell(black_box(&poly_winterfell)))
         })
     });
     group.bench_function("lambda_evaluate_fft", |bench| {
         bench.iter(|| {
-            black_box(run_lambdaworks(black_box(poly_lambda)))
+            black_box(run_lambdaworks(black_box(&poly_lambda)))
         })
     });
 }

--- a/fft/src/polynomial.rs
+++ b/fft/src/polynomial.rs
@@ -159,7 +159,7 @@ where
     Polynomial::interpolate_fft(values.as_slice()).unwrap()
 }
 
-fn evaluate_fft_cpu<F>(coeffs: &[FieldElement<F>]) -> Result<Vec<FieldElement<F>>, FFTError>
+pub fn evaluate_fft_cpu<F>(coeffs: &[FieldElement<F>]) -> Result<Vec<FieldElement<F>>, FFTError>
 where
     F: IsFFTField,
 {

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -4,12 +4,9 @@ use crate::unsigned_integer::element::UnsignedInteger;
 use crate::unsigned_integer::montgomery::MontgomeryAlgorithms;
 use crate::unsigned_integer::traits::IsUnsignedInteger;
 use std::fmt;
+use std::fmt::Debug;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
-use std::{
-    fmt::Debug,
-    hash::{Hash, Hasher},
-};
 
 use super::fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField};
 use super::traits::{IsPrimeField, LegendreSymbol};
@@ -90,15 +87,6 @@ where
 }
 
 impl<F> Eq for FieldElement<F> where F: IsField {}
-
-impl<F> Hash for FieldElement<F>
-where
-    F: IsField,
-{
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.value.hash(state);
-    }
-}
 
 /// Addition operator overloading for field elements
 impl<F> Add<&FieldElement<F>> for &FieldElement<F>

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -1,6 +1,6 @@
 use crate::unsigned_integer::traits::IsUnsignedInteger;
 
-use std::{fmt::Debug, hash::Hash};
+use std::{fmt::Debug};
 
 use super::{element::FieldElement, errors::FieldError};
 
@@ -56,7 +56,7 @@ pub trait IsFFTField: IsPrimeField {
 pub trait IsField: Debug + Clone {
     /// The underlying base type for representing elements from the field.
     // TODO: Relax Unpin for non cuda usage
-    type BaseType: Clone + Debug + Hash + Unpin;
+    type BaseType: Clone + Debug + Unpin;
 
     /// Returns the sum of `a` and `b`.
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType;


### PR DESCRIPTION
# FFT Bench: Winterfell vs Lambdaworks

## Description

A simple bench comparing the evaluation of polynomials in lambdaworks vs in winterfell. To compare apples and apples, a wrapper around the FieldElement used in winterfell is used.