### PR TITLE
fix: broken links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Right now Plonk prover is in this repo, you can find the others here:
 ## Main crates
 
 - [Math](https://github.com/lambdaclass/lambdaworks/tree/main/math)
-- [Crypto primitives](https://github.com/lambdaclass/lambdaworks/crypto)
-- [Plonk Prover](https://github.com/lambdaclass/lambdaworks/provers/plonk)
+- [Crypto primitives](https://github.com/lambdaclass/lambdaworks/tree/main/crypto)
+- [Plonk Prover](https://github.com/lambdaclass/lambdaworks/tree/main/provers/plonk)
 
 ### Crypto
 - [Elliptic curves](https://github.com/lambdaclass/lambdaworks/tree/main/math/src/elliptic_curve)


### PR DESCRIPTION
Broken links in Readme fix

## Description
This PR solves #550 
The links to the Crypto primitives and Plonk Prover are broken.

## Type of change
- [X] Bug fix

## Checklist
- [X] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
