### PR TITLE
perf: use overflowing_add for UnsignedInteger::add

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,21 @@ ARM - M1
 
 | Operation| N    | Arkworks  | Lambdaworks |
 | -------- | --- | --------- | ----------- |
-| `mul`    |   10k  | 115 μs | 117 μs   |
-| `add`    |   1M  | 8.6 ms  | 7.3 ms    |
-| `sub`    |   1M  | 7.57 ms   | 7.27 ms     |
-| `pow`    |   10k  | 11.5 ms   | 12.6 ms    |
-| `invert` |  10k   | 33.3 ms  | 30.7 ms   | 
+| `mul`    |   10k  | 112 μs | 115 μs   |
+| `add`    |   1M  | 8.5 ms  | 7.0 ms    |
+| `sub`    |   1M  | 7.53 ms   | 7.12 ms     |
+| `pow`    |   10k  | 11.2 ms   | 12.4 ms    |
+| `invert` |  10k   | 30.0 ms  | 27.2 ms   |
 
 x86 - AMD Ryzen 7 PRO 
 
 | Operation | N    | Arkworks (ASM)*  | Lambdaworks |
 | -------- | --- | --------- | ----------- |
-| `mul`    |   10k  | 102.7 us | 94.4 us   
-| `add`    |   1M  | 4.9 ms  | 5.6 ms    |
-| `sub`    |   1M  |  4.5 ms  |  5.3 ms   
-| `pow`    |   10k  |  10.5 ms   | 9.7 ms    |
-| `invert` |  10k   | 33.4 ms  | 37.45 ms |
+| `mul`    |   10k  | 118.9 us | 95.7 us   |
+| `add`    |   1M  | 6.8 ms  | 5.4 ms    |
+| `sub`    |   1M  |  6.6 ms  |  5.2 ms   |
+| `pow`    |   10k  |  10.6 ms   | 9.4 ms    |
+| `invert` |  10k   | 34.2 ms  | 35.74 ms |
 
 *assembly feature was enabled manually for that bench, and is not activated by default when running criterion
 

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -554,12 +554,13 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         b: &UnsignedInteger<NUM_LIMBS>,
     ) -> (UnsignedInteger<NUM_LIMBS>, bool) {
         let mut limbs = [0u64; NUM_LIMBS];
-        let mut carry = 0u128;
+        let mut carry = 0u64;
         let mut i = NUM_LIMBS;
         while i > 0 {
-            let c: u128 = a.limbs[i - 1] as u128 + b.limbs[i - 1] as u128 + carry;
-            limbs[i - 1] = c as u64;
-            carry = c >> 64;
+            let (x, cb) = a.limbs[i - 1].overflowing_add(b.limbs[i - 1]);
+            let (x, cc) = x.overflowing_add(carry);
+            limbs[i - 1] = x;
+            carry = (cb | cc) as u64;
             i -= 1;
         }
         (UnsignedInteger { limbs }, carry > 0)


### PR DESCRIPTION
This allows using only `u64` variables and gives a bit more information
to the compiler about our intent.

Results on M1 with 16GB:
```
add 1M elements | lambdaworks
                        time:   [7.0109 ms 7.0278 ms 7.0465 ms]
                        change: [-29.850% -29.645% -29.430%] (p = 0.00 < 0.01)
                        Performance has improved.
```

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added/run
