### PR TITLE
Stark: Small refactor of StarkTranscript

### DIFF
--- a/provers/stark/src/prover.rs
+++ b/provers/stark/src/prover.rs
@@ -14,7 +14,7 @@ use rayon::prelude::{IndexedParallelIterator, IntoParallelRefIterator, ParallelI
 
 #[cfg(debug_assertions)]
 use crate::debug::validate_trace;
-use crate::transcript::{sample_z_ood, IsStarkTranscript};
+use crate::transcript::IsStarkTranscript;
 
 use super::config::{BatchedMerkleTree, Commitment};
 use super::constraints::evaluator::ConstraintEvaluator;
@@ -658,10 +658,9 @@ where
     let timer3 = Instant::now();
 
     // <<<< Receive challenge: z
-    let z = sample_z_ood(
+    let z = transcript.sample_z_ood(
         &domain.lde_roots_of_unity_coset,
         &domain.trace_roots_of_unity,
-        &mut transcript,
     );
 
     let round_3_result = round_3_evaluate_polynomials_in_out_of_domain_element(

--- a/provers/stark/src/verifier.rs
+++ b/provers/stark/src/verifier.rs
@@ -22,7 +22,7 @@ use super::{
     grinding::hash_transcript_with_int_and_get_leading_zeros,
     proof::{options::ProofOptions, stark::StarkProof},
     traits::AIR,
-    transcript::{batch_sample_challenges, sample_z_ood},
+    transcript::batch_sample_challenges,
 };
 
 struct Challenges<F, A>
@@ -90,10 +90,9 @@ where
     // ===================================
 
     // >>>> Send challenge: z
-    let z = sample_z_ood(
+    let z = transcript.sample_z_ood(
         &domain.lde_roots_of_unity_coset,
         &domain.trace_roots_of_unity,
-        transcript,
     );
 
     // <<<< Receive value: H₁(z²)


### PR DESCRIPTION
# Small refactor of StarkTranscript

## Description

This PR does as small reorganization of the code of `stark/src/transcript.rs` adds `sample_z_ood` to the `StarkTranscript` trait. It also moves constants only used by `StoneProverTranscript` to its implementation. And replaces the `hasher` attribute by a `state`.
