### PR TITLE
Fix some CLI errors related to Makefile

### DIFF
--- a/provers/cairo/Makefile
+++ b/provers/cairo/Makefile
@@ -6,6 +6,8 @@ CAIRO0_PROGRAMS_DIR=cairo_programs/cairo0
 CAIRO0_PROGRAMS:=$(wildcard $(CAIRO0_PROGRAMS_DIR)/*.cairo)
 COMPILED_CAIRO0_PROGRAMS:=$(patsubst $(CAIRO0_PROGRAMS_DIR)/%.cairo, $(CAIRO0_PROGRAMS_DIR)/%.json, $(CAIRO0_PROGRAMS))
 
+COMPILED_PROGRAM=$(basename $(PROGRAM)).json
+
 # Rule to compile Cairo programs for testing purposes.
 # If the `cairo-lang` toolchain is installed, programs will be compiled with it.
 # Otherwise, the cairo_compile docker image will be used
@@ -53,38 +55,38 @@ docker_build_cairo_compiler:
 	docker build -f cairo_compile.Dockerfile -t cairo .	
 	
 docker_compile_cairo:
-	docker run -v $(ROOT_DIR):/pwd cairo --proof_mode /pwd/$(PROGRAM) > $(OUTPUT)
+	docker run -v $(ROOT_DIR):/pwd cairo --proof_mode /pwd/$(PROGRAM) > $(COMPILED_PROGRAM)
 
 target/release/cairo-platinum-prover:
 	cargo build --bin cairo-platinum-prover --release --features instruments
 	
 docker_compile_and_run_all: target/release/cairo-platinum-prover
 	@echo "Compiling program with docker"
-	@docker run -v $(ROOT_DIR):/pwd cairo --proof_mode /pwd/$(PROGRAM) > $(PROGRAM).json
+	docker run -v $(ROOT_DIR):/pwd cairo --proof_mode /pwd/$(PROGRAM) > $(COMPILED_PROGRAM)
 	@echo "Compiling done \n"
-	@cargo run --bin cairo-platinum-prover --features instruments --quiet --release prove_and_verify $(PROGRAM).json
-	@rm $(PROGRAM).json
+	@cargo run --bin cairo-platinum-prover --features instruments --quiet --release prove_and_verify $(COMPILED_PROGRAM)
+	@rm $(COMPILED_PROGRAM)
 
 docker_compile_and_prove: target/release/cairo-platinum-prover
 	@echo "Compiling program with docker"
-	@docker run -v $(ROOT_DIR):/pwd cairo --proof_mode /pwd/$(PROGRAM) > $(PROGRAM).json
+	@docker run -v $(ROOT_DIR):/pwd cairo --proof_mode /pwd/$(PROGRAM) > $(COMPILED_PROGRAM)
 	@echo "Compiling done \n"
-	@cargo run --bin cairo-platinum-prover --features instruments --quiet --release prove $(PROGRAM).json $(PROOF_PATH)
-	@rm $(PROGRAM).json
+	@cargo run --bin cairo-platinum-prover --features instruments --quiet --release prove $(COMPILED_PROGRAM) $(PROOF_PATH)
+	@rm $(COMPILED_PROGRAM)
 
 compile_and_run_all: target/release/cairo-platinum-prover
 	@echo "Compiling program with cairo-compile"
-	@cairo-compile --proof_mode $(PROGRAM) > $(PROGRAM).json
+	@cairo-compile --proof_mode $(PROGRAM) > $(COMPILED_PROGRAM)
 	@echo "Compiling done \n"
-	@cargo run --bin cairo-platinum-prover --features instruments --quiet --release prove_and_verify $(PROGRAM).json 
-	@rm $(PROGRAM).json
+	@cargo run --bin cairo-platinum-prover --features instruments --quiet --release prove_and_verify $(COMPILED_PROGRAM)
+	@rm $(COMPILED_PROGRAM)
 
 compile_and_prove: target/release/cairo-platinum-prover
 	@echo "Compiling program with cairo-compile"
-	@cairo-compile --proof_mode $(PROGRAM) > $(PROGRAM).json
+	@cairo-compile --proof_mode $(PROGRAM) --output $(COMPILED_PROGRAM)
 	@echo "Compiling done \n"
-	@cargo run --bin cairo-platinum-prover --features instruments --quiet --release prove $(PROGRAM).json $(PROOF_PATH)
-	@rm $(PROGRAM).json
+	@cargo run --bin cairo-platinum-prover --features instruments --quiet --release prove $(COMPILED_PROGRAM) $(PROOF_PATH)
+	@rm $(COMPILED_PROGRAM)
 
 clean:
 	rm -f $(CAIRO0_PROGRAMS_DIR)/*.json


### PR DESCRIPTION
When compiling a Cairo program, the compiled program name was constructed appending the name of the program passed as an input `PROGRAM` in the CLI, with the `.json` extension. 
So if the the passed program had the `.cairo` extension, the resulting compiled program had the two extensions `.cairo.json`, and that raised an error in the prover, a feature recently implemented.

This PR adds a variable to the Makefile that extracts the extension to the Cairo program and adds the JSON one to it.