### PR TITLE
Fix possible multiplication overflow in `UnsignedInteger::from_dec_str`

### DIFF
--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -844,11 +844,11 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
             if b > 9 {
                 return Err(CreationError::InvalidDecString);
             }
-            let (high, low) = Self::mul(res, Self::from(10_u64)) + Self::from(b as u64);
+            let (high, low) = Self::mul(res, Self::from(10_u64));
             if high > Self::from_u64(0) {
                 return Err(CreationError::InvalidDecString);
             }
-            res = low;
+            res = low + Self::from(b as u64);
         }
         Ok(res)
     }

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -844,8 +844,11 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
             if b > 9 {
                 return Err(CreationError::InvalidDecString);
             }
-            let r = res * Self::from(10_u64) + Self::from(b as u64);
-            res = r;
+            let (high, low) = Self::mul(&res, &Self::from(10_u64 + b as u64));
+            if high > Self::from_u64(0) {
+                return Err(CreationError::InvalidDecString);
+            }
+            res = low;
         }
         Ok(res)
     }

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -844,7 +844,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
             if b > 9 {
                 return Err(CreationError::InvalidDecString);
             }
-            let (high, low) = Self::mul(&res, &Self::from(10_u64 + b as u64));
+            let (high, low) = Self::mul(res, Self::from(10_u64)) + Self::from(b as u64);
             if high > Self::from_u64(0) {
                 return Err(CreationError::InvalidDecString);
             }

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -844,7 +844,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
             if b > 9 {
                 return Err(CreationError::InvalidDecString);
             }
-            let (high, low) = Self::mul(res, Self::from(10_u64));
+            let (high, low) = Self::mul(&res, &Self::from(10_u64));
             if high > Self::from_u64(0) {
                 return Err(CreationError::InvalidDecString);
             }


### PR DESCRIPTION
# Fix possible multiplication overflow in UnsignedInteger::from_dec_str

## Description

The method `UnsignedInteger::from_dec_str` uses the `Mul` operation when constructing the resulting Unsignedinteger, this can cause a multiplication overflow if the number in the dec string is too large.
This pr changes the code to use the `mul` function instead, which returns a high and low part, and returns an error if the high part is not zero.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
