### PR TITLE
Update readmes with the info of the old repos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,9 @@ jobs:
           toolchain: stable
           targets: wasm32-unknown-unknown
 
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Run cargo check
         run: cargo check
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,9 +24,6 @@ jobs:
           toolchain: stable
           targets: wasm32-unknown-unknown
 
-      - name: Set up cargo cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Run cargo check
         run: cargo check
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ From the heights of these towers of fields, forty centuries of mathematics look 
 
 </div>
 
+## [Documentation](https://lambdaclass.github.io/lambdaworks)
+
 Zero-Knowledge and Validity Proofs have gained a lot of attention over the last few years. We strongly believe in this potential and that is why we decided to start working in this challenging ecosystem, where math, cryptography and distributed systems meet. The main barrier in the beginning was not the cryptography or math but the lack of good libraries which are performant and developer friendly. There are some exceptions, though, like gnark or halo2. Some have nice APIs and are easy to work with, but they are not written in Rust, and some are written in Rust but have poor programming and engineering practices. Most of them don't have support for CUDA, Metal and WebGPU or distributed FFT calculation using schedulers like Dask.
 
 So, we decided to build our library, focusing on performance, with clear documentation and developer-focused. Our core team is a group of passionate people from different backgrounds and different strengths; we think that the whole is greater than just the addition of the parts. We don't want to be a compilation of every research result in the ZK space. We want this to be a library that can be used in production, not just in academic research. We want to offer developers the main building blocks and proof systems so that they can build their applications on top of this library.

--- a/References.md
+++ b/References.md
@@ -1,11 +1,14 @@
 # References
 
-## GPU
-- [Yrrid and MatterLabs combined solution for MSM](https://github.com/matter-labs/z-prize-msm-gpu-combined)
-- [FFT library](https://developer.nvidia.com/cufft)
-- [snarks with GPU](https://github.com/MariusVanDerWijden/gpusnarks)
-- [FFTW](https://fftw.org/)
-- [FFT with hadoop and CUDA](https://arxiv.org/pdf/1407.6915.pdf)
+The following links, repos and projects have been important in the development of this library and we want to thank and acknowledge them. 
+## Finite Fields
+- [zkcrypto](https://github.com/zkcrypto/ff)
+- [Nilfoundation's crypto 3 multiprecision](https://github.com/nilfoundation/crypto3-multiprecision)
+- [Montgomery REDC](https://jeffhurchalla.com/2022/04/28/montgomery-redc-using-the-positive-inverse-mod-r/)
+- [Domb's fast modular multiplication](http://ingonyama.com/s/modular_multiplication.pdf)
+- [Rust crypto bigint](https://github.com/RustCrypto/crypto-bigint)
+- [Cairo felt](https://github.com/lambdaclass/cairo-rs/blob/main/felt/src/lib.rs)
+- [Various optimizations](https://github.com/mratsim/constantine/blob/master/docs/optimizations.md)
 
 ## PLONK
 - [Simplified Plonk](https://hackmd.io/vUGG8CO_Rk2iEjruBL_gGw?view#Note-A-Mind-Boggling-Issue-with-Ultra-Plonk)
@@ -21,16 +24,6 @@
 
 ## Groth16
 - [Proof forgery](https://medium.com/ppio/how-to-generate-a-groth16-proof-for-forgery-9f857b0dcafd)
-
-
-## Finite Fields
-- [zkcrypto](https://github.com/zkcrypto/ff)
-- [Nilfoundation's crypto 3 multiprecision](https://github.com/nilfoundation/crypto3-multiprecision)
-- [Montgomery REDC](https://jeffhurchalla.com/2022/04/28/montgomery-redc-using-the-positive-inverse-mod-r/)
-- [Domb's fast modular multiplication](http://ingonyama.com/s/modular_multiplication.pdf)
-- [Rust crypto bigint](https://github.com/RustCrypto/crypto-bigint)
-- [Cairo felt](https://github.com/lambdaclass/cairo-rs/blob/main/felt/src/lib.rs)
-- [Various optimizations](https://github.com/mratsim/constantine/blob/master/docs/optimizations.md)
 
 ## Elliptic curves
 - [Pairing-friendly curves](https://members.loria.fr/AGuillevic/pairing-friendly-curves/)
@@ -52,20 +45,47 @@
 - [Caulk Paper](https://eprint.iacr.org/2022/621.pdf)
 - [Plook Up Paper](https://eprint.iacr.org/2020/315.pdf)
 
-## Starks
+## Starks, FRI & Stark VMs
+- [Anatomy of a Stark](https://aszepieniec.github.io/stark-anatomy/overview)
+- [Anatomy of a Stark](https://neptune.cash/learn/stark-anatomy/fri/)
+- [BrainSTARK](https://aszepieniec.github.io/stark-brainfuck/)
+- [CAIRO verifier](https://github.com/starkware-libs/cairo-lang/tree/master/src/starkware/cairo/stark_verifier)
+- [CAIRO whitepaper](https://eprint.iacr.org/2021/1063.pdf)
+- [Chiplets Miden VM](https://wiki.polygon.technology/docs/miden/design/chiplets/main/)
+- [DEEP FRI Video](https://www.youtube.com/watch?v=txo_kPSn59Y&list=PLcIyXLwiPilWvjvNkhMn283LV370Pk5CT&index=6)
+- [DEEP FRI](https://eprint.iacr.org/2019/336)
 - [DeepFRI](https://eprint.iacr.org/2019/336.pdf)
-- [FRI](https://eccc.weizmann.ac.il/report/2017/134/)
-- [Starks](https://starkware.co/wp-content/uploads/2022/05/STARK-paper.pdf)
+- [Diving DEEP FRI](https://blog.lambdaclass.com/diving-deep-fri/)
+- [EthSTARK - Git](https://github.com/starkware-libs/ethSTARK/tree/master)
 - [EthStark](https://eprint.iacr.org/2021/582.pdf)
-- [Starks-101](https://starkware.co/stark-101/)
-- [Starks-101-Github](https://github.com/starkware-industries/stark101)
+- [FRI](https://eccc.weizmann.ac.il/report/2017/134/)
+- [Giza](https://github.com/maxgillett/giza)
+- [Gnark](https://github.com/Consensys/gnark)
+- [Low-degree testing](https://medium.com/starkware/low-degree-testing-f7614f5172db)
+- [Ministark](https://github.com/andrewmilson/ministark)
+- [Periodic constraints](https://blog.lambdaclass.com/periodic-constraints-and-recursion-in-zk-starks/)
+- [Plonky2](https://github.com/mir-protocol/plonky2)
+- [Risc0](https://github.com/risc0/risc0)
+- [STARKs paper](https://eprint.iacr.org/2018/046)
+- [Sandstorm](https://github.com/andrewmilson/sandstorm)
+- [Solidity Verifier](https://github.com/starkware-libs/starkex-contracts/tree/master/evm-verifier/solidity/contracts/cpu)
 - [Starks arithmetization-1](https://medium.com/starkware/arithmetization-i-15c046390862)
 - [Starks arithmetization-2](https://medium.com/starkware/arithmetization-ii-403c3b3f4355)
-- [Low-degree testing](https://medium.com/starkware/low-degree-testing-f7614f5172db)
+- [Starks-101-Github](https://github.com/starkware-industries/stark101)
+- [Starks-101](https://starkware.co/stark-101/)
+- [Starks](https://starkware.co/wp-content/uploads/2022/05/STARK-paper.pdf)
+- [Summary on FRI low degree test](https://eprint.iacr.org/2022/1216)
+- [Thank goodness it's FRIday](https://vitalik.ca/general/2017/11/22/starks_part_2.html)
+- [Valida](https://github.com/valida-xyz/valida/tree/main)
 - [Winterfell](https://github.com/facebook/winterfell)
-- [Anatomy of a Stark](https://neptune.cash/learn/stark-anatomy/fri/)
-- [DEEP FRI video](https://www.youtube.com/watch?v=txo_kPSn59Y&list=PLcIyXLwiPilWvjvNkhMn283LV370Pk5CT&index=6)
+## GPU
+- [Yrrid and MatterLabs combined solution for MSM](https://github.com/matter-labs/z-prize-msm-gpu-combined)
+- [FFT library](https://developer.nvidia.com/cufft)
+- [snarks with GPU](https://github.com/MariusVanDerWijden/gpusnarks)
+- [FFTW](https://fftw.org/)
+- [FFT with hadoop and CUDA](https://arxiv.org/pdf/1407.6915.pdf)
 
+## Cairo prover
 ## FHE
 - [Zama](https://github.com/zama-ai/concrete-core)
 - [Sunscreen](https://github.com/Sunscreen-tech/Sunscreen)
@@ -74,10 +94,13 @@
 - [SEAL](https://github.com/microsoft/SEAL)
 
 ## Miscellanea
+- [Arkworks](https://github.com/arkworks-rs)
+- [Aztec](https://github.com/AztecProtocol)
+- [BitwiseOperations](https://hackmd.io/vejHasuZSVWZOafBLNS_YQ)
+- [Blake3](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf)
 - [FastCrypto-MystenLabs](https://github.com/MystenLabs/fastcrypto/tree/main/fastcrypto-zkp)
+- [Neptune](https://github.com/Neptune-Crypto)
+- [OlaVM](https://github.com/Sin7Y/olavm/blob/main/docs/olavm/olavm_sepc.pdf)
 - [Wycheproof](https://github.com/google/wycheproof)
 - [zeroize](https://docs.rs/zeroize/latest/zeroize/)
 - [zkNotebook](https://github.com/hecmas/zkNotebook)
-- [BitwiseOperations](https://hackmd.io/vejHasuZSVWZOafBLNS_YQ)
-- [Blake3](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf)
-- [OlaVM](https://github.com/Sin7Y/olavm/blob/main/docs/olavm/olavm_sepc.pdf)

--- a/provers/cairo/README.md
+++ b/provers/cairo/README.md
@@ -1,0 +1,208 @@
+<div align="center">
+
+# 🌟 Lambdaworks Cairo Platinum Prover 🌟
+
+<img src="https://github.com/lambdaclass/lambdaworks_stark_platinum/assets/569014/ad8d7943-f011-49b5-a0c5-f07e5ef4133e" alt="drawing" width="300"/>
+
+## An open-source Cairo prover
+
+</div>
+
+[![Telegram Chat][tg-badge]][tg-url]
+
+[tg-badge]: https://img.shields.io/static/v1?color=green&logo=telegram&label=chat&style=flat&message=join
+[tg-url]: https://t.me/+98Whlzql7Hs0MDZh
+
+
+## ⚠️ Disclaimer
+
+This prover is still in development and may contain bugs. It is not intended to be used in production yet. 
+
+Please check issues under security label, and wait for them to be resolved if they are relevant your project.
+
+Output builtin is finished, and range check is supported but it's not sound yet. 
+
+We expect to have something working in a good state by mid August 2023.
+
+CLI currently runs with 100 bits of conjecturable security
+
+## [Documentation]([lambdaclass.github.io/lambdaworks/](https://lambdaclass.github.io/lambdaworks/starks/cairo.html))
+
+## Table of Contents
+
+- [🌟 Lambdaworks Cairo Platinum Prover 🌟](#-lambdaworks-cairo-platinum-prover-)
+  - [An open-source Cairo prover](#an-open-source-cairo-prover)
+  - [⚠️ Disclaimer](#️-disclaimer)
+  - [Documentation](#documentation)
+  - [Table of Contents](#table-of-contents)
+  - [To be added](#to-be-added)
+  - [Requirements](#requirements)
+  - [How to try it](#how-to-try-it)
+    - [🚀 Prove and verify](#-prove-and-verify)
+    - [Using Docker compiler for Cairo 0 programs](#using-docker-compiler-for-cairo-0-programs)
+    - [Using cairo-compile for Cairo 0 programs](#using-cairo-compile-for-cairo-0-programs)
+    - [Using WASM verifier](#using-wasm-verifier)
+  - [Running tests](#running-tests)
+  - [Running fuzzers](#running-fuzzers)
+  - [📚 References](#-references)
+  - [🌞 Related Projects](#-related-projects)
+
+## To be added
+
+To be added:
+- CLI Improvements
+-  Add parameters for proving and verifying in the CLI / (Public inputs should be serialized and deserialized)
+-  Add Cairo compilation inside Rust, to prove and verify Cairo1/Cairo2 from the .cairo file, instead of the .casm file
+-  Add last constraint of Range Check Built In
+-  Add more parallelization
+-  Benchmarks and optimizations for Graviton
+-  Bitwise Builtin
+-  Cairo Verifier
+   - Batch verifier / For trees and N proofs
+-  Chiplet support
+-  Different layouts
+-  Pedersen Builtin
+-  Pick hash configuration with ProofOptions
+-  Poseidon Builtin
+
+## Requirements
+
+- Cargo 1.69+
+  
+## How to try it
+
+### 🚀 Prove and verify
+
+To prove Cairo 0 programs without arguments you can use:
+
+```bash
+make prove PROGRAM_PATH=<compiled_program_path> PROOF_PATH=<output_proof_path>
+```
+
+To verify a proof you can use:
+  
+```bash
+make verify PROOF_PATH=<proof_path>
+```
+
+For example:
+
+```bash
+make prove PROGRAM_PATH=fibonacci.json PROOF_PATH=fibonacci_proof
+make verify PROOF_PATH=fibonacci_proof
+```
+
+To prove and verify with a single command you can use:
+
+```bash
+make run_all PROGRAM_PATH=<proof_path>
+```
+
+### Using Docker compiler for Cairo 0 programs
+
+Build the compiler image with:
+
+```bash
+make docker_build_cairo_compiler
+```
+
+Then for example, if you have a Cairo program in the project folder, you can use:
+
+```bash
+make docker_compile_and_run_all PROGRAM=program_name.cairo
+```
+
+Or
+
+```bash
+make docker_compile_and_prove PROGRAM=program_name.cairo PROOF_PATH=proof_path
+```
+
+### Using cairo-compile for Cairo 0 programs
+
+If you have `cairo-lang` installed, you can use it instead of the Dockerfile
+
+Then for example, if you have some Cairo program in the project folder, you can use:
+
+```bash
+make compile_and_run_all PROGRAM=program_name.cairo
+```
+
+Or 
+
+```bash
+make compile_and_prove PROGRAM=program_name.cairo PROOF_PATH=proof_path
+```
+
+### Using WASM verifier
+
+To use the verifier in WASM, generate a npm package using `wasm-pack`
+
+As a shortcut, you can call
+`make build_wasm`
+## Running tests
+To run tests, simply use
+```
+make test
+```
+If you have the `cairo-lang` toolchain installed, this will compile the Cairo programs needed
+for tests.
+If you have built the cairo-compile docker image, that will be used for compiling instead.
+
+Be sure to build the docker image if you don't want to install the `cairo-lang` toolchain:
+```
+make docker_build_cairo_compiler
+```
+
+## Running fuzzers
+To run a fuzzer, simply use 
+
+```
+make fuzzer <name of the fuzzer>
+```
+
+if you don´t have the tools for fuzzing installed use
+
+```
+make fuzzer_tools
+```
+
+## 📚 References
+
+The following links, repos and projects have been important in the development of this library and we want to thank and acknowledge them. 
+
+- [Starkware](https://starkware.co/)
+- [Winterfell](https://github.com/facebook/winterfell)
+- [Anatomy of a Stark](https://aszepieniec.github.io/stark-anatomy/overview)
+- [Giza](https://github.com/maxgillett/giza)
+- [Ministark](https://github.com/andrewmilson/ministark)
+- [Sandstorm](https://github.com/andrewmilson/sandstorm)
+- [STARK-101](https://starkware.co/stark-101/)
+- [Risc0](https://github.com/risc0/risc0)
+- [Neptune](https://github.com/Neptune-Crypto)
+- [Summary on FRI low degree test](https://eprint.iacr.org/2022/1216)
+- [STARKs paper](https://eprint.iacr.org/2018/046)
+- [DEEP FRI](https://eprint.iacr.org/2019/336)
+- [BrainSTARK](https://aszepieniec.github.io/stark-brainfuck/)
+- [Plonky2](https://github.com/mir-protocol/plonky2)
+- [Aztec](https://github.com/AztecProtocol)
+- [Arkworks](https://github.com/arkworks-rs)
+- [Thank goodness it's FRIday](https://vitalik.ca/general/2017/11/22/starks_part_2.html)
+- [Diving DEEP FRI](https://blog.lambdaclass.com/diving-deep-fri/)
+- [Periodic constraints](https://blog.lambdaclass.com/periodic-constraints-and-recursion-in-zk-starks/)
+- [Chiplets Miden VM](https://wiki.polygon.technology/docs/miden/design/chiplets/main/)
+- [Valida](https://github.com/valida-xyz/valida/tree/main)
+- [Solidity Verifier](https://github.com/starkware-libs/starkex-contracts/tree/master/evm-verifier/solidity/contracts/cpu)
+- [CAIRO verifier](https://github.com/starkware-libs/cairo-lang/tree/master/src/starkware/cairo/stark_verifier)
+- [EthSTARK](https://github.com/starkware-libs/ethSTARK/tree/master)
+- [CAIRO whitepaper](https://eprint.iacr.org/2021/1063.pdf)
+- [Gnark](https://github.com/Consensys/gnark)
+
+## 🌞 Related Projects
+
+- [CAIRO VM - Rust](https://github.com/lambdaclass/cairo-vm)
+- [CAIRO VM - Go](https://github.com/lambdaclass/cairo_vm.go)
+- [Lambdaworks](https://github.com/lambdaclass/lambdaworks)
+- [CAIRO native](https://github.com/lambdaclass/cairo_native/)
+- [StarkNet in Rust](https://github.com/lambdaclass/starknet_in_rust)
+- [StarkNet Stack](https://github.com/lambdaclass/starknet_stack)

--- a/provers/stark/README.md
+++ b/provers/stark/README.md
@@ -1,0 +1,83 @@
+<div align="center">
+
+# 🌟 Lambdaworks Stark Platinum Prover 🌟
+
+<img src="https://github.com/lambdaclass/lambdaworks_stark_platinum/assets/569014/ad8d7943-f011-49b5-a0c5-f07e5ef4133e" alt="drawing" width="300"/>
+
+## An open-source STARK prover, drop-in replacement for Winterfell.
+
+</div>
+
+[![Telegram Chat][tg-badge]][tg-url]
+
+[tg-badge]: https://img.shields.io/static/v1?color=green&logo=telegram&label=chat&style=flat&message=join
+[tg-url]: https://t.me/+98Whlzql7Hs0MDZh
+
+
+## ⚠️ Disclaimer
+
+This prover is still in development and may contain bugs. It is not intended to be used in production yet. 
+
+## [Documentation](https://lambdaclass.github.io/lambdaworks/starks/cairo.html)
+
+## To be added
+
+-  Winterfell api compatibility
+-  Add more parallelizationd
+-  Optimizations
+  - Skip layers
+  - Stop FRI
+  - Batch FRI queries (improves proof size)
+  - Others
+-  Optimized backend for mini goldilocks
+-  Pedersen Builtin
+-  Pick hash configuration with ProofOptions
+-  Support FFTx for CUDA
+-  Tracing tools
+-  Virtual columns
+
+## Requirements
+
+- Cargo 1.69+
+  
+## How to try it
+
+## 📚 References
+
+The following links, repos and projects have been important in the development of this library and we want to thank and acknowledge them. 
+
+- [Starkware](https://starkware.co/)
+- [Winterfell](https://github.com/facebook/winterfell)
+- [Anatomy of a Stark](https://aszepieniec.github.io/stark-anatomy/overview)
+- [Giza](https://github.com/maxgillett/giza)
+- [Ministark](https://github.com/andrewmilson/ministark)
+- [Sandstorm](https://github.com/andrewmilson/sandstorm)
+- [STARK-101](https://starkware.co/stark-101/)
+- [Risc0](https://github.com/risc0/risc0)
+- [Neptune](https://github.com/Neptune-Crypto)
+- [Summary on FRI low degree test](https://eprint.iacr.org/2022/1216)
+- [STARKs paper](https://eprint.iacr.org/2018/046)
+- [DEEP FRI](https://eprint.iacr.org/2019/336)
+- [BrainSTARK](https://aszepieniec.github.io/stark-brainfuck/)
+- [Plonky2](https://github.com/mir-protocol/plonky2)
+- [Aztec](https://github.com/AztecProtocol)
+- [Arkworks](https://github.com/arkworks-rs)
+- [Thank goodness it's FRIday](https://vitalik.ca/general/2017/11/22/starks_part_2.html)
+- [Diving DEEP FRI](https://blog.lambdaclass.com/diving-deep-fri/)
+- [Periodic constraints](https://blog.lambdaclass.com/periodic-constraints-and-recursion-in-zk-starks/)
+- [Chiplets Miden VM](https://wiki.polygon.technology/docs/miden/design/chiplets/main/)
+- [Valida](https://github.com/valida-xyz/valida/tree/main)
+- [Solidity Verifier](https://github.com/starkware-libs/starkex-contracts/tree/master/evm-verifier/solidity/contracts/cpu)
+- [CAIRO verifier](https://github.com/starkware-libs/cairo-lang/tree/master/src/starkware/cairo/stark_verifier)
+- [EthSTARK](https://github.com/starkware-libs/ethSTARK/tree/master)
+- [CAIRO whitepaper](https://eprint.iacr.org/2021/1063.pdf)
+- [Gnark](https://github.com/Consensys/gnark)
+
+## 🌞 Related Projects
+
+- [CAIRO VM - Rust](https://github.com/lambdaclass/cairo-vm)
+- [CAIRO VM - Go](https://github.com/lambdaclass/cairo_vm.go)
+- [Lambdaworks](https://github.com/lambdaclass/lambdaworks)
+- [CAIRO native](https://github.com/lambdaclass/cairo_native/)
+- [StarkNet in Rust](https://github.com/lambdaclass/starknet_in_rust)
+- [StarkNet Stack](https://github.com/lambdaclass/starknet_stack)


### PR DESCRIPTION
# Update readmes with the info of the old repos

- Created a Readme, based in the old ones, for Cairo prover and Stark Prover. 
- Updated main readme with a link to the documentation and added there references there. 
- Added a Makefile to the cairo prover so the CLI can be run as it was run before
- Added missing make clean to main Makefile
- Add link to the provers in the main README so they are easier to access