### PR TITLE
Looped fibonacci 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,9 @@ jobs:
           toolchain: stable
           targets: wasm32-unknown-unknown
 
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Run cargo check
         run: cargo check
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,9 +24,6 @@ jobs:
           toolchain: stable
           targets: wasm32-unknown-unknown
 
-      - name: Set up cargo cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Run cargo check
         run: cargo check
 

--- a/provers/cairo/cairo_programs/cairo0/fibonacci_5_loop.cairo
+++ b/provers/cairo/cairo_programs/cairo0/fibonacci_5_loop.cairo
@@ -1,0 +1,21 @@
+
+// Looped fibonacci is more efficient
+// than calling the fibo function with recursion
+// For n = 5, it's 31 steps vs 49 steps
+// This is useful to compare with other vms that are not validating the call stack for fibonacci
+
+func main{}() {
+    tempvar x0 = 0;
+    tempvar x1 = 1;
+    tempvar fib_acc = x0 + x1;
+    tempvar n = 5;
+    loop:
+        tempvar x0 = x1;
+        tempvar x1 = fib_acc;
+        tempvar fib_acc = x0 + x1;
+        tempvar n = n - 1;
+        jmp loop if n != 0;
+
+    assert fib_acc = 13;
+    return ();
+}


### PR DESCRIPTION
# Add a looped fibonacci for benchmarks

This fibonacci is useful for comparing against other vms that are not validating the call stack, and benchmarks in general. It works as the other fibonaccis but uses less steps.