### PR TITLE
feat(proptest): Implement `proptest::Arbitrary` for `UnsignedInteger`

### DIFF
--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 thiserror = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
-proptest = "1.1.0"
+proptest = { version = "1.1.0", optional = true }
 
 # rayon
 rayon = { version = "1.7", optional = true }
@@ -30,12 +30,14 @@ rand = { version = "0.8.5", default-features = false }
 criterion = "0.4"
 const-random = "0.1.15"
 iai-callgrind.workspace = true
+proptest = "1.1.0"
 
 [features]
 rayon = ["dep:rayon"]
 default = ["rayon", "std"]
 std = ["dep:thiserror"]
 lambdaworks-serde = ["dep:serde", "dep:serde_json", "std"]
+proptest = ["dep:proptest"]
 
 # gpu
 metal = [

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 thiserror = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
+proptest = "1.1.0"
 
 # rayon
 rayon = { version = "1.7", optional = true }
@@ -25,8 +26,7 @@ cudarc = { version = "0.9.7", optional = true }
 lambdaworks-gpu = { workspace = true, optional = true }
 
 [dev-dependencies]
-rand = { version = "0.8.5", default-features = false}
-proptest = "1.1.0"
+rand = { version = "0.8.5", default-features = false }
 criterion = "0.4"
 const-random = "0.1.15"
 iai-callgrind.workspace = true

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -958,16 +958,9 @@ impl<const NUM_LIMBS: usize> Arbitrary for UnsignedInteger<NUM_LIMBS> {
 
 #[cfg(test)]
 mod tests_u384 {
-    use core::ops::Shr;
 
     use crate::traits::ByteConversion;
     use crate::unsigned_integer::element::{UnsignedInteger, U384};
-
-    use proptest::prelude::*;
-
-    const N_LIMBS: usize = 6;
-    type Uint = U384;
-
 
     #[cfg(feature = "proptest")]
     proptest! {
@@ -2010,16 +2003,10 @@ mod tests_u384 {
 
 #[cfg(test)]
 mod tests_u256 {
-    use core::ops::Shr;
 
     use crate::unsigned_integer::element::{UnsignedInteger, U256};
 
     use crate::unsigned_integer::element::ByteConversion;
-
-    use proptest::prelude::*;
-
-    const N_LIMBS: usize = 4;
-    type Uint = U256;
 
     #[cfg(feature = "proptest")]
     proptest! {

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -5,9 +5,12 @@ use core::ops::{
     Sub,
 };
 
-use proptest::prelude::any;
-use proptest::strategy::Strategy;
-use proptest::{arbitrary::Arbitrary, strategy::SBoxedStrategy};
+#[cfg(feature = "proptest")]
+use proptest::{
+    arbitrary::Arbitrary,
+    prelude::any,
+    strategy::{SBoxedStrategy, Strategy},
+};
 
 use crate::errors::ByteConversionError;
 use crate::errors::CreationError;
@@ -853,6 +856,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         Ok(res)
     }
 
+    #[cfg(feature = "proptest")]
     pub fn nonzero_uint() -> impl Strategy<Value = UnsignedInteger<NUM_LIMBS>> {
         any_uint::<NUM_LIMBS>().prop_filter("is_zero", |&x| x != UnsignedInteger::from_u64(0))
     }
@@ -935,10 +939,12 @@ impl<const NUM_LIMBS: usize> From<UnsignedInteger<NUM_LIMBS>> for u16 {
     }
 }
 
+#[cfg(feature = "proptest")]
 fn any_uint<const NUM_LIMBS: usize>() -> impl Strategy<Value = UnsignedInteger<NUM_LIMBS>> {
     any::<[u64; NUM_LIMBS]>().prop_map(|limbs| UnsignedInteger::from_limbs(limbs))
 }
 
+#[cfg(feature = "proptest")]
 impl<const NUM_LIMBS: usize> Arbitrary for UnsignedInteger<NUM_LIMBS> {
     type Parameters = ();
 
@@ -963,7 +969,8 @@ mod tests_u384 {
 
     proptest! {
         #[test]
-        fn bitand(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
+        #[cfg(feature = "proptest")]
+        fn bitand(a in any::<Uint>(), b in any::<Uint>()) {
             let result = Uint::from_limbs(a) & Uint::from_limbs(b);
 
             for i in 0..N_LIMBS {
@@ -972,6 +979,7 @@ mod tests_u384 {
         }
 
         #[test]
+        #[cfg(feature = "proptest")]
         fn bitand_assign(a in any::<Uint>(), b in any::<Uint>()) {
             let mut result = a;
             result &= b;
@@ -982,6 +990,7 @@ mod tests_u384 {
         }
 
         #[test]
+        #[cfg(feature = "proptest")]
         fn bitor(a in any::<Uint>(), b in any::<Uint>()) {
             let result = a | b;
 
@@ -991,6 +1000,7 @@ mod tests_u384 {
         }
 
         #[test]
+        #[cfg(feature = "proptest")]
         fn bitor_assign(a in any::<Uint>(), b in any::<Uint>()) {
             let mut result = a;
             result |= b;
@@ -1001,6 +1011,7 @@ mod tests_u384 {
         }
 
         #[test]
+        #[cfg(feature = "proptest")]
         fn bitxor(a in any::<Uint>(), b in any::<Uint>()) {
             let result = a ^ b;
 
@@ -1010,6 +1021,7 @@ mod tests_u384 {
         }
 
         #[test]
+        #[cfg(feature = "proptest")]
         fn bitxor_assign(a in any::<Uint>(), b in any::<Uint>()) {
             let mut result = a;
             result ^= b;
@@ -1020,6 +1032,7 @@ mod tests_u384 {
         }
 
         #[test]
+        #[cfg(feature = "proptest")]
         fn div_rem(a in any::<Uint>(), b in any::<Uint>()) {
             let a = a.shr(256);
             let b = b.shr(256);
@@ -2014,6 +2027,7 @@ mod tests_u256 {
 
     proptest! {
         #[test]
+        #[cfg(feature = "proptest")]
         fn bitand(a in any::<Uint>(), b in any::<Uint>()) {
             let result = a & b;
 
@@ -2023,6 +2037,7 @@ mod tests_u256 {
         }
 
         #[test]
+        #[cfg(feature = "proptest")]
         fn bitand_assign(a in any::<Uint>(), b in any::<Uint>()) {
             let mut result = a;
             result &= b;
@@ -2033,6 +2048,7 @@ mod tests_u256 {
         }
 
         #[test]
+        #[cfg(feature = "proptest")]
         fn bitor(a in any::<Uint>(), b in any::<Uint>()) {
             let result = a | b;
 
@@ -2042,6 +2058,7 @@ mod tests_u256 {
         }
 
         #[test]
+        #[cfg(feature = "proptest")]
         fn bitor_assign(a in any::<Uint>(), b in any::<Uint>()) {
             let mut result = a;
             result |= b;
@@ -2052,6 +2069,7 @@ mod tests_u256 {
         }
 
         #[test]
+        #[cfg(feature = "proptest")]
         fn bitxor(a in any::<Uint>(), b in any::<Uint>()) {
             let result = a ^ b;
 
@@ -2061,6 +2079,7 @@ mod tests_u256 {
         }
 
         #[test]
+        #[cfg(feature = "proptest")]
         fn bitxor_assign(a in any::<Uint>(), b in any::<Uint>()) {
             let mut result = a;
             result ^= b;
@@ -2071,6 +2090,7 @@ mod tests_u256 {
         }
 
         #[test]
+        #[cfg(feature = "proptest")]
         fn div_rem(a in any::<Uint>(), b in any::<Uint>()) {
             let a = a.shr(128);
             let b = b.shr(128);

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -967,9 +967,10 @@ mod tests_u384 {
     const N_LIMBS: usize = 6;
     type Uint = U384;
 
+
+    #[cfg(feature = "proptest")]
     proptest! {
         #[test]
-        #[cfg(feature = "proptest")]
         fn bitand(a in any::<Uint>(), b in any::<Uint>()) {
             let result = Uint::from_limbs(a) & Uint::from_limbs(b);
 
@@ -979,7 +980,6 @@ mod tests_u384 {
         }
 
         #[test]
-        #[cfg(feature = "proptest")]
         fn bitand_assign(a in any::<Uint>(), b in any::<Uint>()) {
             let mut result = a;
             result &= b;
@@ -990,7 +990,6 @@ mod tests_u384 {
         }
 
         #[test]
-        #[cfg(feature = "proptest")]
         fn bitor(a in any::<Uint>(), b in any::<Uint>()) {
             let result = a | b;
 
@@ -1000,7 +999,6 @@ mod tests_u384 {
         }
 
         #[test]
-        #[cfg(feature = "proptest")]
         fn bitor_assign(a in any::<Uint>(), b in any::<Uint>()) {
             let mut result = a;
             result |= b;
@@ -1011,7 +1009,6 @@ mod tests_u384 {
         }
 
         #[test]
-        #[cfg(feature = "proptest")]
         fn bitxor(a in any::<Uint>(), b in any::<Uint>()) {
             let result = a ^ b;
 
@@ -1021,7 +1018,6 @@ mod tests_u384 {
         }
 
         #[test]
-        #[cfg(feature = "proptest")]
         fn bitxor_assign(a in any::<Uint>(), b in any::<Uint>()) {
             let mut result = a;
             result ^= b;
@@ -1032,7 +1028,6 @@ mod tests_u384 {
         }
 
         #[test]
-        #[cfg(feature = "proptest")]
         fn div_rem(a in any::<Uint>(), b in any::<Uint>()) {
             let a = a.shr(256);
             let b = b.shr(256);
@@ -2025,9 +2020,9 @@ mod tests_u256 {
     const N_LIMBS: usize = 4;
     type Uint = U256;
 
+    #[cfg(feature = "proptest")]
     proptest! {
         #[test]
-        #[cfg(feature = "proptest")]
         fn bitand(a in any::<Uint>(), b in any::<Uint>()) {
             let result = a & b;
 
@@ -2037,7 +2032,6 @@ mod tests_u256 {
         }
 
         #[test]
-        #[cfg(feature = "proptest")]
         fn bitand_assign(a in any::<Uint>(), b in any::<Uint>()) {
             let mut result = a;
             result &= b;
@@ -2048,7 +2042,6 @@ mod tests_u256 {
         }
 
         #[test]
-        #[cfg(feature = "proptest")]
         fn bitor(a in any::<Uint>(), b in any::<Uint>()) {
             let result = a | b;
 
@@ -2058,7 +2051,6 @@ mod tests_u256 {
         }
 
         #[test]
-        #[cfg(feature = "proptest")]
         fn bitor_assign(a in any::<Uint>(), b in any::<Uint>()) {
             let mut result = a;
             result |= b;
@@ -2069,7 +2061,6 @@ mod tests_u256 {
         }
 
         #[test]
-        #[cfg(feature = "proptest")]
         fn bitxor(a in any::<Uint>(), b in any::<Uint>()) {
             let result = a ^ b;
 
@@ -2079,7 +2070,6 @@ mod tests_u256 {
         }
 
         #[test]
-        #[cfg(feature = "proptest")]
         fn bitxor_assign(a in any::<Uint>(), b in any::<Uint>()) {
             let mut result = a;
             result ^= b;
@@ -2090,7 +2080,6 @@ mod tests_u256 {
         }
 
         #[test]
-        #[cfg(feature = "proptest")]
         fn div_rem(a in any::<Uint>(), b in any::<Uint>()) {
             let a = a.shr(128);
             let b = b.shr(128);

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -972,57 +972,57 @@ mod tests_u384 {
         }
 
         #[test]
-        fn bitand_assign(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
-            let mut result = Uint::from_limbs(a);
-            result &= Uint::from_limbs(b);
+        fn bitand_assign(a in any::<Uint>(), b in any::<Uint>()) {
+            let mut result = a;
+            result &= b;
 
             for i in 0..N_LIMBS {
-                assert_eq!(result.limbs[i], a[i] & b[i]);
+                assert_eq!(result.limbs[i], a.limbs[i] & b.limbs[i]);
             }
         }
 
         #[test]
-        fn bitor(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
-            let result = Uint::from_limbs(a) | Uint::from_limbs(b);
+        fn bitor(a in any::<Uint>(), b in any::<Uint>()) {
+            let result = a | b;
 
             for i in 0..N_LIMBS {
-                assert_eq!(result.limbs[i], a[i] | b[i]);
+                assert_eq!(result.limbs[i], a.limbs[i] | b.limbs[i]);
             }
         }
 
         #[test]
-        fn bitor_assign(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
-            let mut result = Uint::from_limbs(a);
-            result |= Uint::from_limbs(b);
+        fn bitor_assign(a in any::<Uint>(), b in any::<Uint>()) {
+            let mut result = a;
+            result |= b;
 
             for i in 0..N_LIMBS {
-                assert_eq!(result.limbs[i], a[i] | b[i]);
+                assert_eq!(result.limbs[i], a.limbs[i] | b.limbs[i]);
             }
         }
 
         #[test]
-        fn bitxor(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
-            let result = Uint::from_limbs(a) ^ Uint::from_limbs(b);
+        fn bitxor(a in any::<Uint>(), b in any::<Uint>()) {
+            let result = a ^ b;
 
             for i in 0..N_LIMBS {
-                assert_eq!(result.limbs[i], a[i] ^ b[i]);
+                assert_eq!(result.limbs[i], a.limbs[i] ^ b.limbs[i]);
             }
         }
 
         #[test]
-        fn bitxor_assign(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
-            let mut result = Uint::from_limbs(a);
-            result ^= Uint::from_limbs(b);
+        fn bitxor_assign(a in any::<Uint>(), b in any::<Uint>()) {
+            let mut result = a;
+            result ^= b;
 
             for i in 0..N_LIMBS {
-                assert_eq!(result.limbs[i], a[i] ^ b[i]);
+                assert_eq!(result.limbs[i], a.limbs[i] ^ b.limbs[i]);
             }
         }
 
         #[test]
-        fn div_rem(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
-            let a = Uint::from_limbs(a).shr(256);
-            let b = Uint::from_limbs(b).shr(256);
+        fn div_rem(a in any::<Uint>(), b in any::<Uint>()) {
+            let a = a.shr(256);
+            let b = b.shr(256);
             assert_eq!((a * b).div_rem(&b), (a, Uint::from_u64(0)));
         }
     }
@@ -2014,66 +2014,66 @@ mod tests_u256 {
 
     proptest! {
         #[test]
-        fn bitand(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
-            let result = Uint::from_limbs(a) & Uint::from_limbs(b);
+        fn bitand(a in any::<Uint>(), b in any::<Uint>()) {
+            let result = a & b;
 
             for i in 0..N_LIMBS {
-                assert_eq!(result.limbs[i], a[i] & b[i]);
+                assert_eq!(result.limbs[i], a.limbs[i] & b.limbs[i]);
             }
         }
 
         #[test]
-        fn bitand_assign(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
-            let mut result = Uint::from_limbs(a);
-            result &= Uint::from_limbs(b);
+        fn bitand_assign(a in any::<Uint>(), b in any::<Uint>()) {
+            let mut result = a;
+            result &= b;
 
             for i in 0..N_LIMBS {
-                assert_eq!(result.limbs[i], a[i] & b[i]);
+                assert_eq!(result.limbs[i], a.limbs[i] & b.limbs[i]);
             }
         }
 
         #[test]
-        fn bitor(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
-            let result = Uint::from_limbs(a) | Uint::from_limbs(b);
+        fn bitor(a in any::<Uint>(), b in any::<Uint>()) {
+            let result = a | b;
 
             for i in 0..N_LIMBS {
-                assert_eq!(result.limbs[i], a[i] | b[i]);
+                assert_eq!(result.limbs[i], a.limbs[i] | b.limbs[i]);
             }
         }
 
         #[test]
-        fn bitor_assign(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
-            let mut result = Uint::from_limbs(a);
-            result |= Uint::from_limbs(b);
+        fn bitor_assign(a in any::<Uint>(), b in any::<Uint>()) {
+            let mut result = a;
+            result |= b;
 
             for i in 0..N_LIMBS {
-                assert_eq!(result.limbs[i], a[i] | b[i]);
+                assert_eq!(result.limbs[i], a.limbs[i] | b.limbs[i]);
             }
         }
 
         #[test]
-        fn bitxor(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
-            let result = Uint::from_limbs(a) ^ Uint::from_limbs(b);
+        fn bitxor(a in any::<Uint>(), b in any::<Uint>()) {
+            let result = a ^ b;
 
             for i in 0..N_LIMBS {
-                assert_eq!(result.limbs[i], a[i] ^ b[i]);
+                assert_eq!(result.limbs[i], a.limbs[i] ^ b.limbs[i]);
             }
         }
 
         #[test]
-        fn bitxor_assign(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
-            let mut result = Uint::from_limbs(a);
-            result ^= Uint::from_limbs(b);
+        fn bitxor_assign(a in any::<Uint>(), b in any::<Uint>()) {
+            let mut result = a;
+            result ^= b;
 
             for i in 0..N_LIMBS {
-                assert_eq!(result.limbs[i], a[i] ^ b[i]);
+                assert_eq!(result.limbs[i], a.limbs[i] ^ b.limbs[i]);
             }
         }
 
         #[test]
-        fn div_rem(a in any::<[u64; N_LIMBS]>(), b in any::<[u64; N_LIMBS]>()) {
-            let a = Uint::from_limbs(a).shr(128);
-            let b = Uint::from_limbs(b).shr(128);
+        fn div_rem(a in any::<Uint>(), b in any::<Uint>()) {
+            let a = a.shr(128);
+            let b = b.shr(128);
             assert_eq!((a * b).div_rem(&b), (a, Uint::from_u64(0)));
         }
     }


### PR DESCRIPTION
Closes #414 

Adds an implementation of `proptest::Arbitrary` for `UnsignedInteger`. Refactors proptests to use `any::<UnsignedInteger>()`
