### PR TITLE
From Hex for PrimeField Elements

### DIFF
--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -416,7 +416,7 @@ impl<F: IsPrimeField> FieldElement<F> {
     /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring
     pub fn from_hex(hex_string: &str) -> Result<Self, CreationError> {
         Ok(Self {
-            value: F::from_hex(hex_string)?
+            value: F::from_hex(hex_string)?,
         })
     }
 }
@@ -589,7 +589,7 @@ mod tests {
         type FE = FieldElement<F>;
         assert_eq!(FE::from_hex("1a").unwrap(), FE::from(62))
     }
-    
+
     prop_compose! {
         fn field_element()(num in any::<u64>().prop_filter("Avoid null coefficients", |x| x != &0)) -> FieldElement::<Stark252PrimeField> {
             FieldElement::<Stark252PrimeField>::from(num)

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -411,6 +411,14 @@ impl<F: IsPrimeField> FieldElement<F> {
     pub fn legendre_symbol(&self) -> LegendreSymbol {
         F::legendre_symbol(&self.value)
     }
+
+    /// Creates a `FieldElement` from a hexstring. It can contain `0x` or not.
+    /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring
+    pub fn from_hex(hex_string: &str) -> Result<Self, CreationError> {
+        Ok(Self {
+            value: F::from_hex(hex_string)?
+        })
+    }
 }
 
 impl<M, const NUM_LIMBS: usize> fmt::Display
@@ -441,21 +449,6 @@ where
                 &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::MU,
             ),
         }
-    }
-
-    /// Creates a `FieldElement` from a hexstring. It can contain `0x` or not.
-    /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring
-    pub fn from_hex(hex: &str) -> Result<Self, CreationError> {
-        let integer = UnsignedInteger::<NUM_LIMBS>::from_hex(hex)?;
-
-        Ok(Self {
-            value: MontgomeryAlgorithms::cios(
-                &integer,
-                &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::R2,
-                &M::MODULUS,
-                &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::MU,
-            ),
-        })
     }
 }
 
@@ -590,6 +583,13 @@ mod tests {
         assert!(sqrt.is_none());
     }
 
+    #[test]
+    fn from_hex_1a_is_26_for_stark252_prime_field_element() {
+        type F = Stark252PrimeField;
+        type FE = FieldElement<F>;
+        assert_eq!(FE::from_hex("1a").unwrap(), FE::from(62))
+    }
+    
     prop_compose! {
         fn field_element()(num in any::<u64>().prop_filter("Avoid null coefficients", |x| x != &0)) -> FieldElement::<Stark252PrimeField> {
             FieldElement::<Stark252PrimeField>::from(num)

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -587,7 +587,7 @@ mod tests {
     fn from_hex_1a_is_26_for_stark252_prime_field_element() {
         type F = Stark252PrimeField;
         type FE = FieldElement<F>;
-        assert_eq!(FE::from_hex("1a").unwrap(), FE::from(62))
+        assert_eq!(FE::from_hex("1a").unwrap(), FE::from(26))
     }
 
     prop_compose! {

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -270,6 +270,18 @@ where
 
         evaluated_bit + 1
     }
+
+    fn from_hex(hex_string: &str) -> Result<Self::BaseType, crate::errors::CreationError> {
+        let integer =Self::BaseType::from_hex(hex_string)?;
+        Ok(
+            MontgomeryAlgorithms::cios(
+                &integer,
+                &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::R2,
+                &M::MODULUS,
+                &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::MU
+            )
+        )
+    }
 }
 
 impl<M, const NUM_LIMBS: usize> FieldElement<MontgomeryBackendPrimeField<M, NUM_LIMBS>> where

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -272,15 +272,13 @@ where
     }
 
     fn from_hex(hex_string: &str) -> Result<Self::BaseType, crate::errors::CreationError> {
-        let integer =Self::BaseType::from_hex(hex_string)?;
-        Ok(
-            MontgomeryAlgorithms::cios(
-                &integer,
-                &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::R2,
-                &M::MODULUS,
-                &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::MU
-            )
-        )
+        let integer = Self::BaseType::from_hex(hex_string)?;
+        Ok(MontgomeryAlgorithms::cios(
+            &integer,
+            &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::R2,
+            &M::MODULUS,
+            &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::MU,
+        ))
     }
 }
 

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -87,7 +87,6 @@ impl<const MODULUS: u64> IsPrimeField for U64PrimeField<MODULUS> {
     }
 
     fn from_hex(hex_string: &str) -> Result<Self::BaseType, CreationError> {
-
         let mut hex_string = hex_string;
         // Remove 0x if it's on the string
         let mut char_iterator = hex_string.chars();
@@ -164,21 +163,14 @@ mod tests {
     type F = U64PrimeField<MODULUS>;
     type FE = FieldElement<F>;
 
-
     #[test]
     fn from_hex_for_b_is_11() {
-        assert_eq!(
-            F::from_hex("B").unwrap(),
-            11
-        );
+        assert_eq!(F::from_hex("B").unwrap(), 11);
     }
 
     #[test]
     fn from_hex_for_0x1_a_is_26() {
-        assert_eq!(
-            F::from_hex("0x1a").unwrap(),
-            26
-        );
+        assert_eq!(F::from_hex("0x1a").unwrap(), 26);
     }
 
     #[test]

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -1,6 +1,7 @@
 use crate::cyclic_group::IsGroup;
 #[cfg(feature = "std")]
 use crate::errors::ByteConversionError::{FromBEBytesError, FromLEBytesError};
+use crate::errors::CreationError;
 #[cfg(feature = "std")]
 use crate::errors::DeserializationError;
 use crate::field::element::FieldElement;
@@ -84,6 +85,21 @@ impl<const MODULUS: u64> IsPrimeField for U64PrimeField<MODULUS> {
     fn field_bit_size() -> usize {
         ((MODULUS - 1).ilog2() + 1) as usize
     }
+
+    fn from_hex(hex_string: &str) -> Result<Self::BaseType, CreationError> {
+
+        let mut hex_string = hex_string;
+        // Remove 0x if it's on the string
+        let mut char_iterator = hex_string.chars();
+        if hex_string.len() > 2
+            && char_iterator.next().unwrap() == '0'
+            && char_iterator.next().unwrap() == 'x'
+        {
+            hex_string = &hex_string[2..];
+        }
+
+        u64::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
+    }
 }
 
 /// Represents an element in Fp. (E.g: 0, 1, 2 are the elements of F3)
@@ -145,7 +161,25 @@ impl<const MODULUS: u64> Deserializable for FieldElement<U64PrimeField<MODULUS>>
 mod tests {
     use super::*;
     const MODULUS: u64 = 13;
-    type FE = FieldElement<U64PrimeField<MODULUS>>;
+    type F = U64PrimeField<MODULUS>;
+    type FE = FieldElement<F>;
+
+
+    #[test]
+    fn from_hex_for_b_is_11() {
+        assert_eq!(
+            F::from_hex("B").unwrap(),
+            11
+        );
+    }
+
+    #[test]
+    fn from_hex_for_0x1_a_is_26() {
+        assert_eq!(
+            F::from_hex("0x1a").unwrap(),
+            26
+        );
+    }
 
     #[test]
     fn bit_size_of_mod_13_field_is_4() {

--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -1,4 +1,7 @@
-use crate::{field::traits::{IsFFTField, IsField, IsPrimeField}, errors::CreationError};
+use crate::{
+    errors::CreationError,
+    field::traits::{IsFFTField, IsField, IsPrimeField},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 
@@ -97,12 +100,9 @@ mod tests_u32_test_field {
 
     #[test]
     fn from_hex_for_b_is_11() {
-        assert_eq!(
-            U32TestField::from_hex("B").unwrap(),
-            11
-        );
+        assert_eq!(U32TestField::from_hex("B").unwrap(), 11);
     }
-    
+
     #[test]
     fn bit_size_of_test_field_is_31() {
         assert_eq!(

--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -1,4 +1,4 @@
-use crate::field::traits::{IsFFTField, IsField, IsPrimeField};
+use crate::{field::traits::{IsFFTField, IsField, IsPrimeField}, errors::CreationError};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 
@@ -65,6 +65,21 @@ impl<const MODULUS: u32> IsPrimeField for U32Field<MODULUS> {
     fn field_bit_size() -> usize {
         ((MODULUS - 1).ilog2() + 1) as usize
     }
+
+    /// Unimplemented for test fields
+    fn from_hex(hex_string: &str) -> Result<Self::BaseType, crate::errors::CreationError> {
+        let mut hex_string = hex_string;
+        // Remove 0x if it's on the string
+        let mut char_iterator = hex_string.chars();
+        if hex_string.len() > 2
+            && char_iterator.next().unwrap() == '0'
+            && char_iterator.next().unwrap() == 'x'
+        {
+            hex_string = &hex_string[2..];
+        }
+
+        u32::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
+    }
 }
 
 // 15 * 2^27 + 1;
@@ -78,8 +93,16 @@ impl IsFFTField for U32TestField {
 
 #[cfg(test)]
 mod tests_u32_test_field {
-    use crate::field::test_fields::u32_test_field::U32TestField;
+    use crate::field::{test_fields::u32_test_field::U32TestField, traits::IsPrimeField};
 
+    #[test]
+    fn from_hex_for_b_is_11() {
+        assert_eq!(
+            U32TestField::from_hex("B").unwrap(),
+            11
+        );
+    }
+    
     #[test]
     fn bit_size_of_test_field_is_31() {
         assert_eq!(

--- a/math/src/field/test_fields/u64_test_field.rs
+++ b/math/src/field/test_fields/u64_test_field.rs
@@ -1,4 +1,4 @@
-use crate::field::traits::{IsFFTField, IsField, IsPrimeField};
+use crate::{field::traits::{IsFFTField, IsField, IsPrimeField}, errors::CreationError};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct U64Field<const MODULUS: u64>;
@@ -64,6 +64,21 @@ impl<const MODULUS: u64> IsPrimeField for U64Field<MODULUS> {
     fn field_bit_size() -> usize {
         ((MODULUS - 1).ilog2() + 1) as usize
     }
+
+    /// Unimplemented for test fields
+    fn from_hex(hex_string: &str) -> Result<Self::BaseType, crate::errors::CreationError> {
+        let mut hex_string = hex_string;
+        // Remove 0x if it's on the string
+        let mut char_iterator = hex_string.chars();
+        if hex_string.len() > 2
+            && char_iterator.next().unwrap() == '0'
+            && char_iterator.next().unwrap() == 'x'
+        {
+            hex_string = &hex_string[2..];
+        }
+
+        u64::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
+    }
 }
 
 pub type U64TestField = U64Field<18446744069414584321>;
@@ -76,7 +91,15 @@ impl IsFFTField for U64TestField {
 
 #[cfg(test)]
 mod tests_u64_test_field {
-    use crate::field::test_fields::u64_test_field::U64TestField;
+    use crate::field::{test_fields::u64_test_field::U64TestField, traits::IsPrimeField};
+
+    #[test]
+    fn from_hex_for_b_is_11() {
+        assert_eq!(
+            U64TestField::from_hex("B").unwrap(),
+            11
+        );
+    }
 
     #[test]
     fn bit_size_of_test_field_is_64() {

--- a/math/src/field/test_fields/u64_test_field.rs
+++ b/math/src/field/test_fields/u64_test_field.rs
@@ -65,7 +65,6 @@ impl<const MODULUS: u64> IsPrimeField for U64Field<MODULUS> {
         ((MODULUS - 1).ilog2() + 1) as usize
     }
 
-    /// Unimplemented for test fields
     fn from_hex(hex_string: &str) -> Result<Self::BaseType, crate::errors::CreationError> {
         let mut hex_string = hex_string;
         // Remove 0x if it's on the string

--- a/math/src/field/test_fields/u64_test_field.rs
+++ b/math/src/field/test_fields/u64_test_field.rs
@@ -1,4 +1,7 @@
-use crate::{field::traits::{IsFFTField, IsField, IsPrimeField}, errors::CreationError};
+use crate::{
+    errors::CreationError,
+    field::traits::{IsFFTField, IsField, IsPrimeField},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct U64Field<const MODULUS: u64>;
@@ -94,10 +97,7 @@ mod tests_u64_test_field {
 
     #[test]
     fn from_hex_for_b_is_11() {
-        assert_eq!(
-            U64TestField::from_hex("B").unwrap(),
-            11
-        );
+        assert_eq!(U64TestField::from_hex("B").unwrap(), 11);
     }
 
     #[test]

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -151,6 +151,7 @@ pub trait IsPrimeField: IsField {
 
     /// Creates a BaseType from a Hex String
     /// 0x is optional
+    /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring
     fn from_hex(hex_string: &str) -> Result<Self::BaseType, CreationError>;
 
     /// Returns the number of bits of the max element of the field, as per field documentation, not internal representation.

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -1,5 +1,5 @@
 use super::{element::FieldElement, errors::FieldError};
-use crate::{unsigned_integer::traits::IsUnsignedInteger, errors::CreationError};
+use crate::{errors::CreationError, unsigned_integer::traits::IsUnsignedInteger};
 use core::fmt::Debug;
 
 /// Represents different configurations that powers of roots of unity can be in. Some of these may

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -1,5 +1,5 @@
 use super::{element::FieldElement, errors::FieldError};
-use crate::unsigned_integer::traits::IsUnsignedInteger;
+use crate::{unsigned_integer::traits::IsUnsignedInteger, errors::CreationError};
 use core::fmt::Debug;
 
 /// Represents different configurations that powers of roots of unity can be in. Some of these may
@@ -148,6 +148,10 @@ pub trait IsPrimeField: IsField {
     fn modulus_minus_one() -> Self::RepresentativeType {
         Self::representative(&Self::neg(&Self::one()))
     }
+
+    /// Creates a BaseType from a Hex String
+    /// 0x is optional
+    fn from_hex(hex_string: &str) -> Result<Self::BaseType, CreationError>;
 
     /// Returns the number of bits of the max element of the field, as per field documentation, not internal representation.
     /// This is `log2(max FE)` rounded up


### PR DESCRIPTION
# From Hex for PrimeField

## Description

Add from_hex for PrimeField elements, so it's avaible for generic functions that uses PrimeFields

## Type of change

Please delete options that are not relevant.

- [x] New feature
