### PR TITLE
Fix CIOS overflow check

### DIFF
--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -12,6 +12,7 @@ use core::marker::PhantomData;
 
 pub type U384PrimeField<M> = MontgomeryBackendPrimeField<M, 6>;
 pub type U256PrimeField<M> = MontgomeryBackendPrimeField<M, 4>;
+pub type U64PrimeField<M> = MontgomeryBackendPrimeField<M, 1>;
 
 /// This trait is necessary for us to be able to use unsigned integer types bigger than
 /// `u128` (the biggest native `unit`) as constant generics.
@@ -759,8 +760,10 @@ mod tests_u256_prime_fields {
     use crate::field::traits::IsPrimeField;
     #[cfg(feature = "std")]
     use crate::traits::ByteConversion;
-    use crate::unsigned_integer::element::UnsignedInteger;
     use crate::unsigned_integer::element::U256;
+    use crate::unsigned_integer::element::{UnsignedInteger, U64};
+
+    use super::U64PrimeField;
 
     #[derive(Clone, Debug)]
     struct U256Modulus29;
@@ -1121,5 +1124,25 @@ mod tests_u256_prime_fields {
         let a = U256F29Element::from_hex_unchecked("1d");
         let b = U256F29Element::zero();
         assert_eq!(a, b);
+    }
+
+    // Goldilocks
+    #[derive(Clone, Debug)]
+    struct GoldilocksModulus;
+    impl IsModulus<U64> for GoldilocksModulus {
+        const MODULUS: U64 = UnsignedInteger {
+            limbs: [18446744069414584321],
+        };
+    }
+
+    type GoldilocksField = U64PrimeField<GoldilocksModulus>;
+    type GoldilocksElement = FieldElement<GoldilocksField>;
+
+    #[test]
+    fn test_off_by_one_bug() {
+        let a = GoldilocksElement::from(732582227915286439);
+        let b = GoldilocksElement::from(3906369333256140342);
+        let expected_sum = GoldilocksElement::from(4638951561171426781);
+        assert_eq!(a + b, expected_sum);
     }
 }

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -1139,7 +1139,7 @@ mod tests_u256_prime_fields {
     type GoldilocksElement = FieldElement<GoldilocksField>;
 
     #[test]
-    fn test_off_by_one_bug() {
+    fn test_cios_overflow_case() {
         let a = GoldilocksElement::from(732582227915286439);
         let b = GoldilocksElement::from(3906369333256140342);
         let expected_sum = GoldilocksElement::from(4638951561171426781);

--- a/math/src/unsigned_integer/montgomery.rs
+++ b/math/src/unsigned_integer/montgomery.rs
@@ -67,7 +67,7 @@ impl MontgomeryAlgorithms {
         }
         let mut result = UnsignedInteger { limbs: t };
 
-        let overflow = t_extra[0] > 0;
+        let overflow = t_extra[1] > 0;
 
         if overflow || UnsignedInteger::const_le(q, &result) {
             (result, _) = UnsignedInteger::sub(&result, q);


### PR DESCRIPTION
# Fix CIOS overflow check

## Description

As pointed out in Issue #600, the Montgomery backend was giving incorrect results. The issue was in the convertion of element `3906369333256140342` to Montgomery form. The cause of this was an incorrect overflow check in the `cios` method. As described in [Acar's thesis](https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf) (page 15), the final result of algorithm is in the first `NUM_LIMBS+1` limbs (in the terminology of the thesis, these are the first `s+1` words). In our code, since we use a big endian representation, these are the first `NUMB_LIBMS` of element `t` and the rightmost limb of `t_extra`. So to check overflow, and subsequently reduce it to an element smaller than the modulus, one has to check whether `t_extra[1] > 0`.
## Type of change

- [x] Bug fix

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
