### PR TITLE
bugfix: Fix `UnsignedInteger::bits_le` + make it pub

### DIFF
--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -794,7 +794,8 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         let mut i = 0;
         while i < NUM_LIMBS {
             if self.limbs[i] != 0 {
-                return u64::BITS as usize * (NUM_LIMBS - i) - self.limbs[i].leading_zeros() as usize
+                return u64::BITS as usize * (NUM_LIMBS - i)
+                    - self.limbs[i].leading_zeros() as usize;
             }
             i += 1;
         }

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -790,14 +790,15 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
 
     #[inline(always)]
     /// Returns the number of bits needed to represent the number as little endian
-    const fn bits_le(&self) -> usize {
+    pub const fn bits_le(&self) -> usize {
         let mut i = 0;
-        while i < NUM_LIMBS && self.limbs[i] == 0 {
+        while i < NUM_LIMBS {
+            if self.limbs[i] != 0 {
+                return u64::BITS as usize * (NUM_LIMBS - i) - self.limbs[i].leading_zeros() as usize
+            }
             i += 1;
         }
-
-        let limb = self.limbs[i];
-        u64::BITS as usize * (NUM_LIMBS - i) - limb.leading_zeros() as usize
+        0
     }
 
     /// Computes self / rhs, returns the quotient, remainder.


### PR DESCRIPTION
The method currently panicks with 'index out of bounds' when self is zero

Description of the pull request changes and motivation.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
