### PR TITLE
Re add Cairo Prover makefile, simplified readme

### DIFF
--- a/provers/cairo/Makefile
+++ b/provers/cairo/Makefile
@@ -1,0 +1,92 @@
+.PHONY: test coverage clippy clean
+
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+CAIRO0_PROGRAMS_DIR=cairo_prover/cairo_programs/cairo0
+CAIRO0_PROGRAMS:=$(wildcard $(CAIRO0_PROGRAMS_DIR)/*.cairo)
+COMPILED_CAIRO0_PROGRAMS:=$(patsubst $(CAIRO0_PROGRAMS_DIR)/%.cairo, $(CAIRO0_PROGRAMS_DIR)/%.json, $(CAIRO0_PROGRAMS))
+
+# Rule to compile Cairo programs for testing purposes.
+# If the `cairo-lang` toolchain is installed, programs will be compiled with it.
+# Otherwise, the cairo_compile docker image will be used
+# When using the docker version, be sure to build the image using `make docker_build_cairo_compiler`.
+$(CAIRO0_PROGRAMS_DIR)/%.json: $(CAIRO0_PROGRAMS_DIR)/%.cairo
+	@echo "Compiling Cairo program..."
+	@cairo-compile --cairo_path="$(CAIRO0_PROGRAMS_DIR)" $< --output $@ 2> /dev/null --proof_mode || \
+	docker run --rm -v $(ROOT_DIR)/$(CAIRO0_PROGRAMS_DIR):/pwd/$(CAIRO0_PROGRAMS_DIR) cairo --proof_mode /pwd/$< > $@
+
+build: 
+	cargo build --release
+
+prove: build
+	cargo run --release prove $(PROGRAM_PATH) $(PROOF_PATH)
+
+verify: build
+	cargo run --release verify $(PROOF_PATH)
+
+run_all: build
+	cargo run --release prove_and_verify $(PROGRAM_PATH)
+
+test: $(COMPILED_CAIRO0_PROGRAMS)
+	cargo test
+
+test_metal: $(COMPILED_CAIRO0_PROGRAMS)
+	cargo test -F metal
+	
+clippy:
+	cargo clippy --workspace --all-targets -- -D warnings
+
+benchmarks_sequential: $(COMPILED_CAIRO0_PROGRAMS)
+	cargo bench
+
+benchmarks_parallel: $(COMPILED_CAIRO0_PROGRAMS)
+	cargo bench -F parallel --bench criterion_prover
+	cargo bench -F parallel --bench criterion_verifier
+
+benchmarks_parallel_all: $(COMPILED_CAIRO0_PROGRAMS)
+	cargo bench -F parallel
+
+build_metal:
+	cargo b --features metal --release
+
+docker_build_cairo_compiler:
+	docker build -f cairo_compile.Dockerfile -t cairo .	
+	
+docker_compile_cairo:
+	docker run -v $(ROOT_DIR):/pwd cairo --proof_mode /pwd/$(PROGRAM) > $(OUTPUT)
+
+target/release/cairo-platinum-prover:
+	cargo build --bin cairo-platinum-prover --release --features instruments
+	
+docker_compile_and_run_all: target/release/cairo-platinum-prover
+	@echo "Compiling program with docker"
+	@docker run -v $(ROOT_DIR):/pwd cairo --proof_mode /pwd/$(PROGRAM) > $(PROGRAM).json
+	@echo "Compiling done \n"
+	@cargo run --bin cairo-platinum-prover --features instruments --quiet --release prove_and_verify $(PROGRAM).json
+	@rm $(PROGRAM).json
+
+docker_compile_and_prove: target/release/cairo-platinum-prover
+	@echo "Compiling program with docker"
+	@docker run -v $(ROOT_DIR):/pwd cairo --proof_mode /pwd/$(PROGRAM) > $(PROGRAM).json
+	@echo "Compiling done \n"
+	@cargo run --bin cairo-platinum-prover --features instruments --quiet --release prove $(PROGRAM).json $(PROOF_PATH)
+	@rm $(PROGRAM).json
+
+compile_and_run_all: target/release/cairo-platinum-prover
+	@echo "Compiling program with cairo-compile"
+	@cairo-compile --proof_mode $(PROGRAM) > $(PROGRAM).json
+	@echo "Compiling done \n"
+	@cargo run --bin cairo-platinum-prover --features instruments --quiet --release prove_and_verify $(PROGRAM).json 
+	@rm $(PROGRAM).json
+
+compile_and_prove: target/release/cairo-platinum-prover
+	@echo "Compiling program with cairo-compile"
+	@cairo-compile --proof_mode $(PROGRAM) > $(PROGRAM).json
+	@echo "Compiling done \n"
+	@cargo run --bin cairo-platinum-prover --features instruments --quiet --release prove $(PROGRAM).json $(PROOF_PATH)
+	@rm $(PROGRAM).json
+
+clean:
+	rm -f $(CAIRO0_PROGRAMS_DIR)/*.json
+	rm -f $(CAIRO0_PROGRAMS_DIR)/*.trace
+	rm -f $(CAIRO0_PROGRAMS_DIR)/*.memory

--- a/provers/cairo/README.md
+++ b/provers/cairo/README.md
@@ -39,8 +39,6 @@ CLI currently runs with 100 bits of conjecturable security
   - [Requirements](#requirements)
   - [How to try it](#how-to-try-it)
     - [🚀 Prove and verify](#-prove-and-verify)
-    - [Using Docker compiler for Cairo 0 programs](#using-docker-compiler-for-cairo-0-programs)
-    - [Using cairo-compile for Cairo 0 programs](#using-cairo-compile-for-cairo-0-programs)
     - [Using WASM verifier](#using-wasm-verifier)
   - [Running tests](#running-tests)
   - [Running fuzzers](#running-fuzzers)
@@ -73,10 +71,30 @@ To be added:
 
 ### 🚀 Prove and verify
 
-To prove Cairo 0 programs without arguments you can use:
+To compile and prove Cairo 0 programs without arguments you can use:
+
+```bash
+  make compile_and_prove PROGRAM=<program_path> PROOF_PATH=<output_proof_path>
+```
+
+For example:
+
+```bash
+  make prove PROGRAM_PATH=cairo_programs/cairo0/fibonacci_5.json PROOF_PATH=fibonacci_5.proof
+```
+
+Notice for compilation either `cairo-lang` or `docker` is required
+
+If the program is already compiled you can use:
 
 ```bash
 make prove PROGRAM_PATH=<compiled_program_path> PROOF_PATH=<output_proof_path>
+```
+
+For example:
+
+```bash
+make prove PROGRAM_PATH=cairo_programs/cairo0/fibonacci_5.json PROOF_PATH=program_proof.proof
 ```
 
 To verify a proof you can use:
@@ -88,50 +106,13 @@ make verify PROOF_PATH=<proof_path>
 For example:
 
 ```bash
-make prove PROGRAM_PATH=fibonacci.json PROOF_PATH=fibonacci_proof
-make verify PROOF_PATH=fibonacci_proof
+make verify PROOF_PATH=fibonacci_5.proof
 ```
 
 To prove and verify with a single command you can use:
 
 ```bash
 make run_all PROGRAM_PATH=<proof_path>
-```
-
-### Using Docker compiler for Cairo 0 programs
-
-Build the compiler image with:
-
-```bash
-make docker_build_cairo_compiler
-```
-
-Then for example, if you have a Cairo program in the project folder, you can use:
-
-```bash
-make docker_compile_and_run_all PROGRAM=program_name.cairo
-```
-
-Or
-
-```bash
-make docker_compile_and_prove PROGRAM=program_name.cairo PROOF_PATH=proof_path
-```
-
-### Using cairo-compile for Cairo 0 programs
-
-If you have `cairo-lang` installed, you can use it instead of the Dockerfile
-
-Then for example, if you have some Cairo program in the project folder, you can use:
-
-```bash
-make compile_and_run_all PROGRAM=program_name.cairo
-```
-
-Or 
-
-```bash
-make compile_and_prove PROGRAM=program_name.cairo PROOF_PATH=proof_path
 ```
 
 ### Using WASM verifier


### PR DESCRIPTION
# Re add Cairo Makefile, simplified readme

## Description

This PR re adds the Makefile to use the Cairo CLI, and simplifies the readme

## Type of change

Please delete options that are not relevant.

- [x] New feature