### PR TITLE
Change generator in the Stark252PrimeField to one of maximal order $2^{192}$

### DIFF
--- a/math/src/field/fields/fft_friendly/stark_252_prime_field.rs
+++ b/math/src/field/fields/fft_friendly/stark_252_prime_field.rs
@@ -17,16 +17,11 @@ impl IsModulus<U256> for MontgomeryConfigStark252PrimeField {
 pub type Stark252PrimeField = U256PrimeField<MontgomeryConfigStark252PrimeField>;
 
 impl IsFFTField for Stark252PrimeField {
-    const TWO_ADICITY: u64 = 48;
+    const TWO_ADICITY: u64 = 192;
     // Change this line for a new function like `from_limbs`.
-    const TWO_ADIC_PRIMITVE_ROOT_OF_UNITY: U256 = UnsignedInteger {
-        limbs: [
-            219038664817244121,
-            2879838607450979157,
-            15244050560987562958,
-            16338897044258952332,
-        ],
-    };
+    const TWO_ADIC_PRIMITVE_ROOT_OF_UNITY: U256 = UnsignedInteger::from_hex_unchecked(
+        "5282db87529cfa3f0464519c8b0fa5ad187148e11a61616070024f42f8ef94",
+    );
 
     fn field_name() -> &'static str {
         "stark256"

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -43,7 +43,7 @@ pub trait IsFFTField: IsPrimeField {
             return Err(FieldError::RootOfUnityError(order));
         }
         let log_power = F::TWO_ADICITY - order;
-        let root = (0..log_power).fold(two_adic_primitive_root_of_unity, |acc, _| &acc * &acc);
+        let root = (0..log_power).fold(two_adic_primitive_root_of_unity, |acc, _| acc.square());
         Ok(root)
     }
 }

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -42,8 +42,9 @@ pub trait IsFFTField: IsPrimeField {
         if order > F::TWO_ADICITY {
             return Err(FieldError::RootOfUnityError(order));
         }
-        let power = 1u64 << (F::TWO_ADICITY - order);
-        Ok(two_adic_primitive_root_of_unity.pow(power))
+        let log_power = F::TWO_ADICITY - order;
+        let root = (0..log_power).fold(two_adic_primitive_root_of_unity, |acc, _| &acc * &acc);
+        Ok(root)
     }
 }
 


### PR DESCRIPTION
# Change generator in the Stark252PrimeField to one of maximal order $2^{192}$

## Description
We were using a generator of a subgroup of order $2^{48}$. However, the largest power of 2 that divides p-1, where p is the prime of the Stark252PrimeField, is $2^{192}$. This PR sets the generator to be $3^{(p-1) / (2^{192})}$, laying the ground to have domains compatible with the Stone Prover.
Also, since 2^{192} does not fit in a `usize`, this PR slightly changes the way the method `get_primitive_root_of_unity` computes primitives by avoiding a call to `pow` and manually performing succesive squares of the original root.
