### PR TITLE
Sha3 512 tree and merkle tree backends refactor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "rust-analyzer.linkedProjects": [
-        "./crypto/Cargo.toml"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "./crypto/Cargo.toml"
+    ]
+}

--- a/crypto/benches/criterion_merkle.rs
+++ b/crypto/benches/criterion_merkle.rs
@@ -1,6 +1,6 @@
 use core::time::Duration;
 use criterion::{criterion_group, criterion_main, Criterion};
-use lambdaworks_crypto::merkle_tree::merkle::{FieldElementBackend, MerkleTree};
+use lambdaworks_crypto::merkle_tree::merkle::{Sha3_256Backend, MerkleTree};
 use lambdaworks_math::{
     field::element::FieldElement,
     field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
@@ -24,7 +24,7 @@ fn merkle_tree_benchmarks(c: &mut Criterion) {
         unhashed_leaves.as_slice(),
         |bench, unhashed_leaves| {
             bench.iter_with_large_drop(|| {
-                MerkleTree::<FieldElementBackend<F>>::build(unhashed_leaves)
+                MerkleTree::<Sha3_256Backend<F>>::build(unhashed_leaves)
             });
         },
     );

--- a/crypto/benches/criterion_merkle.rs
+++ b/crypto/benches/criterion_merkle.rs
@@ -1,6 +1,6 @@
 use core::time::Duration;
 use criterion::{criterion_group, criterion_main, Criterion};
-use lambdaworks_crypto::merkle_tree::merkle::{Sha3_256Backend, MerkleTree};
+use lambdaworks_crypto::merkle_tree::{merkle::MerkleTree, backends::sha3_256::Sha3_256Tree};
 use lambdaworks_math::{
     field::element::FieldElement,
     field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
@@ -24,7 +24,7 @@ fn merkle_tree_benchmarks(c: &mut Criterion) {
         unhashed_leaves.as_slice(),
         |bench, unhashed_leaves| {
             bench.iter_with_large_drop(|| {
-                MerkleTree::<Sha3_256Backend<F>>::build(unhashed_leaves)
+                MerkleTree::<Sha3_256Tree<F>>::build(unhashed_leaves)
             });
         },
     );

--- a/crypto/benches/iai_merkle.rs
+++ b/crypto/benches/iai_merkle.rs
@@ -1,7 +1,7 @@
 use core::hint::black_box;
 use lambdaworks_crypto::{
     hash::sha3::Sha3Hasher,
-    merkle_tree::merkle::{FieldElementBackend, MerkleTree},
+    merkle_tree::merkle::{Sha3_256Backend, MerkleTree},
 };
 use lambdaworks_math::{
     field::element::FieldElement,
@@ -30,7 +30,7 @@ fn build_hasher() -> Box<Sha3Hasher> {
 #[inline(never)]
 fn merkle_tree_build_benchmark() {
     let unhashed_leaves = build_unhashed_leaves();
-    let result = black_box(MerkleTree::<FieldElementBackend<F>>::build(black_box(
+    let result = black_box(MerkleTree::<Sha3_256Backend<F>>::build(black_box(
         &unhashed_leaves,
     )));
     // Let's not count `drop` in our timings.

--- a/crypto/benches/iai_merkle.rs
+++ b/crypto/benches/iai_merkle.rs
@@ -1,7 +1,7 @@
 use core::hint::black_box;
 use lambdaworks_crypto::{
     hash::sha3::Sha3Hasher,
-    merkle_tree::merkle::{Sha3_256Backend, MerkleTree},
+    merkle_tree::{merkle::MerkleTree, backends::sha3_256::Sha3_256Tree},
 };
 use lambdaworks_math::{
     field::element::FieldElement,
@@ -30,7 +30,7 @@ fn build_hasher() -> Box<Sha3Hasher> {
 #[inline(never)]
 fn merkle_tree_build_benchmark() {
     let unhashed_leaves = build_unhashed_leaves();
-    let result = black_box(MerkleTree::<Sha3_256Backend<F>>::build(black_box(
+    let result = black_box(MerkleTree::<Sha3_256Tree<F>>::build(black_box(
         &unhashed_leaves,
     )));
     // Let's not count `drop` in our timings.

--- a/crypto/src/merkle_tree/backends/mod.rs
+++ b/crypto/src/merkle_tree/backends/mod.rs
@@ -1,0 +1,2 @@
+pub mod sha3_256;
+pub mod sha3_512;

--- a/crypto/src/merkle_tree/backends/sha3_256.rs
+++ b/crypto/src/merkle_tree/backends/sha3_256.rs
@@ -1,0 +1,68 @@
+use std::marker::PhantomData;
+use lambdaworks_math::{field::{traits::IsField, element::FieldElement}, traits::ByteConversion};
+use sha3::{Digest, Sha3_256};
+use crate::merkle_tree::traits::IsMerkleTreeBackend;
+
+#[derive(Clone)]
+pub struct Sha3_256Tree<F> {
+    phantom: PhantomData<F>,
+}
+
+impl<F> Default for Sha3_256Tree<F> {
+    fn default() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<F> IsMerkleTreeBackend for Sha3_256Tree<F>
+where
+    F: IsField,
+    FieldElement<F>: ByteConversion,
+{
+    type Node = [u8; 32];
+    type Data = FieldElement<F>;
+
+    fn hash_data(&self, input: &FieldElement<F>) -> [u8; 32] {
+        let mut hasher = Sha3_256::new();
+        hasher.update(input.to_bytes_be());
+        hasher.finalize().into()
+    }
+
+    fn hash_new_parent(&self, left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
+        let mut hasher = Sha3_256::new();
+        hasher.update(left);
+        hasher.update(right);
+        let mut result_hash = [0_u8; 32];
+        result_hash.copy_from_slice(&hasher.finalize());
+        result_hash
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lambdaworks_math::field::{fields::u64_prime_field::U64PrimeField, element::FieldElement};
+
+    use crate::merkle_tree::{merkle::MerkleTree, test_merkle::TestBackend, backends::sha3_256::Sha3_256Tree};
+
+    
+    const MODULUS: u64 = 13;
+    type U64PF = U64PrimeField<MODULUS>;
+    type FE = FieldElement<U64PF>;
+    #[test]
+    // expected | 8 | 7 | 1 | 6 | 1 | 7 | 7 | 2 | 4 | 6 | 8 | 10 | 10 | 10 | 10 |
+    fn build_merkle_tree_from_an_odd_set_of_leaves() {
+        let values: Vec<FE> = (1..6).map(FE::new).collect();
+        let merkle_tree = MerkleTree::<TestBackend<U64PF>>::build(&values);
+        assert_eq!(merkle_tree.root, FE::new(8));
+    }
+
+    #[test]
+    fn hash_data_field_element_backend_works() {
+        let values: Vec<FE> = (1..6).map(FE::new).collect();
+        let merkle_tree = MerkleTree::<Sha3_256Tree<U64PF>>::build(&values);
+        let proof = merkle_tree.get_proof_by_pos(0).unwrap();
+        assert!(proof.verify::<Sha3_256Tree<U64PF>>(&merkle_tree.root, 0, &values[0]));
+    }
+}

--- a/crypto/src/merkle_tree/backends/sha3_512.rs
+++ b/crypto/src/merkle_tree/backends/sha3_512.rs
@@ -1,0 +1,67 @@
+
+use std::marker::PhantomData;
+use lambdaworks_math::{field::{traits::IsField, element::FieldElement}, traits::ByteConversion};
+use sha3::{Digest, Sha3_512};
+use crate::merkle_tree::traits::IsMerkleTreeBackend;
+
+#[derive(Clone)]
+pub struct Sha3_512Tree<F> {
+    phantom: PhantomData<F>,
+}
+
+impl<F> Default for Sha3_512Tree<F> {
+    fn default() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<F> IsMerkleTreeBackend for Sha3_512Tree<F>
+where
+    F: IsField,
+    FieldElement<F>: ByteConversion,
+{
+    type Node = [u8; 64];
+    type Data = FieldElement<F>;
+
+    fn hash_data(&self, input: &FieldElement<F>) -> [u8; 64] {
+        let mut hasher = Sha3_512::new();
+        hasher.update(input.to_bytes_be());
+        hasher.finalize().into()
+    }
+
+    fn hash_new_parent(&self, left: &[u8; 64], right: &[u8; 64]) -> [u8; 64] {
+        let mut hasher = Sha3_512::new();
+        hasher.update(left);
+        hasher.update(right);
+        hasher.finalize().into()
+    }
+
+    fn hash_leaves(&self, unhashed_leaves: &[Self::Data]) -> Vec<Self::Node> {
+        unhashed_leaves
+            .iter()
+            .map(|leaf| self.hash_data(leaf))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lambdaworks_math::field::{fields::u64_prime_field::U64PrimeField, element::FieldElement};
+
+    use crate::merkle_tree::{merkle::MerkleTree, backends::{sha3_512::Sha3_512Tree}};
+
+    
+    const MODULUS: u64 = 13;
+    type U64PF = U64PrimeField<MODULUS>;
+    type FE = FieldElement<U64PF>;
+    #[test]
+    fn hash_data_field_element_backend_works() {
+        let values: Vec<FE> = (1..6).map(FE::new).collect();
+        let merkle_tree = MerkleTree::<Sha3_512Tree<U64PF>>::build(&values);
+        let proof = merkle_tree.get_proof_by_pos(0).unwrap();
+        assert!(proof.verify::<Sha3_512Tree<U64PF>>(&merkle_tree.root, 0, &values[0]));
+    }
+}
+

--- a/crypto/src/merkle_tree/merkle.rs
+++ b/crypto/src/merkle_tree/merkle.rs
@@ -21,7 +21,7 @@ where
 
         //The length of leaves minus one inner node in the merkle tree
 
-        // This is not so clean
+        // The first elements are overwritten by build function, it doesn't matter what it's there
         let mut inner_nodes = vec![hashed_leaves[0].clone(); hashed_leaves.len() - 1];
         inner_nodes.extend(hashed_leaves);
 

--- a/crypto/src/merkle_tree/merkle.rs
+++ b/crypto/src/merkle_tree/merkle.rs
@@ -1,11 +1,3 @@
-use std::marker::PhantomData;
-
-use lambdaworks_math::{
-    field::{element::FieldElement, traits::IsField},
-    traits::ByteConversion,
-};
-use sha3::{Digest, Sha3_256};
-
 use super::{proof::Proof, traits::IsMerkleTreeBackend, utils::*};
 
 #[derive(Clone)]
@@ -28,7 +20,9 @@ where
         hashed_leaves = complete_until_power_of_two(&mut hashed_leaves);
 
         //The length of leaves minus one inner node in the merkle tree
-        let mut inner_nodes = vec![B::Node::default(); hashed_leaves.len() - 1];
+
+        // This is not so clean
+        let mut inner_nodes = vec![hashed_leaves[0].clone(); hashed_leaves.len() - 1];
         inner_nodes.extend(hashed_leaves);
 
         //Build the inner nodes of the tree
@@ -64,52 +58,13 @@ where
     }
 }
 
-#[derive(Clone)]
-pub struct FieldElementBackend<F> {
-    phantom: PhantomData<F>,
-}
 
-impl<F> Default for FieldElementBackend<F> {
-    fn default() -> Self {
-        Self {
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<F> IsMerkleTreeBackend for FieldElementBackend<F>
-where
-    F: IsField,
-    FieldElement<F>: ByteConversion,
-{
-    type Node = [u8; 32];
-    type Data = FieldElement<F>;
-
-    fn hash_data(&self, input: &FieldElement<F>) -> [u8; 32] {
-        let mut hasher = Sha3_256::new();
-        hasher.update(input.to_bytes_be());
-        let mut result_hash = [0_u8; 32];
-        result_hash.copy_from_slice(&hasher.finalize());
-        result_hash
-    }
-
-    fn hash_new_parent(&self, left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
-        let mut hasher = Sha3_256::new();
-        hasher.update(left);
-        hasher.update(right);
-        let mut result_hash = [0_u8; 32];
-        result_hash.copy_from_slice(&hasher.finalize());
-        result_hash
-    }
-}
 
 #[cfg(test)]
 mod tests {
     use lambdaworks_math::field::{element::FieldElement, fields::u64_prime_field::U64PrimeField};
 
     use crate::merkle_tree::{merkle::MerkleTree, test_merkle::TestBackend};
-
-    use super::FieldElementBackend;
 
     const MODULUS: u64 = 13;
     type U64PF = U64PrimeField<MODULUS>;
@@ -120,21 +75,5 @@ mod tests {
         let values: Vec<FE> = (1..5).map(FE::new).collect();
         let merkle_tree = MerkleTree::<TestBackend<U64PF>>::build(&values);
         assert_eq!(merkle_tree.root, FE::new(20));
-    }
-
-    #[test]
-    // expected | 8 | 7 | 1 | 6 | 1 | 7 | 7 | 2 | 4 | 6 | 8 | 10 | 10 | 10 | 10 |
-    fn build_merkle_tree_from_an_odd_set_of_leaves() {
-        let values: Vec<FE> = (1..6).map(FE::new).collect();
-        let merkle_tree = MerkleTree::<TestBackend<U64PF>>::build(&values);
-        assert_eq!(merkle_tree.root, FE::new(8));
-    }
-
-    #[test]
-    fn hash_data_field_element_backend_works() {
-        let values: Vec<FE> = (1..6).map(FE::new).collect();
-        let merkle_tree = MerkleTree::<FieldElementBackend<U64PF>>::build(&values);
-        let proof = merkle_tree.get_proof_by_pos(0).unwrap();
-        assert!(proof.verify::<FieldElementBackend<U64PF>>(&merkle_tree.root, 0, &values[0]));
     }
 }

--- a/crypto/src/merkle_tree/mod.rs
+++ b/crypto/src/merkle_tree/mod.rs
@@ -1,5 +1,6 @@
 pub mod merkle;
 pub mod proof;
+pub mod backends;
 #[cfg(test)]
 pub mod test_merkle;
 pub mod traits;

--- a/crypto/src/merkle_tree/traits.rs
+++ b/crypto/src/merkle_tree/traits.rs
@@ -2,7 +2,7 @@
 /// tree is built from. It also defines the `Node` type and the hash function
 /// used to build parent nodes from children nodes.
 pub trait IsMerkleTreeBackend: Default {
-    type Node: PartialEq + Eq + Clone + Default;
+    type Node: PartialEq + Eq + Clone;
     type Data;
 
     /// This function takes a single variable `Data` and converts it to a node.


### PR DESCRIPTION
# Sha3 512 and MerkleTree Backend

## Description

Add sha3 512, and moved all the backends to one folder

## Type of change

Please delete options that are not relevant.

- [x] New feature
