### PR TITLE
perf: specialize `PartialOrd` for `UnsignedInteger`

### DIFF
--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::convert::From;
 use std::ops::{
     Add, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Mul, Shl, Shr, ShrAssign,
@@ -19,9 +20,39 @@ pub type U128 = UnsignedInteger<2>;
 /// The most significant bit is in the left-most position.
 /// That is, the array `[a_n, ..., a_0]` represents the
 /// integer 2^{64 * n} * a_n + ... + 2^{64} * a_1 + a_0.
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct UnsignedInteger<const NUM_LIMBS: usize> {
     pub limbs: [u64; NUM_LIMBS],
+}
+
+// NOTE: manually implementing `PartialOrd` may seem unorthodox, but the
+// derived implementation had terrible performance.
+impl<const NUM_LIMBS: usize> PartialOrd for UnsignedInteger<NUM_LIMBS> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let mut i = 0;
+        while i < NUM_LIMBS {
+            if self.limbs[i] != other.limbs[i] {
+                return Some(self.limbs[i].cmp(&other.limbs[i]));
+            }
+            i += 1;
+        }
+        Some(Ordering::Equal)
+    }
+}
+
+// NOTE: because we implemented `PartialOrd`, clippy asks us to implement
+// this manually too.
+impl<const NUM_LIMBS: usize> Ord for UnsignedInteger<NUM_LIMBS> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let mut i = 0;
+        while i < NUM_LIMBS {
+            if self.limbs[i] != other.limbs[i] {
+                return self.limbs[i].cmp(&other.limbs[i]);
+            }
+            i += 1;
+        }
+        Ordering::Equal
+    }
 }
 
 impl<const NUM_LIMBS: usize> From<u128> for UnsignedInteger<NUM_LIMBS> {


### PR DESCRIPTION
The `derive`d implementation of `PartialOrd` for `UnsignedInteger` was a major bottleneck in substraction for fields and possibly other operations.
By implementing it manually with a while loop a big speedup was achieved.

## Type of change

- [x] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] This change is an Optimization
  - [x] Benchmarks added/run

## Results

```
Stark FP operations/add time:   [2.1716 ns 2.1718 ns 2.1719 ns]
                        change: [-8.8891% -8.8713% -8.8545%] (p = 0.00 < 0.05)                                         
Stark FP operations/mul time:   [11.256 ns 11.267 ns 11.279 ns]                                                        
                        change: [-1.3248% -1.1605% -0.9798%] (p = 0.00 < 0.05)                                         
Stark FP operations/pow by 1                     
                        time:   [2.4193 ns 2.4195 ns 2.4197 ns]                                                        
                        change: [+1.3484% +1.4212% +1.5022%] (p = 0.00 < 0.05)
Stark FP operations/sos_square
                        time:   [10.134 ns 10.137 ns 10.139 ns]
                        change: [+2.8970% +3.0355% +3.1636%] (p = 0.00 < 0.05)
Stark FP operations/square
                        time:   [3.0620 ns 3.0622 ns 3.0624 ns]
                        change: [-1.7055% -1.6848% -1.6640%] (p = 0.00 < 0.05)
Stark FP operations/square with pow
                        time:   [11.753 ns 11.755 ns 11.757 ns]
                        change: [-1.2809% -1.2513% -1.2224%] (p = 0.00 < 0.05)
Stark FP operations/square with mul
                        time:   [11.375 ns 11.387 ns 11.398 ns]
                        change: [-0.8058% -0.6037% -0.4047%] (p = 0.00 < 0.05)
Stark FP operations/pow time:   [30.992 ns 31.017 ns 31.043 ns]
                        change: [-3.1635% -3.0911% -3.0156%] (p = 0.00 < 0.05)
Stark FP operations/sub time:   [2.1801 ns 2.1801 ns 2.1802 ns]
                        change: [-0.3174% -0.2976% -0.2764%] (p = 0.00 < 0.05)
Stark FP operations/inv time:   [2.0044 µs 2.0047 µs 2.0051 µs]
                        change: [-7.1994% -7.1541% -7.1082%] (p = 0.00 < 0.05)
Stark FP operations/div time:   [1.8040 µs 1.8045 µs 1.8050 µs]
                        change: [-18.569% -18.533% -18.500%] (p = 0.00 < 0.05)
Stark FP operations/eq  time:   [214.54 ps 214.55 ps 214.56 ps]
                        change: [-2.1736% -2.1439% -2.1151%] (p = 0.00 < 0.05)
Stark FP operations/sqrt
                        time:   [3.3790 µs 3.3794 µs 3.3797 µs]
                        change: [+0.0646% +0.1024% +0.1386%] (p = 0.00 < 0.05)
Stark FP operations/sqrt squared
                        time:   [122.30 µs 122.31 µs 122.32 µs]
                        change: [+0.2354% +0.2820% +0.3277%] (p = 0.00 < 0.05)
Stark FP operations/bitand
                        time:   [659.82 ps 659.89 ps 659.96 ps]
                        change: [+0.5884% +0.6239% +0.6588%] (p = 0.00 < 0.05)
Stark FP operations/bitor
                        time:   [660.60 ps 660.66 ps 660.72 ps]
                        change: [+0.9083% +0.9417% +0.9756%] (p = 0.00 < 0.05)
Stark FP operations/bitxor
                        time:   [659.28 ps 659.34 ps 659.41 ps]
                        change: [+0.6881% +0.7189% +0.7486%] (p = 0.00 < 0.05)
```
