### PR TITLE
Change order of evaluation to avoid underflow error

### DIFF
--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -707,7 +707,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         while i > 0 {
             i -= 1;
             if NUM_LIMBS - 1 <= i * 2 {
-                let index = 2 * i - NUM_LIMBS + 1;
+                let index = 2 * i + 1 - NUM_LIMBS;
                 let cs = lo.limbs[index] as u128 + a.limbs[i] as u128 * a.limbs[i] as u128 + c;
                 c = cs >> 64;
                 lo.limbs[index] = cs as u64;


### PR DESCRIPTION
# Change order of evaluation to avoid underflow error

## Description

When the number of limbs in an unsigned integer is 1, like in the babybear field, the line

```rust
let index = 2 * i - NUM_LIMBS + 1;
```

panicks. This is because all variables are `usize` and when `i=0` then `NUM_LIMBS` is subtracted and gives `-1`.

To solve the problem mentioned above is suffices to change the evaluation order.

## Type of change

- [x] Bug fix

