### PR TITLE
fix: polish some CLI details

### DIFF
--- a/provers/cairo/README.md
+++ b/provers/cairo/README.md
@@ -97,13 +97,13 @@ cargo run --release --features="cli" prove-and-verify cairo_programs/cairo0/fibo
 **To compile, proof, prove and verify at the same time you can use:**
 
 ```bash
-cargo run --release --features="cli" compile-and-run-all <program_path>
+cargo run --release --features="cli" compile-prove-and-verify <program_path>
 ```
 
 For example:
 
 ```bash
-cargo run --release --features="cli" compile-and-run-all cairo_programs/cairo0/fibonacci_5.cairo
+cargo run --release --features="cli" compile-prove-and-verify cairo_programs/cairo0/fibonacci_5.cairo
 ```
 
 ### Run CLI as a binary

--- a/provers/cairo/README.md
+++ b/provers/cairo/README.md
@@ -97,13 +97,13 @@ cargo run --release --features="cli" run_all cairo_programs/cairo0/fibonacci_5.j
 **To compile, proof, prove and verify at the same time you can use:**
 
 ```bash
-cargo run --release --features="cli" compile_and_run_all <program_path>
+cargo run --release --features="cli" compile-and-run-all <program_path>
 ```
 
 For example:
 
 ```bash
-cargo run --release --features="cli" compile_and_run_all cairo_programs/cairo0/fibonacci_5.cairo
+cargo run --release --features="cli" compile-and-run-all cairo_programs/cairo0/fibonacci_5.cairo
 ```
 
 ### Run CLI as a binary

--- a/provers/cairo/README.md
+++ b/provers/cairo/README.md
@@ -83,13 +83,13 @@ cargo run --release --features="cli" prove cairo_programs/cairo0/fibonacci_5.jso
 **To prove and verify with a single command you can use:**
 
 ```bash
-cargo run --release --features="cli" run_all <compiled_program_path>
+cargo run --release --features="cli" prove-and-verify <compiled_program_path>
 ```
 
 For example:
 
 ```bash
-cargo run --release --features="cli" run_all cairo_programs/cairo0/fibonacci_5.json
+cargo run --release --features="cli" prove-and-verify cairo_programs/cairo0/fibonacci_5.json
 ```
 
 
@@ -115,9 +115,9 @@ cargo install --features="cli" --path .
 
 To run the CLI as a binary instead of using cargo replace `cargo run --release --features="cli"` with `platinum-prover`.
 
-for example:
+for example, the command to generate a proof becomes:
 ```bash
-platinum-prover cairo_programs/cairo0/fibonacci_5.cairo cairo_programs/cairo0/fibonacci_5.proof
+platinum-prover prove cairo_programs/cairo0/fibonacci_5.json cairo_programs/cairo0/fibonacci_5.proof
 ```
 
 **You can uninstall the binary with:**

--- a/provers/cairo/src/commands.rs
+++ b/provers/cairo/src/commands.rs
@@ -20,7 +20,7 @@ pub enum ProverEntity {
     #[clap(about = "Compile and prove a given cairo program")]
     CompileAndProve(CompileAndProveArgs),
     #[clap(about = "Compile, prove and verify a given cairo program")]
-    CompileAndRunAll(CompileAndRunAllArgs),
+    CompileProveAndVerify(CompileAndRunAllArgs),
 }
 
 #[derive(Args, Debug)]

--- a/provers/cairo/src/main.rs
+++ b/provers/cairo/src/main.rs
@@ -264,7 +264,7 @@ fn main() {
                 }
             }
         }
-        commands::ProverEntity::CompileAndRunAll(args) => {
+        commands::ProverEntity::CompileProveAndVerify(args) => {
             let out_file_path = args.program_path.replace(".cairo", ".json");
             match try_compile(&args.program_path, &out_file_path) {
                 Ok(_) => {


### PR DESCRIPTION
Some minor details from the CLI and readme were corrected:
* when executing `compile-and-prove`, the proof was not being serialized
* the `run_all` command in the readme was not longer supported, replaced with `prove-and-verify` instead.
* replaced `compile_and_run_all` for `compile-prove-and-verify`
* refactor serialization of proof in the CLI into a function