### PR TITLE
Improve benches

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -8,6 +8,7 @@ ark-ff = { git = "https://github.com/arkworks-rs/algebra", rev = "ef8f758" }
 ark-test-curves = { git = "https://github.com/arkworks-rs/algebra", rev = "ef8f758" }
 ark-std = "0.4.0"
 rand = "0.8.5"
+rand_chacha = "0.3.1"
 
 [dependencies.lambdaworks-math]
 path = "../math"

--- a/benches/benches/add.rs
+++ b/benches/benches/add.rs
@@ -15,14 +15,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     // arkworks-ff
     {
         c.bench_function(
-            &format!(
-                "{} 10000 elements | ark-ff - ef8f758",
-                BENCHMARK_NAME
-            ),
+            &format!("{} 10000 elements | ark-ff - ef8f758", BENCHMARK_NAME),
             |b| {
                 b.iter(|| {
                     let mut iter = arkworks_vec.iter();
-                    
+
                     for _i in 0..10000 {
                         let a = iter.next().unwrap();
                         let b = iter.next().unwrap();
@@ -37,17 +34,20 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let lambdaworks_vec = to_lambdaworks_vec(&arkworks_vec);
 
-        c.bench_function(&format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,), |b| {
-            b.iter(|| {
-                let mut iter = lambdaworks_vec.iter();
+        c.bench_function(
+            &format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,),
+            |b| {
+                b.iter(|| {
+                    let mut iter = lambdaworks_vec.iter();
 
-                for _i in 0..10000 {
-                    let a = iter.next().unwrap();
-                    let b = iter.next().unwrap();
-                    black_box(black_box(&a).add(black_box(b)));
-                }
-            });
-        });
+                    for _i in 0..10000 {
+                        let a = iter.next().unwrap();
+                        let b = iter.next().unwrap();
+                        black_box(black_box(&a).add(black_box(b)));
+                    }
+                });
+            },
+        );
     }
 }
 

--- a/benches/benches/add.rs
+++ b/benches/benches/add.rs
@@ -37,7 +37,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let lambdaworks_vec = to_lambdaworks_vec(&arkworks_vec);
 
-        c.bench_function(&format!("{} | lambdaworks", BENCHMARK_NAME,), |b| {
+        c.bench_function(&format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,), |b| {
             b.iter(|| {
                 let mut iter = lambdaworks_vec.iter();
 

--- a/benches/benches/add.rs
+++ b/benches/benches/add.rs
@@ -16,14 +16,14 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         c.bench_function(
             &format!(
-                "{} | ark-ff - branch: faster-benchmarks-and-starknet-field",
+                "{} 10000 random elements | ark-ff - ef8f758",
                 BENCHMARK_NAME
             ),
             |b| {
                 b.iter(|| {
                     let mut iter = arkworks_vec.iter();
-
-                    for _i in 0..5000 {
+                    
+                    for _i in 0..10000 {
                         let a = iter.next().unwrap();
                         let b = iter.next().unwrap();
                         black_box(black_box(&a).add(black_box(b)));
@@ -41,7 +41,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 let mut iter = lambdaworks_vec.iter();
 
-                for _i in 0..5000 {
+                for _i in 0..10000 {
                     let a = iter.next().unwrap();
                     let b = iter.next().unwrap();
                     black_box(black_box(&a).add(black_box(b)));

--- a/benches/benches/add.rs
+++ b/benches/benches/add.rs
@@ -16,7 +16,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         c.bench_function(
             &format!(
-                "{} 10000 random elements | ark-ff - ef8f758",
+                "{} 10000 elements | ark-ff - ef8f758",
                 BENCHMARK_NAME
             ),
             |b| {

--- a/benches/benches/invert.rs
+++ b/benches/benches/invert.rs
@@ -9,7 +9,7 @@ pub mod utils;
 const BENCHMARK_NAME: &str = "invert";
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let arkworks_vec = generate_random_elements();
+    let arkworks_vec = generate_random_elements()[0..10000].to_vec();
 
     // arkworks-ff
     {
@@ -36,7 +36,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let lambdaworks_vec = to_lambdaworks_vec(&arkworks_vec);
 
-        c.bench_function(&format!("{} | lambdaworks", BENCHMARK_NAME,), |b| {
+        c.bench_function(&format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,), |b| {
             b.iter(|| {
                 for elem in lambdaworks_vec.iter() {
                     black_box(black_box(&elem).inv());

--- a/benches/benches/invert.rs
+++ b/benches/benches/invert.rs
@@ -14,10 +14,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     // arkworks-ff
     {
         c.bench_function(
-            &format!(
-                "{} 10000 elements| ark-ff - ef8f758",
-                BENCHMARK_NAME
-            ),
+            &format!("{} 10000 elements| ark-ff - ef8f758", BENCHMARK_NAME),
             |b| {
                 b.iter_batched(
                     || arkworks_vec.clone(),
@@ -36,13 +33,16 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let lambdaworks_vec = to_lambdaworks_vec(&arkworks_vec);
 
-        c.bench_function(&format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,), |b| {
-            b.iter(|| {
-                for elem in lambdaworks_vec.iter() {
-                    black_box(black_box(&elem).inv());
-                }
-            });
-        });
+        c.bench_function(
+            &format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,),
+            |b| {
+                b.iter(|| {
+                    for elem in lambdaworks_vec.iter() {
+                        black_box(black_box(&elem).inv());
+                    }
+                });
+            },
+        );
     }
 }
 

--- a/benches/benches/invert.rs
+++ b/benches/benches/invert.rs
@@ -15,7 +15,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         c.bench_function(
             &format!(
-                "{} | ark-ff - branch: faster-benchmarks-and-starknet-field",
+                "{} 10000 elements| ark-ff - ef8f758",
                 BENCHMARK_NAME
             ),
             |b| {

--- a/benches/benches/mul.rs
+++ b/benches/benches/mul.rs
@@ -15,14 +15,14 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         c.bench_function(
             &format!(
-                "{} | ark-ff - branch: faster-benchmarks-and-starknet-field",
+                "{} 10000 elements | ark-ff - commit: ef8f758 ",
                 BENCHMARK_NAME
             ),
             |b| {
                 b.iter(|| {
                     let mut iter = arkworks_vec.iter();
 
-                    for _i in 0..5000 {
+                    for _i in 0..10000 {
                         let a = iter.next().unwrap();
                         let b = iter.next().unwrap();
                         black_box(black_box(a).mul(black_box(b)));
@@ -40,7 +40,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 let mut iter = lambdaworks_vec.iter();
 
-                for _i in 0..5000 {
+                for _i in 0..10000 {
                     let a = iter.next().unwrap();
                     let b = iter.next().unwrap();
                     black_box(black_box(&a).mul(black_box(b)));

--- a/benches/benches/mul.rs
+++ b/benches/benches/mul.rs
@@ -36,7 +36,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let lambdaworks_vec = to_lambdaworks_vec(&arkworks_vec);
 
-        c.bench_function(&format!("{} | lambdaworks", BENCHMARK_NAME,), |b| {
+        c.bench_function(&format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,), |b| {
             b.iter(|| {
                 let mut iter = lambdaworks_vec.iter();
 

--- a/benches/benches/mul.rs
+++ b/benches/benches/mul.rs
@@ -36,17 +36,20 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let lambdaworks_vec = to_lambdaworks_vec(&arkworks_vec);
 
-        c.bench_function(&format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,), |b| {
-            b.iter(|| {
-                let mut iter = lambdaworks_vec.iter();
+        c.bench_function(
+            &format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,),
+            |b| {
+                b.iter(|| {
+                    let mut iter = lambdaworks_vec.iter();
 
-                for _i in 0..10000 {
-                    let a = iter.next().unwrap();
-                    let b = iter.next().unwrap();
-                    black_box(black_box(&a).mul(black_box(b)));
-                }
-            });
-        });
+                    for _i in 0..10000 {
+                        let a = iter.next().unwrap();
+                        let b = iter.next().unwrap();
+                        black_box(black_box(&a).mul(black_box(b)));
+                    }
+                });
+            },
+        );
     }
 }
 

--- a/benches/benches/pow.rs
+++ b/benches/benches/pow.rs
@@ -13,7 +13,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let arkworks_vec = generate_random_elements();
 
     let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(9001);
-    
+
     let mut v_ints = Vec::new();
     for _i in 0..10000 {
         v_ints.push(rng.gen::<u64>());
@@ -22,10 +22,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     // arkworks-ff
     {
         c.bench_function(
-            &format!(
-                "{} 10000 elements | ark-ff - ef8f758",
-                BENCHMARK_NAME
-            ),
+            &format!("{} 10000 elements | ark-ff - ef8f758", BENCHMARK_NAME),
             |b| {
                 b.iter(|| {
                     let mut iter = arkworks_vec.iter();
@@ -45,18 +42,21 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let lambdaworks_vec = to_lambdaworks_vec(&arkworks_vec);
 
-        c.bench_function(&format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,), |b| {
-            b.iter(|| {
-                let mut iter = lambdaworks_vec.iter();
-                let mut iter_ints = v_ints.iter();
+        c.bench_function(
+            &format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,),
+            |b| {
+                b.iter(|| {
+                    let mut iter = lambdaworks_vec.iter();
+                    let mut iter_ints = v_ints.iter();
 
-                for _i in 0..10000 {
-                    let a = iter.next().unwrap();
-                    let exp = iter_ints.next().unwrap();
-                    black_box(black_box(&a).pow(black_box(*exp)));
-                }
-            });
-        });
+                    for _i in 0..10000 {
+                        let a = iter.next().unwrap();
+                        let exp = iter_ints.next().unwrap();
+                        black_box(black_box(&a).pow(black_box(*exp)));
+                    }
+                });
+            },
+        );
     }
 }
 

--- a/benches/benches/pow.rs
+++ b/benches/benches/pow.rs
@@ -1,6 +1,6 @@
 use ark_ff::Field;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use rand::Rng;
+use rand::{Rng, SeedableRng};
 use utils::generate_random_elements;
 
 use crate::utils::to_lambdaworks_vec;
@@ -12,7 +12,8 @@ const BENCHMARK_NAME: &str = "pow";
 pub fn criterion_benchmark(c: &mut Criterion) {
     let arkworks_vec = generate_random_elements();
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(9001);
+    
     let mut v_ints = Vec::new();
     for _i in 0..10000 {
         v_ints.push(rng.gen::<u64>());
@@ -22,7 +23,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         c.bench_function(
             &format!(
-                "{} | ark-ff - branch: faster-benchmarks-and-starknet-field",
+                "{} 10000 elements | ark-ff - ef8f758",
                 BENCHMARK_NAME
             ),
             |b| {

--- a/benches/benches/pow.rs
+++ b/benches/benches/pow.rs
@@ -45,7 +45,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let lambdaworks_vec = to_lambdaworks_vec(&arkworks_vec);
 
-        c.bench_function(&format!("{} | lambdaworks", BENCHMARK_NAME,), |b| {
+        c.bench_function(&format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,), |b| {
             b.iter(|| {
                 let mut iter = lambdaworks_vec.iter();
                 let mut iter_ints = v_ints.iter();

--- a/benches/benches/sqrt.rs
+++ b/benches/benches/sqrt.rs
@@ -23,7 +23,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         c.bench_function(
             &format!(
-                "{} | ark-ff - branch: faster-benchmarks-and-starknet-field",
+                "{} 10000 elements | ark-ff - ef8f758",
                 BENCHMARK_NAME
             ),
             |b| {

--- a/benches/benches/sqrt.rs
+++ b/benches/benches/sqrt.rs
@@ -1,5 +1,5 @@
 use ark_ff::Field;
-use ark_std::{test_rng, UniformRand};
+use ark_std::UniformRand;
 use ark_test_curves::starknet_fp::Fq as F;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
@@ -10,7 +10,7 @@ pub mod utils;
 const BENCHMARK_NAME: &str = "sqrt";
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let mut rng = test_rng();
+    let mut rng = <rand_chacha::ChaCha20Rng as rand::SeedableRng>::seed_from_u64(9001);
 
     let mut arkworks_vec = Vec::new();
     for _i in 0..1000 {
@@ -23,7 +23,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         c.bench_function(
             &format!(
-                "{} 10000 elements | ark-ff - ef8f758",
+                "{} 1000 elements | ark-ff - ef8f758",
                 BENCHMARK_NAME
             ),
             |b| {
@@ -43,7 +43,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let lambdaworks_vec = to_lambdaworks_vec(&arkworks_vec);
 
-        c.bench_function(&format!("{} | lambdaworks", BENCHMARK_NAME,), |b| {
+        c.bench_function(&format!("{} 1000 elements | lambdaworks", BENCHMARK_NAME,), |b| {
             b.iter(|| {
                 let mut iter = lambdaworks_vec.iter();
 

--- a/benches/benches/sqrt.rs
+++ b/benches/benches/sqrt.rs
@@ -22,10 +22,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     // arkworks-ff
     {
         c.bench_function(
-            &format!(
-                "{} 1000 elements | ark-ff - ef8f758",
-                BENCHMARK_NAME
-            ),
+            &format!("{} 1000 elements | ark-ff - ef8f758", BENCHMARK_NAME),
             |b| {
                 b.iter(|| {
                     let mut iter = arkworks_vec.iter();
@@ -43,16 +40,19 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let lambdaworks_vec = to_lambdaworks_vec(&arkworks_vec);
 
-        c.bench_function(&format!("{} 1000 elements | lambdaworks", BENCHMARK_NAME,), |b| {
-            b.iter(|| {
-                let mut iter = lambdaworks_vec.iter();
+        c.bench_function(
+            &format!("{} 1000 elements | lambdaworks", BENCHMARK_NAME,),
+            |b| {
+                b.iter(|| {
+                    let mut iter = lambdaworks_vec.iter();
 
-                for _i in 0..1000 {
-                    let a = iter.next().unwrap();
-                    black_box(black_box(a).sqrt());
-                }
-            });
-        });
+                    for _i in 0..1000 {
+                        let a = iter.next().unwrap();
+                        black_box(black_box(a).sqrt());
+                    }
+                });
+            },
+        );
     }
 }
 

--- a/benches/benches/sub.rs
+++ b/benches/benches/sub.rs
@@ -33,7 +33,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     // lambdaworks-math
     {
         let lambdaworks_vec = to_lambdaworks_vec(&arkworks_vec);
-        c.bench_function(&format!("{} | lambdaworks", BENCHMARK_NAME,), |b| {
+        c.bench_function(&format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,), |b| {
             b.iter(|| {
                 let mut iter = lambdaworks_vec.iter();
 

--- a/benches/benches/sub.rs
+++ b/benches/benches/sub.rs
@@ -12,10 +12,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     // arkworks-ff
     {
         c.bench_function(
-            &format!(
-                "{} 10000 elements | ark-ff - ef8f758",
-                BENCHMARK_NAME
-            ),
+            &format!("{} 10000 elements | ark-ff - ef8f758", BENCHMARK_NAME),
             |b| {
                 b.iter(|| {
                     let mut iter = arkworks_vec.iter();
@@ -33,17 +30,20 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     // lambdaworks-math
     {
         let lambdaworks_vec = to_lambdaworks_vec(&arkworks_vec);
-        c.bench_function(&format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,), |b| {
-            b.iter(|| {
-                let mut iter = lambdaworks_vec.iter();
+        c.bench_function(
+            &format!("{} 10000 elements | lambdaworks", BENCHMARK_NAME,),
+            |b| {
+                b.iter(|| {
+                    let mut iter = lambdaworks_vec.iter();
 
-                for _i in 0..10000 {
-                    let a = iter.next().unwrap();
-                    let b = iter.next().unwrap();
-                    black_box(black_box(&a).sub(black_box(b)));
-                }
-            });
-        });
+                    for _i in 0..10000 {
+                        let a = iter.next().unwrap();
+                        let b = iter.next().unwrap();
+                        black_box(black_box(&a).sub(black_box(b)));
+                    }
+                });
+            },
+        );
     }
 }
 

--- a/benches/benches/sub.rs
+++ b/benches/benches/sub.rs
@@ -13,14 +13,14 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         c.bench_function(
             &format!(
-                "{} | ark-ff - branch: faster-benchmarks-and-starknet-field",
+                "{} 10000 elements | ark-ff - ef8f758",
                 BENCHMARK_NAME
             ),
             |b| {
                 b.iter(|| {
                     let mut iter = arkworks_vec.iter();
 
-                    for _i in 0..5000 {
+                    for _i in 0..10000 {
                         let a = iter.next().unwrap();
                         let b = iter.next().unwrap();
                         black_box(black_box(&a).sub(black_box(b)));
@@ -37,7 +37,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 let mut iter = lambdaworks_vec.iter();
 
-                for _i in 0..5000 {
+                for _i in 0..10000 {
                     let a = iter.next().unwrap();
                     let b = iter.next().unwrap();
                     black_box(black_box(&a).sub(black_box(b)));

--- a/benches/benches/utils.rs
+++ b/benches/benches/utils.rs
@@ -1,5 +1,5 @@
 use ark_ff::BigInt;
-use ark_std::{UniformRand};
+use ark_std::UniformRand;
 use ark_test_curves::starknet_fp::Fq;
 use lambdaworks_math::{
     field::{

--- a/benches/benches/utils.rs
+++ b/benches/benches/utils.rs
@@ -1,5 +1,5 @@
 use ark_ff::BigInt;
-use ark_std::{test_rng, UniformRand};
+use ark_std::{UniformRand};
 use ark_test_curves::starknet_fp::Fq;
 use lambdaworks_math::{
     field::{
@@ -7,11 +7,13 @@ use lambdaworks_math::{
     },
     unsigned_integer::element::UnsignedInteger,
 };
+use rand::SeedableRng;
 
+/// Creates 20000 random elements
 pub fn generate_random_elements() -> Vec<Fq> {
-    let mut rng = test_rng();
+    let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(9001);
     let mut arkworks_vec = Vec::new();
-    for _i in 0..10000 {
+    for _i in 0..20000 {
         let a = Fq::rand(&mut rng);
         arkworks_vec.push(a);
     }


### PR DESCRIPTION
# General improvements for the benches

## Description

- Fix seed so results are always the same
- Fixed all benchmarks but sqrt to use 10000 operations with random elements
- Add the amount of operations made to the text of the benchmarks, so it's clear the time measured it's not one operation
- Updated the text that shows which arkworks version is used 

## Type of change

- [x] New feature