### PR TITLE
Fix sqrt overflow for moduli with large 2-adicity

### DIFF
--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -525,6 +525,7 @@ mod tests {
         assert_eq!(sqrt.0, result);
         assert_eq!(sqrt.1, -result);
     }
+
     #[test]
     fn one_of_sqrt_roots_for_25_is_5() {
         let input = FrElement::from(25);
@@ -532,6 +533,18 @@ mod tests {
         let result = FrElement::from(5);
         assert_eq!(sqrt.1, result);
         assert_eq!(sqrt.0, -result);
+    }
+
+    #[test]
+    fn sqrt_works_for_prime_minus_one() {
+        type FrField = Stark252PrimeField;
+        type FrElement = FieldElement<FrField>;
+
+        let input = -FrElement::from(1);
+        let sqrt = input.sqrt().unwrap();
+        assert_eq!(sqrt.0.square(), input);
+        assert_eq!(sqrt.1.square(), input);
+        assert_ne!(sqrt.0, sqrt.1);
     }
 
     #[test]

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -213,7 +213,10 @@ pub trait IsPrimeField: IsField {
                 i + 1
             };
 
-            let b = Self::pow(&c, 1usize << (m - i - 1));
+            let mut b = c.clone();
+            for _ in 0..(m - i - 1) {
+                b = Self::square(&b);
+            }
 
             c = Self::mul(&b, &b);
             x = Self::mul(&x, &b);

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -213,10 +213,7 @@ pub trait IsPrimeField: IsField {
                 i + 1
             };
 
-            let mut b = c.clone();
-            for _ in 0..(m - i - 1) {
-                b = Self::square(&b);
-            }
+            let b = (0..(m - i - 1)).fold(c, |acc, _| Self::square(&acc));
 
             c = Self::mul(&b, &b);
             x = Self::mul(&x, &b);


### PR DESCRIPTION
# Fix sqrt overflow for moduli with large 2-adicity

## Description
This PR solves Issue #445.

The Tonelli-Shanks algorithm attempts to raise a field element to the power `2^(m-i-1)`. The value` m-i-1` can be of the order of the 2-adicity of the field. At the moment this is computed as `c.pow(1_usize << (m - i - 1))`, which overflows for fields with 2-adicity larger than 128. This is the case for `Stark252PrimeField`.

This PR solves this by avoiding the call to `pow` and replaces it with successive calls to `square`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

