### PR TITLE
Add fft benchmark vs winterfell

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 ark-ff = { git = "https://github.com/arkworks-rs/algebra", rev = "ef8f758" }
 ark-test-curves = { git = "https://github.com/arkworks-rs/algebra", rev = "ef8f758" }
 ark-std = "0.4.0"
+winter-math = { git = "https://github.com/facebook/winterfell.git", rev="18dfc30"}
 rand = "0.8.5"
 
 [dependencies.lambdaworks-math]
@@ -38,3 +39,8 @@ harness = false
 [[bench]]
 name = "pow"
 harness = false
+
+[[bench]]
+name = "fft"
+harness = false
+

--- a/benches/benches/fft.rs
+++ b/benches/benches/fft.rs
@@ -17,8 +17,8 @@ pub fn run_winterfell(poly: &[BaseElement]) {
 pub fn run_lambdaworks(
     poly: &[LambdaFieldElement<WinterfellFieldWrapper>],
 ) -> Vec<LambdaFieldElement<WinterfellFieldWrapper>> {
-    let p = poly.clone();
-    evaluate_fft_cpu(p).unwrap()
+    let p = poly.to_vec();
+    evaluate_fft_cpu(&p).unwrap()
 }
 
 pub fn run_winterfell_twiddles(poly: &[BaseElement]) {
@@ -27,7 +27,7 @@ pub fn run_winterfell_twiddles(poly: &[BaseElement]) {
 }
 
 pub fn run_lambdaworks_twiddles(poly: &[LambdaFieldElement<WinterfellFieldWrapper>]) {
-    let p = poly.clone();
+    let p = poly.to_vec();
     let order = p.len().trailing_zeros();
     get_twiddles_lambdaworks::<WinterfellFieldWrapper>(order.into(), RootsConfig::BitReverse)
         .unwrap();
@@ -58,23 +58,23 @@ impl IsField for WinterfellFieldWrapper {
     type BaseType = BaseElement;
 
     fn add(a: &BaseElement, b: &BaseElement) -> BaseElement {
-        a.clone() + b.clone()
+        *a + *b
     }
 
     fn sub(a: &BaseElement, b: &BaseElement) -> BaseElement {
-        a.clone() - b.clone()
+        *a - *b
     }
 
     fn neg(a: &BaseElement) -> BaseElement {
-        -a.clone()
+        -*a
     }
 
     fn mul(a: &BaseElement, b: &BaseElement) -> BaseElement {
-        a.clone() * b.clone()
+        *a * *b
     }
 
     fn div(a: &BaseElement, b: &BaseElement) -> BaseElement {
-        a.clone() / b.clone()
+        *a / *b
     }
 
     fn inv(a: &BaseElement) -> BaseElement {
@@ -117,16 +117,20 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     // Benches
     c.bench_function("fft | winterfell", |bench| {
-        bench.iter(|| black_box(run_winterfell(black_box(&poly_winterfell))))
+        bench.iter(|| run_winterfell(black_box(&poly_winterfell)));
+        black_box(())
     });
     c.bench_function("fft | lambdaworks", |bench| {
-        bench.iter(|| black_box(run_lambdaworks(black_box(&poly_lambda))))
+        bench.iter(|| run_lambdaworks(black_box(&poly_lambda)));
+        black_box(())
     });
     c.bench_function("fft twiddles | winterfell", |bench| {
-        bench.iter(|| black_box(run_winterfell_twiddles(black_box(&poly_winterfell))))
+        bench.iter(|| run_winterfell_twiddles(black_box(&poly_winterfell)));
+        black_box(())
     });
     c.bench_function("fft twiddles | lambdaworks", |bench| {
-        bench.iter(|| black_box(run_lambdaworks_twiddles(black_box(&poly_lambda))))
+        bench.iter(|| run_lambdaworks_twiddles(black_box(&poly_lambda)));
+        black_box(())
     });
 }
 

--- a/benches/benches/fft.rs
+++ b/benches/benches/fft.rs
@@ -1,0 +1,136 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use lambdaworks_math::fft::polynomial::evaluate_fft_cpu;
+use lambdaworks_math::fft::roots_of_unity::get_twiddles as get_twiddles_lambdaworks;
+use lambdaworks_math::field::element::FieldElement as LambdaFieldElement;
+use lambdaworks_math::field::traits::{IsFFTField, IsPrimeField};
+use lambdaworks_math::field::traits::{IsField, RootsConfig};
+use rand::Rng;
+use winter_math::fft::{evaluate_poly, get_twiddles};
+use winter_math::{fields::f64::BaseElement, FieldElement, StarkField};
+
+pub fn run_winterfell(poly: &[BaseElement]) {
+    let mut p = poly.to_vec();
+    let twiddles = get_twiddles::<BaseElement>(p.len());
+    evaluate_poly(&mut p, &twiddles);
+}
+
+pub fn run_lambdaworks(
+    poly: &[LambdaFieldElement<WinterfellFieldWrapper>],
+) -> Vec<LambdaFieldElement<WinterfellFieldWrapper>> {
+    let p = poly.clone();
+    evaluate_fft_cpu(p).unwrap()
+}
+
+pub fn run_winterfell_twiddles(poly: &[BaseElement]) {
+    let p = poly.to_vec();
+    get_twiddles::<BaseElement>(p.len());
+}
+
+pub fn run_lambdaworks_twiddles(poly: &[LambdaFieldElement<WinterfellFieldWrapper>]) {
+    let p = poly.clone();
+    let order = p.len().trailing_zeros();
+    get_twiddles_lambdaworks::<WinterfellFieldWrapper>(order.into(), RootsConfig::BitReverse)
+        .unwrap();
+}
+
+#[derive(Clone, Debug)]
+pub struct WinterfellFieldWrapper;
+
+impl IsFFTField for WinterfellFieldWrapper {
+    const TWO_ADICITY: u64 = 32;
+    const TWO_ADIC_PRIMITVE_ROOT_OF_UNITY: Self::BaseType =
+        Self::BaseType::new(7277203076849721926u64);
+}
+
+impl IsPrimeField for WinterfellFieldWrapper {
+    type RepresentativeType = u64;
+
+    fn representative(a: &Self::BaseType) -> Self::RepresentativeType {
+        a.as_int()
+    }
+
+    fn field_bit_size() -> usize {
+        todo!()
+    }
+}
+
+impl IsField for WinterfellFieldWrapper {
+    type BaseType = BaseElement;
+
+    fn add(a: &BaseElement, b: &BaseElement) -> BaseElement {
+        a.clone() + b.clone()
+    }
+
+    fn sub(a: &BaseElement, b: &BaseElement) -> BaseElement {
+        a.clone() - b.clone()
+    }
+
+    fn neg(a: &BaseElement) -> BaseElement {
+        -a.clone()
+    }
+
+    fn mul(a: &BaseElement, b: &BaseElement) -> BaseElement {
+        a.clone() * b.clone()
+    }
+
+    fn div(a: &BaseElement, b: &BaseElement) -> BaseElement {
+        a.clone() / b.clone()
+    }
+
+    fn inv(a: &BaseElement) -> BaseElement {
+        a.inv()
+    }
+
+    fn eq(a: &BaseElement, b: &BaseElement) -> bool {
+        a == b
+    }
+
+    fn zero() -> BaseElement {
+        BaseElement::from(0u64)
+    }
+
+    fn one() -> BaseElement {
+        BaseElement::from(1u64)
+    }
+
+    fn from_u64(x: u64) -> BaseElement {
+        BaseElement::from(x)
+    }
+
+    fn from_base_type(x: BaseElement) -> BaseElement {
+        x
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("FFT");
+
+    // Create a slice with 8192 random elements.
+    let mut rng = rand::thread_rng();
+    let mut random_u64s: Vec<u64> = Vec::with_capacity(8192);
+    for _ in 0..8192 {
+        random_u64s.push(rng.gen());
+    }
+    let poly_winterfell: Vec<_> = random_u64s.iter().map(|x| BaseElement::from(*x)).collect();
+    let poly_lambda: Vec<_> = random_u64s
+        .iter()
+        .map(|x| LambdaFieldElement::<WinterfellFieldWrapper>::from(*x))
+        .collect();
+
+    // Benches
+    group.bench_function("fft_winterfell_evaluate_poly_fft", |bench| {
+        bench.iter(|| black_box(run_winterfell(black_box(&poly_winterfell))))
+    });
+    group.bench_function("fft_lambda_evaluate_poly_fft", |bench| {
+        bench.iter(|| black_box(run_lambdaworks(black_box(&poly_lambda))))
+    });
+    group.bench_function("fft_winterfell_compute_twiddles", |bench| {
+        bench.iter(|| black_box(run_winterfell_twiddles(black_box(&poly_winterfell))))
+    });
+    group.bench_function("fft_lambda_compute_twiddles", |bench| {
+        bench.iter(|| black_box(run_lambdaworks_twiddles(black_box(&poly_lambda))))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/benches/fft.rs
+++ b/benches/benches/fft.rs
@@ -103,8 +103,6 @@ impl IsField for WinterfellFieldWrapper {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let mut group = c.benchmark_group("FFT");
-
     // Create a slice with 8192 random elements.
     let mut rng = rand::thread_rng();
     let mut random_u64s: Vec<u64> = Vec::with_capacity(8192);
@@ -118,16 +116,16 @@ fn criterion_benchmark(c: &mut Criterion) {
         .collect();
 
     // Benches
-    group.bench_function("fft_winterfell_evaluate_poly_fft", |bench| {
+    c.bench_function("fft | winterfell", |bench| {
         bench.iter(|| black_box(run_winterfell(black_box(&poly_winterfell))))
     });
-    group.bench_function("fft_lambda_evaluate_poly_fft", |bench| {
+    c.bench_function("fft | lambdaworks", |bench| {
         bench.iter(|| black_box(run_lambdaworks(black_box(&poly_lambda))))
     });
-    group.bench_function("fft_winterfell_compute_twiddles", |bench| {
+    c.bench_function("fft twiddles | winterfell", |bench| {
         bench.iter(|| black_box(run_winterfell_twiddles(black_box(&poly_winterfell))))
     });
-    group.bench_function("fft_lambda_compute_twiddles", |bench| {
+    c.bench_function("fft twiddles | lambdaworks", |bench| {
         bench.iter(|| black_box(run_lambdaworks_twiddles(black_box(&poly_lambda))))
     });
 }

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -16,6 +16,11 @@ criterion = "0.4"
 const-random = "0.1.15"
 iai-callgrind.workspace = true
 
+[profile.release]
+lto = true
+opt-level = 3
+codegen-units = 1
+
 [features]
 rayon = ["dep:rayon"]
 

--- a/math/src/fft/polynomial.rs
+++ b/math/src/fft/polynomial.rs
@@ -159,7 +159,7 @@ where
     Polynomial::interpolate_fft(values.as_slice()).unwrap()
 }
 
-fn evaluate_fft_cpu<F>(coeffs: &[FieldElement<F>]) -> Result<Vec<FieldElement<F>>, FFTError>
+pub fn evaluate_fft_cpu<F>(coeffs: &[FieldElement<F>]) -> Result<Vec<FieldElement<F>>, FFTError>
 where
     F: IsFFTField,
 {

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -1,14 +1,14 @@
+use super::fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField};
+use super::traits::{IsPrimeField, LegendreSymbol};
 use crate::errors::CreationError;
 use crate::field::traits::IsField;
 use crate::unsigned_integer::element::UnsignedInteger;
 use crate::unsigned_integer::montgomery::MontgomeryAlgorithms;
 use crate::unsigned_integer::traits::IsUnsignedInteger;
 use std::fmt;
+use std::fmt::Debug;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
-use std::fmt::Debug;
-use super::fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField};
-use super::traits::{IsPrimeField, LegendreSymbol};
 
 /// A field element with operations algorithms defined in `F`
 #[derive(Debug, Clone)]

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -6,11 +6,7 @@ use crate::unsigned_integer::traits::IsUnsignedInteger;
 use std::fmt;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
-use std::{
-    fmt::Debug,
-    hash::{Hash, Hasher},
-};
-
+use std::fmt::Debug;
 use super::fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField};
 use super::traits::{IsPrimeField, LegendreSymbol};
 
@@ -90,15 +86,6 @@ where
 }
 
 impl<F> Eq for FieldElement<F> where F: IsField {}
-
-impl<F> Hash for FieldElement<F>
-where
-    F: IsField,
-{
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.value.hash(state);
-    }
-}
 
 /// Addition operator overloading for field elements
 impl<F> Add<&FieldElement<F>> for &FieldElement<F>

--- a/math/src/field/fields/p448_goldilocks_prime_field.rs
+++ b/math/src/field/fields/p448_goldilocks_prime_field.rs
@@ -12,7 +12,7 @@ pub const P448_GOLDILOCKS_PRIME_FIELD_ORDER: U448 =
 /// 448-bit unsigned integer represented as
 /// a size 8 `u64` array `limbs` of 56-bit words.
 /// The least significant word is in the left most position.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct U56x8 {
     limbs: [u64; 8],
 }

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -6,7 +6,7 @@ use crate::field::traits::{IsFFTField, IsField, IsPrimeField};
 use crate::traits::{ByteConversion, Deserializable, Serializable};
 
 /// Type representing prime fields over unsigned 64-bit integers.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct U64PrimeField<const MODULUS: u64>;
 pub type U64FieldElement<const MODULUS: u64> = FieldElement<U64PrimeField<MODULUS>>;
 

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -1,6 +1,6 @@
 use crate::unsigned_integer::traits::IsUnsignedInteger;
 
-use std::{fmt::Debug, hash::Hash};
+use std::fmt::Debug;
 
 use super::{element::FieldElement, errors::FieldError};
 
@@ -56,7 +56,7 @@ pub trait IsFFTField: IsPrimeField {
 pub trait IsField: Debug + Clone {
     /// The underlying base type for representing elements from the field.
     // TODO: Relax Unpin for non cuda usage
-    type BaseType: Clone + Debug + Hash + Unpin;
+    type BaseType: Clone + Debug + Unpin;
 
     /// Returns the sum of `a` and `b`.
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType;

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -20,7 +20,7 @@ pub type U128 = UnsignedInteger<2>;
 /// The most significant bit is in the left-most position.
 /// That is, the array `[a_n, ..., a_0]` represents the
 /// integer 2^{64 * n} * a_n + ... + 2^{64} * a_1 + a_0.
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct UnsignedInteger<const NUM_LIMBS: usize> {
     pub limbs: [u64; NUM_LIMBS],
 }


### PR DESCRIPTION
# Add fft benchmark vs winterfell

## Description

Add a benchmark comparing the FFT implementation of both libraries. It also removes the requirement of the Hash trait for the BaseType of the IsField trait to facilitate the integration of winterfell fields with lambdaworks.
