### PR TITLE
perf: split sos_square loop

### DIFF
--- a/math/src/unsigned_integer/montgomery.rs
+++ b/math/src/unsigned_integer/montgomery.rs
@@ -163,19 +163,19 @@ impl MontgomeryAlgorithms {
             c = 0;
             let m = (lo.limbs[i] as u128 * *mu as u128) as u64;
             let mut j = NUM_LIMBS;
+            while i + j > NUM_LIMBS - 1 {
+                j -= 1;
+                let index = i + j - (NUM_LIMBS - 1);
+                let cs = lo.limbs[index] as u128 + m as u128 * (q.limbs[j] as u128) + c;
+                c = cs >> 64;
+                lo.limbs[index] = cs as u64;
+            }
             while j > 0 {
                 j -= 1;
-                if i + j >= NUM_LIMBS - 1 {
-                    let index = i + j - (NUM_LIMBS - 1);
-                    let cs = lo.limbs[index] as u128 + m as u128 * (q.limbs[j] as u128) + c;
-                    c = cs >> 64;
-                    lo.limbs[index] = cs as u64;
-                } else {
-                    let index = i + j + 1;
-                    let cs = hi.limbs[index] as u128 + m as u128 * (q.limbs[j] as u128) + c;
-                    c = cs >> 64;
-                    hi.limbs[index] = cs as u64;
-                }
+                let index = i + j + 1;
+                let cs = hi.limbs[index] as u128 + m as u128 * (q.limbs[j] as u128) + c;
+                c = cs >> 64;
+                hi.limbs[index] = cs as u64;
             }
 
             // Carry propagation to `hi`


### PR DESCRIPTION
Splits loop in `sos_square` to reduce branching.

Benches were executed with the following command:
```
for i in {1..5}; do cargo bench --bench pow -- lambda; don
```
Repetitions are performed to deal with potential inconsistent results.

Results on M1:
```
# On main
[12.653 ms 12.823 ms 13.032 ms]
[12.423 ms 12.454 ms 12.500 ms]
[12.412 ms 12.430 ms 12.451 ms]
[12.420 ms 12.478 ms 12.551 ms]
[12.391 ms 12.402 ms 12.414 ms]

# On this branch
[10.409 ms 10.413 ms 10.419 ms]
[10.447 ms 10.457 ms 10.469 ms]
[10.410 ms 10.413 ms 10.416 ms]
[10.413 ms 10.417 ms 10.421 ms]
[10.410 ms 10.413 ms 10.417 ms]
```

Results on Ryzen server:
```
# On main
[9.5494 ms 9.5504 ms 9.5514 ms]
[9.4520 ms 9.4525 ms 9.4529 ms]
[9.6071 ms 9.6078 ms 9.6086 ms]
[9.4917 ms 9.4923 ms 9.4930 ms]
[9.4929 ms 9.4935 ms 9.4942 ms]

# On this branch
[9.4187 ms 9.4201 ms 9.4217 ms]
[9.5338 ms 9.5351 ms 9.5368 ms]
[9.4870 ms 9.4877 ms 9.4885 ms]
[9.4757 ms 9.4764 ms 9.4772 ms]
[9.4760 ms 9.4766 ms 9.4772 ms]
```

Results on Neoverse-N1 server:
```
# On main
[36.200 ms 36.218 ms 36.245 ms]
[36.184 ms 36.190 ms 36.196 ms]
[36.309 ms 36.476 ms 36.683 ms]
[36.281 ms 36.353 ms 36.468 ms]
[36.180 ms 36.182 ms 36.185 ms]

# On this branch
[36.353 ms 36.554 ms 36.819 ms]
[36.215 ms 36.232 ms 36.252 ms]
[36.265 ms 36.293 ms 36.324 ms]
[36.214 ms 36.230 ms 36.249 ms]
[36.234 ms 36.259 ms 36.289 ms]
```

Results on EPYC server:
```
# On main
[14.950 ms 15.141 ms 15.353 ms]
[14.679 ms 14.783 ms 14.906 ms]
[14.644 ms 14.740 ms 14.852 ms]
[14.911 ms 15.182 ms 15.490 ms]
[15.295 ms 15.517 ms 15.760 ms]

# On this branch
[14.388 ms 14.534 ms 14.700 ms]
[14.563 ms 14.721 ms 14.888 ms]
[14.593 ms 14.790 ms 15.002 ms]
[14.697 ms 14.882 ms 15.085 ms]
[14.103 ms 14.193 ms 14.292 ms]
```

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added/run
