### PR TITLE
perf: replace asserts by debug_asserts

### DIFF
--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -149,7 +149,7 @@ impl<const NUM_LIMBS: usize> Sub<&UnsignedInteger<NUM_LIMBS>> for &UnsignedInteg
 
     fn sub(self, other: &UnsignedInteger<NUM_LIMBS>) -> UnsignedInteger<NUM_LIMBS> {
         let (result, overflow) = UnsignedInteger::sub(self, other);
-        assert!(!overflow, "UnsignedInteger subtraction overflow.");
+        debug_assert!(!overflow, "UnsignedInteger subtraction overflow.");
         result
     }
 }
@@ -804,7 +804,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
 
     /// Computes self / rhs, returns the quotient, remainder.
     pub fn div_rem(&self, rhs: &Self) -> (Self, Self) {
-        assert!(
+        debug_assert!(
             *rhs != UnsignedInteger::from_u64(0),
             "Attempted to divide by zero"
         );


### PR DESCRIPTION
Runtime assertions to validate inputs were consuming a significant
amount of time in benchmarks.

Measured on an M1, based on branch `fix_felt_benchmarks` with the
`ark-ff` code commented out to reduce noise we observe the following
changes:

```
add | lambdaworks       time:   [12.273 µs 12.278 µs 12.285 µs]
                        change: [-63.107% -63.042% -62.979%] (p = 0.00 < 0.05)
                        Performance has improved.
invert | lambdaworks    time:   [26.858 ms 26.864 ms 26.871 ms]
                        change: [-7.8986% -7.8611% -7.8231%] (p = 0.00 < 0.05)
                        Performance has improved.
mul | lambdaworks       time:   [63.604 µs 63.622 µs 63.645 µs]
                        change: [-0.1615% -0.0957% -0.0332%] (p = 0.00 < 0.05)
                        Change within noise threshold.
pow | lambdaworks       time:   [12.594 ms 12.599 ms 12.604 ms]
                        change: [-0.4536% -0.4009% -0.3481%] (p = 0.00 < 0.05)
                        Change within noise threshold.
sqrt | lambdaworks      time:   [139.76 ms 139.79 ms 139.82 ms]
                        change: [-0.1288% -0.1015% -0.0730%] (p = 0.00 < 0.05)
                        Change within noise threshold.
sub | lambdaworks       time:   [13.518 µs 13.529 µs 13.542 µs]
                        change: [-19.474% -18.102% -17.059%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## Type of change

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added/run
