### PR TITLE
Use Ruffini division in KZG open

### DIFF
--- a/crypto/src/commitments/kzg.rs
+++ b/crypto/src/commitments/kzg.rs
@@ -179,9 +179,9 @@ impl<const N: usize, F: IsPrimeField<RepresentativeType = UnsignedInteger<N>>, P
         p: &Polynomial<FieldElement<F>>,
     ) -> Self::Commitment {
         let value = p.evaluate(x);
-        let numerator = p + Polynomial::new_monomial(-&value, 0);
-        let denominator = Polynomial::new(&[-x, FieldElement::one()]);
-        self.commit(&(numerator / denominator))
+        let mut poly_to_commit = p + Polynomial::new_monomial(-&value, 0);
+        poly_to_commit.ruffini_division_inplace(x);
+        self.commit(&poly_to_commit)
     }
 
     #[allow(unused)]


### PR DESCRIPTION
# Use ruffini division in KZG open

## Description

Replace long division by Ruffini's rule