### PR TITLE
Make `elliptic_curve` module no std compatible

### DIFF
--- a/math/src/elliptic_curve/edwards/traits.rs
+++ b/math/src/elliptic_curve/edwards/traits.rs
@@ -1,7 +1,6 @@
 use crate::elliptic_curve::traits::IsEllipticCurve;
 use crate::field::element::FieldElement;
-use std::fmt::Debug;
-
+use core::fmt::Debug;
 /// Trait to add elliptic curves behaviour to a struct.
 pub trait IsEdwards: IsEllipticCurve + Clone + Debug {
     fn a() -> FieldElement<Self::BaseField>;

--- a/math/src/elliptic_curve/montgomery/traits.rs
+++ b/math/src/elliptic_curve/montgomery/traits.rs
@@ -1,6 +1,6 @@
 use crate::elliptic_curve::traits::IsEllipticCurve;
 use crate::field::element::FieldElement;
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 /// Trait to add elliptic curves behaviour to a struct.
 pub trait IsMontgomery: IsEllipticCurve + Clone + Debug {

--- a/math/src/elliptic_curve/point.rs
+++ b/math/src/elliptic_curve/point.rs
@@ -1,7 +1,6 @@
 use crate::elliptic_curve::traits::IsEllipticCurve;
 use crate::field::element::FieldElement;
-use std::fmt::Debug;
-
+use core::fmt::Debug;
 /// Represents an elliptic curve point using the projective short Weierstrass form:
 /// y^2 * z = x^3 + a * x * z^2 + b * z^3,
 /// where `x`, `y` and `z` variables are field elements.

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
@@ -103,14 +103,15 @@ pub fn compress_g1_point(point: &G1Point) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::{BLS12381FieldElement, G1Point};
-    use crate::cyclic_group::IsGroup;
     use crate::elliptic_curve::short_weierstrass::curves::bls12_381::curve::BLS12381Curve;
     use crate::elliptic_curve::traits::{FromAffine, IsEllipticCurve};
-    use crate::traits::ByteConversion;
-    use crate::unsigned_integer::element::UnsignedInteger;
 
     #[cfg(feature = "std")]
     use super::{compress_g1_point, decompress_g1_point};
+    #[cfg(feature = "std")]
+    use crate::{
+        cyclic_group::IsGroup, traits::ByteConversion, unsigned_integer::element::UnsignedInteger,
+    };
 
     #[test]
     fn test_zero_point() {

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
@@ -1,16 +1,16 @@
 use super::field_extension::BLS12381PrimeField;
 use crate::cyclic_group::IsGroup;
+use crate::elliptic_curve::short_weierstrass::curves::bls12_381::curve::BLS12381Curve;
 use crate::elliptic_curve::short_weierstrass::point::ShortWeierstrassProjectivePoint;
-use crate::elliptic_curve::traits::FromAffine;
 use crate::field::element::FieldElement;
 use crate::unsigned_integer::element::U256;
-use crate::{
-    elliptic_curve::short_weierstrass::curves::bls12_381::curve::BLS12381Curve,
-    errors::ByteConversionError, traits::ByteConversion,
-};
-use core::cmp::Ordering;
+
 #[cfg(feature = "std")]
-use std::ops::Neg;
+use crate::{
+    elliptic_curve::traits::FromAffine, errors::ByteConversionError, traits::ByteConversion,
+};
+#[cfg(feature = "std")]
+use std::{cmp::Ordering, ops::Neg};
 
 pub type G1Point = ShortWeierstrassProjectivePoint<BLS12381Curve>;
 pub type BLS12381FieldElement = FieldElement<BLS12381PrimeField>;

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
@@ -109,6 +109,7 @@ mod tests {
     use crate::traits::ByteConversion;
     use crate::unsigned_integer::element::UnsignedInteger;
 
+    #[cfg(feature = "std")]
     use super::{compress_g1_point, decompress_g1_point};
 
     #[test]
@@ -124,6 +125,7 @@ mod tests {
         assert!(!super::check_point_is_in_subgroup(&false_point2));
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_g1_compress_generator() {
         let g = BLS12381Curve::generator();
@@ -139,6 +141,7 @@ mod tests {
         assert_eq!(*g_x, compressed_g_x);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_g1_compress_point_at_inf() {
         let inf = G1Point::neutral_element();
@@ -148,6 +151,7 @@ mod tests {
         assert_eq!(*first_byte >> 6, 3_u8);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_compress_decompress_generator() {
         let g = BLS12381Curve::generator();
@@ -159,6 +163,7 @@ mod tests {
         assert_eq!(g, decompressed_g);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_compress_decompress_2g() {
         let g = BLS12381Curve::generator();

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
@@ -8,7 +8,8 @@ use crate::{
     elliptic_curve::short_weierstrass::curves::bls12_381::curve::BLS12381Curve,
     errors::ByteConversionError, traits::ByteConversion,
 };
-use std::cmp::Ordering;
+use core::cmp::Ordering;
+#[cfg(feature = "std")]
 use std::ops::Neg;
 
 pub type G1Point = ShortWeierstrassProjectivePoint<BLS12381Curve>;
@@ -22,6 +23,7 @@ pub fn check_point_is_in_subgroup(point: &G1Point) -> bool {
     inf == aux_point
 }
 
+#[cfg(feature = "std")]
 pub fn decompress_g1_point(input_bytes: &mut [u8; 48]) -> Result<G1Point, ByteConversionError> {
     let first_byte = input_bytes.first().unwrap();
     // We get the 3 most significant bits
@@ -71,6 +73,7 @@ pub fn decompress_g1_point(input_bytes: &mut [u8; 48]) -> Result<G1Point, ByteCo
         .ok_or(ByteConversionError::PointNotInSubgroup)
 }
 
+#[cfg(feature = "std")]
 pub fn compress_g1_point(point: &G1Point) -> Vec<u8> {
     if *point == G1Point::neutral_element() {
         // point is at infinity

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -105,6 +105,7 @@ impl IsField for Degree2ExtensionField {
     }
 }
 
+#[cfg(feature = "std")]
 impl ByteConversion for FieldElement<Degree2ExtensionField> {
     fn to_bytes_be(&self) -> Vec<u8> {
         let mut byte_slice = ByteConversion::to_bytes_be(&self.value()[0]);

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -1,17 +1,17 @@
-use crate::unsigned_integer::element::U384;
-use crate::{
-    field::{
-        element::FieldElement,
-        errors::FieldError,
-        extensions::{
-            cubic::{CubicExtensionField, HasCubicNonResidue},
-            quadratic::{HasQuadraticNonResidue, QuadraticExtensionField},
-        },
-        fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
-        traits::IsField,
+use crate::field::{
+    element::FieldElement,
+    errors::FieldError,
+    extensions::{
+        cubic::{CubicExtensionField, HasCubicNonResidue},
+        quadratic::{HasQuadraticNonResidue, QuadraticExtensionField},
     },
-    traits::ByteConversion,
+    fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+    traits::IsField,
 };
+use crate::unsigned_integer::element::U384;
+
+#[cfg(feature = "std")]
+use crate::traits::ByteConversion;
 
 pub const BLS12381_PRIME_FIELD_ORDER: U384 = U384::from_hex_unchecked("1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab");
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/mod.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/mod.rs
@@ -2,6 +2,8 @@ pub mod compression;
 pub mod curve;
 pub mod default_types;
 pub mod field_extension;
-pub mod pairing;
 pub mod sqrt;
 pub mod twist;
+
+#[cfg(feature = "std")]
+pub mod pairing;

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -221,6 +221,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_double_accumulate_line_doubles_point_correctly() {
         let g1 = BLS12381Curve::generator();
@@ -231,6 +232,7 @@ mod tests {
         assert_eq!(r, g2.operate_with(&g2));
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_add_accumulate_line_adds_points_correctly() {
         let g1 = BLS12381Curve::generator();
@@ -246,6 +248,7 @@ mod tests {
         assert_eq!(r, expected);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn batch_ate_pairing_bilinearity() {
         let p = BLS12381Curve::generator();
@@ -266,6 +269,7 @@ mod tests {
         assert_eq!(result, FieldElement::one());
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn ate_pairing_returns_one_when_one_element_is_the_neutral_element() {
         let p = BLS12381Curve::generator().to_affine();

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -4,9 +4,7 @@ use crate::{
     field::element::FieldElement, unsigned_integer::element::UnsignedInteger,
 };
 
-#[cfg(feature = "std")]
 use super::{curve::BLS12381Curve, twist::BLS12381TwistCurve};
-#[cfg(feature = "std")]
 use crate::{
     cyclic_group::IsGroup,
     elliptic_curve::short_weierstrass::curves::bls12_381::field_extension::LevelTwoResidue,
@@ -17,7 +15,6 @@ use crate::{
 
 #[derive(Clone)]
 pub struct BLS12381AtePairing;
-#[cfg(feature = "std")]
 impl IsPairing for BLS12381AtePairing {
     type G1Point = ShortWeierstrassProjectivePoint<BLS12381Curve>;
     type G2Point = ShortWeierstrassProjectivePoint<BLS12381TwistCurve>;
@@ -39,10 +36,8 @@ impl IsPairing for BLS12381AtePairing {
     }
 }
 
-#[cfg(feature = "std")]
 /// This is equal to the frobenius trace of the BLS12 381 curve minus one.
 const MILLER_LOOP_CONSTANT: u64 = 0xd201000000010000;
-#[cfg(feature = "std")]
 fn double_accumulate_line(
     t: &mut ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,
     p: &ShortWeierstrassProjectivePoint<BLS12381Curve>,
@@ -96,7 +91,6 @@ fn double_accumulate_line(
         ]),
     ]);
 }
-#[cfg(feature = "std")]
 fn add_accumulate_line(
     t: &mut ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,
     q: &ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,
@@ -151,7 +145,6 @@ fn add_accumulate_line(
 /// Implements the miller loop for the ate pairing of the BLS12 381 curve.
 /// Based on algorithm 9.2, page 212 of the book
 /// "Topics in computational number theory" by W. Bons and K. Lenstra
-#[cfg(feature = "std")]
 #[allow(unused)]
 fn miller(
     q: &ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,
@@ -221,7 +214,6 @@ mod tests {
 
     use super::*;
 
-    #[cfg(feature = "std")]
     #[test]
     fn test_double_accumulate_line_doubles_point_correctly() {
         let g1 = BLS12381Curve::generator();
@@ -232,7 +224,6 @@ mod tests {
         assert_eq!(r, g2.operate_with(&g2));
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn test_add_accumulate_line_adds_points_correctly() {
         let g1 = BLS12381Curve::generator();
@@ -248,7 +239,6 @@ mod tests {
         assert_eq!(r, expected);
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn batch_ate_pairing_bilinearity() {
         let p = BLS12381Curve::generator();
@@ -269,7 +259,6 @@ mod tests {
         assert_eq!(result, FieldElement::one());
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn ate_pairing_returns_one_when_one_element_is_the_neutral_element() {
         let p = BLS12381Curve::generator().to_affine();

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -1,20 +1,18 @@
-use super::{
-    curve::BLS12381Curve,
-    field_extension::{Degree12ExtensionField, Degree2ExtensionField},
-    twist::BLS12381TwistCurve,
+use super::field_extension::{Degree12ExtensionField, Degree2ExtensionField};
+use crate::{
+    elliptic_curve::short_weierstrass::curves::bls12_381::field_extension::Degree6ExtensionField,
+    field::element::FieldElement, unsigned_integer::element::UnsignedInteger,
 };
+
+#[cfg(feature = "std")]
+use super::{curve::BLS12381Curve, twist::BLS12381TwistCurve};
+#[cfg(feature = "std")]
 use crate::{
     cyclic_group::IsGroup,
-    elliptic_curve::{
-        short_weierstrass::{
-            curves::bls12_381::field_extension::{Degree6ExtensionField, LevelTwoResidue},
-            point::ShortWeierstrassProjectivePoint,
-            traits::IsShortWeierstrass,
-        },
-        traits::IsPairing,
-    },
-    field::{element::FieldElement, extensions::cubic::HasCubicNonResidue},
-    unsigned_integer::element::UnsignedInteger,
+    elliptic_curve::short_weierstrass::curves::bls12_381::field_extension::LevelTwoResidue,
+    elliptic_curve::short_weierstrass::point::ShortWeierstrassProjectivePoint,
+    elliptic_curve::short_weierstrass::traits::IsShortWeierstrass,
+    elliptic_curve::traits::IsPairing, field::extensions::cubic::HasCubicNonResidue,
 };
 
 #[derive(Clone)]
@@ -41,9 +39,10 @@ impl IsPairing for BLS12381AtePairing {
     }
 }
 
+#[cfg(feature = "std")]
 /// This is equal to the frobenius trace of the BLS12 381 curve minus one.
 const MILLER_LOOP_CONSTANT: u64 = 0xd201000000010000;
-
+#[cfg(feature = "std")]
 fn double_accumulate_line(
     t: &mut ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,
     p: &ShortWeierstrassProjectivePoint<BLS12381Curve>,
@@ -97,6 +96,7 @@ fn double_accumulate_line(
         ]),
     ]);
 }
+#[cfg(feature = "std")]
 fn add_accumulate_line(
     t: &mut ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,
     q: &ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -19,6 +19,7 @@ use crate::{
 
 #[derive(Clone)]
 pub struct BLS12381AtePairing;
+#[cfg(feature = "std")]
 impl IsPairing for BLS12381AtePairing {
     type G1Point = ShortWeierstrassProjectivePoint<BLS12381Curve>;
     type G2Point = ShortWeierstrassProjectivePoint<BLS12381TwistCurve>;
@@ -150,6 +151,7 @@ fn add_accumulate_line(
 /// Implements the miller loop for the ate pairing of the BLS12 381 curve.
 /// Based on algorithm 9.2, page 212 of the book
 /// "Topics in computational number theory" by W. Bons and K. Lenstra
+#[cfg(feature = "std")]
 #[allow(unused)]
 fn miller(
     q: &ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/sqrt.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/sqrt.rs
@@ -1,7 +1,7 @@
 use crate::field::traits::LegendreSymbol;
 
 use super::{curve::BLS12381FieldElement, curve::BLS12381TwistCurveFieldElement};
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 #[must_use]
 pub fn select_sqrt_value_from_third_bit(

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -85,7 +85,6 @@ mod tests {
         elliptic_curve::{
             short_weierstrass::{
                 curves::bls12_381::field_extension::{BLS12381PrimeField, Degree2ExtensionField},
-                point::{Endianness, PointFormat, ShortWeierstrassProjectivePoint},
                 traits::IsShortWeierstrass,
             },
             traits::IsEllipticCurve,
@@ -97,6 +96,11 @@ mod tests {
     use super::BLS12381TwistCurve;
     type Level0FE = FieldElement<BLS12381PrimeField>;
     type Level1FE = FieldElement<Degree2ExtensionField>;
+
+    #[cfg(feature = "std")]
+    use crate::elliptic_curve::short_weierstrass::point::{
+        Endianness, PointFormat, ShortWeierstrassProjectivePoint,
+    };
 
     #[test]
     fn create_generator() {

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -108,6 +108,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn serialize_deserialize_generator() {
         let g = BLS12381TwistCurve::generator();

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -280,16 +280,19 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::elliptic_curve::short_weierstrass::curves::bls12_381::curve::BLS12381Curve;
+
+    #[cfg(feature = "std")]
     use crate::{
-        elliptic_curve::short_weierstrass::curves::bls12_381::{
-            curve::BLS12381Curve, field_extension::BLS12381PrimeField,
-        },
+        elliptic_curve::short_weierstrass::curves::bls12_381::field_extension::BLS12381PrimeField,
         field::element::FieldElement,
     };
 
+    #[cfg(feature = "std")]
     #[allow(clippy::upper_case_acronyms)]
     type FEE = FieldElement<BLS12381PrimeField>;
 
+    #[cfg(feature = "std")]
     fn point() -> ShortWeierstrassProjectivePoint<BLS12381Curve> {
         let x = FEE::new_base("36bb494facde72d0da5c770c4b16d9b2d45cfdc27604a25a1a80b020798e5b0dbd4c6d939a8f8820f042a29ce552ee5");
         let y = FEE::new_base("7acf6e49cc000ff53b06ee1d27056734019c0a1edfa16684da41ebb0c56750f73bc1b0eae4c6c241808a5e485af0ba0");

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -6,10 +6,13 @@ use crate::{
     },
     errors::DeserializationError,
     field::element::FieldElement,
-    traits::{ByteConversion, Deserializable, Serializable},
+    traits::{ByteConversion, Deserializable},
 };
 
 use super::traits::IsShortWeierstrass;
+
+#[cfg(feature = "std")]
+use crate::traits::Serializable;
 
 #[derive(Clone, Debug)]
 pub struct ShortWeierstrassProjectivePoint<E: IsEllipticCurve>(pub ProjectivePoint<E>);

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -183,6 +183,7 @@ where
     FieldElement<E::BaseField>: ByteConversion,
 {
     /// Serialize the points in the given format
+    #[cfg(feature = "std")]
     pub fn serialize(&self, _point_format: PointFormat, endianness: Endianness) -> Vec<u8> {
         // TODO: Add more compact serialization formats
         // Uncompressed affine / Compressed
@@ -249,6 +250,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<E> Serializable for ShortWeierstrassProjectivePoint<E>
 where
     E: IsShortWeierstrass,

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -296,6 +296,7 @@ mod tests {
         BLS12381Curve::create_point_from_affine(x, y).unwrap()
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn byte_conversion_from_and_to_be() {
         let expected_point = point();
@@ -309,6 +310,7 @@ mod tests {
         assert_eq!(expected_point, result.unwrap());
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn byte_conversion_from_and_to_le() {
         let expected_point = point();
@@ -322,6 +324,7 @@ mod tests {
         assert_eq!(expected_point, result.unwrap());
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn byte_conversion_from_and_to_with_mixed_le_and_be_does_not_work() {
         let bytes = point().serialize(PointFormat::Projective, Endianness::LittleEndian);
@@ -338,6 +341,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn byte_conversion_from_and_to_with_mixed_be_and_le_does_not_work() {
         let bytes = point().serialize(PointFormat::Projective, Endianness::BigEndian);

--- a/math/src/elliptic_curve/short_weierstrass/traits.rs
+++ b/math/src/elliptic_curve/short_weierstrass/traits.rs
@@ -1,6 +1,6 @@
 use crate::elliptic_curve::traits::IsEllipticCurve;
 use crate::field::element::FieldElement;
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 /// Trait to add elliptic curves behaviour to a struct.
 /// We use the short Weierstrass form equation: `y^2 = x^3 + a * x  + b`.

--- a/math/src/elliptic_curve/traits.rs
+++ b/math/src/elliptic_curve/traits.rs
@@ -2,7 +2,7 @@ use crate::{
     cyclic_group::IsGroup,
     field::{element::FieldElement, traits::IsField},
 };
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum EllipticCurveError {

--- a/math/src/lib.rs
+++ b/math/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod cyclic_group;
+pub mod elliptic_curve;
 pub mod errors;
 pub mod field;
 pub mod helpers;
@@ -10,8 +11,6 @@ pub mod unsigned_integer;
 pub mod gpu;
 
 // These modules don't work in no-std mode
-#[cfg(feature = "std")]
-pub mod elliptic_curve;
 #[cfg(feature = "std")]
 pub mod fft;
 #[cfg(feature = "std")]


### PR DESCRIPTION
# Make `lambdaworks_math::elliptic_curve` module no std compatible
Except for the `lambdaworks_math::elliptic_curve::short_weierstrass::curves::bls12_381::pairing` module

## Description

Make `lambdaworks_math::elliptic_curve` module no std compatible
Except for the `lambdaworks_math::elliptic_curve::short_weierstrass::curves::bls12_381::pairing` modulePlease delete options that are not relevant.

- [x] New feature
- [ ] Bug fix
- [ ] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
