### PR TITLE
add make command and readme section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,8 @@ build-cuda:
 
 docs:
 	cd docs && mdbook serve --open
+
+FUZZER = field_from_hex
+run-fuzzer:
+		cd fuzz
+		cargo +nightly fuzz run $(FUZZER)

--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ If you use ```Lambdaworks``` libraries in your research projects, please cite th
 
 ### Gadgets
 
+## Fuzzers
+
+Run a specific fuzzer from the ones contained in **fuzz/fuzz_targets/** folder with`cargo`, for example to run the one for the target `field_from_hex`:
+
+```bash
+make run-fuzzer FUZZER=field_from_hex
+```
+
 ## Documentation
 
 To serve the documentation locally, first install both [mdbook](https://rust-lang.github.io/mdBook/guide/installation.html) and the [Katex preprocessor](https://github.com/lzanini/mdbook-katex#getting-started) to render LaTeX, then run


### PR DESCRIPTION
# ADD MAKE COMMAND FOR FUZZERS 

## Description

This PR adds a command to run fuzzers in an easy way in the Makefile

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
