### PR TITLE
Fix `build-metal` rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ benchmark:
 flamegraph_stark:
 	CARGO_PROFILE_BENCH_DEBUG=true cargo flamegraph --root --bench stark_benchmarks -- --bench
 
-METAL_DIR = math/src/gpu/metal/shaders
+METAL_DIR = math/src/gpu/metal
 build-metal:
 	xcrun -sdk macosx metal $(METAL_DIR)/all.metal -o $(METAL_DIR)/lib.metallib
 


### PR DESCRIPTION
# Fix `build-metal` rule

## Description

The metal shaders path in the current Makefile is wrong.

## Type of change

- Bug fix
