### PR TITLE
Fix features on Cairo CLI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,10 +30,14 @@ jobs:
       - name: Run cargo check
         run: cargo check
 
-      - name: Run cargo check cli
+      - name: Run cargo check cli and stark instruments
         run: |
-          cargo check --features cli
-          
+          cargo check --features cli,instruments
+      
+      - name: Run cargo check cli, stark instruments and parallel
+        run: |
+          cargo check --features cli,instruments,parallel
+
       - name: Run cargo check for math with no-std
         run: cargo check --package lambdaworks-math --no-default-features
       

--- a/provers/cairo/Cargo.toml
+++ b/provers/cairo/Cargo.toml
@@ -53,9 +53,9 @@ wasm-bindgen-test = "0.3.0"
 
 [features]
 test_fiat_shamir = []
-instruments = []                   # This enables timing prints in prover and verifier
+instruments = ["stark-platinum-prover/instruments"]# This enables timing prints in prover and verifier
 metal = ["lambdaworks-math/metal"]
-parallel = ["dep:rayon"]
+parallel = ["dep:rayon", "stark-platinum-prover/parallel"]
 wasm = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen", "dep:web-sys"]
 cli = ["dep:clap"]
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]

--- a/provers/cairo/README.md
+++ b/provers/cairo/README.md
@@ -32,50 +32,50 @@ Examples of Cairo 0 programs can be found [here](https://github.com/lambdaclass/
 **To compile and generate a proof you can use:**
 
 ```bash
-cargo run --release --features="cli" compile-and-prove <program_path> <output_proof_path>
+cargo run --release --features=cli,instruments,parallel compile-and-prove <program_path> <output_proof_path>
 ```
 
 For example:
 
 ```bash
-cargo run --release --features="cli" compile-and-prove cairo_programs/cairo0/fibonacci_5.cairo cairo_programs/cairo0/fibonacci_5.proof
+cargo run --release --features=cli,instruments,parallel compile-and-prove cairo_programs/cairo0/fibonacci_5.cairo cairo_programs/cairo0/fibonacci_5.proof
 ```
 
 
 **To verify a proof you can use:**
 
 ```bash
-cargo run --release --features="cli" verify <proof_path>
+cargo run --release --features=cli,instruments,parallel verify <proof_path>
 ```
 
 For example:
 
 ```bash
-cargo run --release --features="cli" verify fibonacci_5.proof
+cargo run --release --features=cli,instruments,parallel verify fibonacci_5.proof
 ```
 
 **To compile Cairo:**
 
 ```bash
-cargo run --release --features="cli" compile <uncompiled_program_path> 
+cargo run --release --features=cli,instruments,parallel compile <uncompiled_program_path> 
 ```
 
 For example:
 
 ```bash
-cargo run --release --features="cli" compile cairo_programs/cairo0/fibonacci_5.cairo
+cargo run --release --features=cli,instruments,parallel compile cairo_programs/cairo0/fibonacci_5.cairo
 ```
 
 **To prove a compiled program:**
 
 ```bash
-cargo run --release --features="cli" prove <compiled_program_path> <output_proof_path>
+cargo run --release --features=cli,instruments,parallel prove <compiled_program_path> <output_proof_path>
 ```
 
 For example:
 
 ```bash
-cargo run --release --features="cli" prove cairo_programs/cairo0/fibonacci_5.json program_proof.proof
+cargo run --release --features=cli,instruments,parallel prove cairo_programs/cairo0/fibonacci_5.json program_proof.proof
 ```
 
 
@@ -83,13 +83,13 @@ cargo run --release --features="cli" prove cairo_programs/cairo0/fibonacci_5.jso
 **To prove and verify with a single command you can use:**
 
 ```bash
-cargo run --release --features="cli" prove-and-verify <compiled_program_path>
+cargo run --release --features=cli,instruments,parallel prove-and-verify <compiled_program_path>
 ```
 
 For example:
 
 ```bash
-cargo run --release --features="cli" prove-and-verify cairo_programs/cairo0/fibonacci_5.json
+cargo run --release --features=cli,instruments,parallel prove-and-verify cairo_programs/cairo0/fibonacci_5.json
 ```
 
 
@@ -97,23 +97,23 @@ cargo run --release --features="cli" prove-and-verify cairo_programs/cairo0/fibo
 **To compile, proof, prove and verify at the same time you can use:**
 
 ```bash
-cargo run --release --features="cli" compile-prove-and-verify <program_path>
+cargo run --release --features=cli,instruments,parallel compile-prove-and-verify <program_path>
 ```
 
 For example:
 
 ```bash
-cargo run --release --features="cli" compile-prove-and-verify cairo_programs/cairo0/fibonacci_5.cairo
+cargo run --release --features=cli,instruments,parallel compile-prove-and-verify cairo_programs/cairo0/fibonacci_5.cairo
 ```
 
 ### Run CLI as a binary
 
 **To install as a binary run the command on the root directory of the CLI:**
 ```bash
-cargo install --features="cli" --path .
+cargo install --features=cli,instruments,parallel --path .
 ```
 
-To run the CLI as a binary instead of using cargo replace `cargo run --release --features="cli"` with `platinum-prover`.
+To run the CLI as a binary instead of using cargo replace `cargo run --release --features=cli,instruments,parallel` with `platinum-prover`.
 
 for example, the command to generate a proof becomes:
 ```bash

--- a/provers/stark/src/prover.rs
+++ b/provers/stark/src/prover.rs
@@ -487,7 +487,7 @@ pub trait IsStarkProver {
             .fold(
                 || Polynomial::zero(),
                 |trace_terms, (i, t_j)| {
-                    compute_trace_term(
+                    Self::compute_trace_term(
                         &trace_terms,
                         (i, t_j),
                         trace_frame_length,


### PR DESCRIPTION
# Fix

## Description

Fix features on cairo CLI. Since we splitted the packages of Starks and Cairo, the dependency of the Cairo Prover should enable the dependencies on the Stark Prover. 

This allows to re enable instruments to have a better log when proving with cairo, and re add parallelism, giving around a 50% speedup in an m1 (1.5 s to 1s for fibo 1000)

It also adds it to the CI so this can't happen again, but to check that one parallel enables the other parallels, has to be don manually 

## Type of change

- [x] Bug fix