### PR TITLE
Fix wasm for crypto package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Run cargo check for math with wasm target
         run: cargo check --package lambdaworks-math --no-default-features --target wasm32-unknown-unknown
 
+      - name: Run cargo check for crypto with wasm target
+        run: cargo check --package lambdaworks-crypto --no-default-features --target wasm32-unknown-unknown
+
       - name: Run cargo build ensure-no_std crate
         run: |
           cd ensure-no_std

--- a/README.md
+++ b/README.md
@@ -57,12 +57,16 @@ You can check the generated HTML report in `target/criterion/reports/index.html`
 - [ABI compatible KZG commitment scheme - EIP-4844](https://github.com/lambdaclass/lambdaworks_kzg)
 
 ## Main crates
+
 - [Finite Field Algebra](https://github.com/lambdaclass/lambdaworks/tree/main/math/src/field)
 - [Polynomial operations](https://github.com/lambdaclass/lambdaworks/blob/main/math/src/polynomial.rs)
 - [Fast Fourier Transform](https://github.com/lambdaclass/lambdaworks/tree/main/fft)
 - [Elliptic curves](https://github.com/lambdaclass/lambdaworks/tree/main/math/src/elliptic_curve)
 - [Multiscalar multiplication](https://github.com/lambdaclass/lambdaworks/tree/main/math/src/msm)
 
+Finite Field crate fully supports no-std with `no-default-features`
+
+Both Math and Crypto support wasm with target `wasm32-unknown-unknown` by default, with `std` feature.
 ## Exercises and Challenges
 - [Lambdaworks exercises and challenges](https://github.com/lambdaclass/lambdaworks_exercises/tree/main)
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,12 +13,10 @@ sha3 = "0.10.6"
 sha2 = "0.10.6"
 thiserror = "1.0.38"
 
-[dependencies.rand]
-version = "0.8"
-
 [dev-dependencies]
 criterion = "0.4"
 iai-callgrind.workspace = true
+rand = "0.8.5"
 
 [features]
 test_fiat_shamir = []

--- a/gpu/Cargo.toml
+++ b/gpu/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 
 [dependencies]
 thiserror = "1.0.38"
-rand = "0.8.5"
 metal = { version = "0.24.0", optional = true }
 objc = { version = "0.2.7", optional = true }
 
@@ -27,6 +26,7 @@ default = []
 
 [dev-dependencies]
 proptest = "1.1.0"
+rand = "0.8.5"
 
 [build-dependencies]
 walkdir = { version = "2.3.3", optional = true }


### PR DESCRIPTION
# Fix wasm for crypto

## Description

Rand should be in dev dependencies. Since it's the only thing not compatible with wasm, this makes crypto compile in wasm.

Adds a check in the CI for crypto and wasm

Documents in the readme the support for wasm

I've also moved rand in GPU to dev dependency. This is not needed for crypto, but it's not needed in general dependencies.

## Type of change

Please delete options that are not relevant.

- [x] New feature