### PR TITLE
Proof serialization fix alt

### DIFF
--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -105,14 +105,15 @@ impl IsField for Degree2ExtensionField {
     }
 }
 
-#[cfg(feature = "std")]
 impl ByteConversion for FieldElement<Degree2ExtensionField> {
+    #[cfg(feature = "std")]
     fn to_bytes_be(&self) -> Vec<u8> {
         let mut byte_slice = ByteConversion::to_bytes_be(&self.value()[0]);
         byte_slice.extend(ByteConversion::to_bytes_be(&self.value()[1]));
         byte_slice
     }
 
+    #[cfg(feature = "std")]
     fn to_bytes_le(&self) -> Vec<u8> {
         let mut byte_slice = ByteConversion::to_bytes_le(&self.value()[0]);
         byte_slice.extend(ByteConversion::to_bytes_le(&self.value()[1]));

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -8,10 +8,8 @@ use crate::field::{
     fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
     traits::IsField,
 };
-use crate::unsigned_integer::element::U384;
-
-#[cfg(feature = "std")]
 use crate::traits::ByteConversion;
+use crate::unsigned_integer::element::U384;
 
 pub const BLS12381_PRIME_FIELD_ORDER: U384 = U384::from_hex_unchecked("1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab");
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -120,7 +120,7 @@ impl ByteConversion for FieldElement<Degree2ExtensionField> {
 
     fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
-        Self: std::marker::Sized,
+        Self: core::marker::Sized,
     {
         const BYTES_PER_FIELD: usize = 48;
         let x0 = FieldElement::from_bytes_be(&bytes[0..BYTES_PER_FIELD])?;
@@ -130,7 +130,7 @@ impl ByteConversion for FieldElement<Degree2ExtensionField> {
 
     fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
-        Self: std::marker::Sized,
+        Self: core::marker::Sized,
     {
         const BYTES_PER_FIELD: usize = 48;
         let x0 = FieldElement::from_bytes_le(&bytes[0..BYTES_PER_FIELD])?;

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -1,6 +1,7 @@
 use crate::errors::CreationError;
 use crate::field::errors::FieldError;
 use crate::field::traits::IsField;
+use crate::traits::ByteConversion;
 use crate::unsigned_integer::element::UnsignedInteger;
 use crate::unsigned_integer::montgomery::MontgomeryAlgorithms;
 use crate::unsigned_integer::traits::IsUnsignedInteger;
@@ -21,7 +22,6 @@ use super::fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackend
 use super::traits::{IsPrimeField, LegendreSymbol};
 
 /// A field element with operations algorithms defined in `F`
-#[allow(clippy::derived_hash_with_manual_eq)]
 #[derive(Debug, Clone, Hash, Copy)]
 pub struct FieldElement<F: IsField> {
     value: F::BaseType,
@@ -442,7 +442,8 @@ impl<F: IsPrimeField> Serialize for FieldElement<F> {
         S: Serializer,
     {
         let mut state = serializer.serialize_struct("FieldElement", 1)?;
-        state.serialize_field("value", &F::representative(self.value()).to_string())?;
+        // state.serialize_field("value", &F::representative(self.value()).to_string())?;
+        state.serialize_field("value", &self.value.to_bytes_be())?;
         state.end()
     }
 }

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -11,9 +11,8 @@ use core::iter::Sum;
 #[cfg(feature = "lambdaworks-serde")]
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
-use serde::de::SeqAccess;
 #[cfg(feature = "lambdaworks-serde")]
-use serde::de::{self, Deserializer, MapAccess, Visitor};
+use serde::de::{self, Deserializer, MapAccess, SeqAccess, Visitor};
 #[cfg(feature = "lambdaworks-serde")]
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 #[cfg(feature = "lambdaworks-serde")]

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -1,6 +1,7 @@
 use crate::errors::CreationError;
 use crate::field::errors::FieldError;
 use crate::field::traits::IsField;
+#[cfg(feature = "lambdaworks-serde")]
 use crate::traits::ByteConversion;
 use crate::unsigned_integer::element::UnsignedInteger;
 use crate::unsigned_integer::montgomery::MontgomeryAlgorithms;

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -23,6 +23,7 @@ use super::fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackend
 use super::traits::{IsPrimeField, LegendreSymbol};
 
 /// A field element with operations algorithms defined in `F`
+#[allow(clippy::derived_hash_with_manual_eq)]
 #[derive(Debug, Clone, Hash, Copy)]
 pub struct FieldElement<F: IsField> {
     value: F::BaseType,

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -31,26 +31,26 @@ where
 {
     #[cfg(feature = "std")]
     fn to_bytes_be(&self) -> Vec<u8> {
-        todo!()
+        unimplemented!()
     }
 
     #[cfg(feature = "std")]
     fn to_bytes_le(&self) -> Vec<u8> {
-        todo!()
+        unimplemented!()
     }
 
     fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        todo!()
+        unimplemented!()
     }
 
     fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -37,13 +37,13 @@ where
         todo!()
     }
 
-    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized {
         todo!()
     }
 
-    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized {
         todo!()

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -1,6 +1,7 @@
 use crate::field::element::FieldElement;
 use crate::field::errors::FieldError;
 use crate::field::traits::IsField;
+use crate::traits::ByteConversion;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 
@@ -22,6 +23,31 @@ pub trait HasCubicNonResidue {
     /// This function must return an element that is not a cube in Fp,
     /// that is, a cubic non-residue.
     fn residue() -> FieldElement<Self::BaseField>;
+}
+
+impl<F> ByteConversion for [FieldElement<F>; 3]
+where
+    F: IsField,
+{
+    fn to_bytes_be(&self) -> Vec<u8> {
+        todo!()
+    }
+
+    fn to_bytes_le(&self) -> Vec<u8> {
+        todo!()
+    }
+
+    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    where
+        Self: Sized {
+        todo!()
+    }
+
+    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    where
+        Self: Sized {
+        todo!()
+    }
 }
 
 impl<Q> IsField for CubicExtensionField<Q>

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -39,13 +39,15 @@ where
 
     fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
-        Self: Sized {
+        Self: Sized,
+    {
         todo!()
     }
 
     fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
-        Self: Sized {
+        Self: Sized,
+    {
         todo!()
     }
 }

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -29,10 +29,12 @@ impl<F> ByteConversion for [FieldElement<F>; 3]
 where
     F: IsField,
 {
+    #[cfg(feature = "std")]
     fn to_bytes_be(&self) -> Vec<u8> {
         todo!()
     }
 
+    #[cfg(feature = "std")]
     fn to_bytes_le(&self) -> Vec<u8> {
         todo!()
     }

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -1,6 +1,7 @@
 use crate::field::element::FieldElement;
 use crate::field::errors::FieldError;
 use crate::field::traits::IsField;
+use crate::traits::ByteConversion;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 
@@ -29,6 +30,33 @@ where
     pub fn conjugate(&self) -> Self {
         let [a, b] = self.value();
         Self::new([a.clone(), -b])
+    }
+}
+
+impl<F> ByteConversion for [FieldElement<F>; 2]
+where
+    F: IsField,
+{
+    fn to_bytes_be(&self) -> Vec<u8> {
+        todo!()
+    }
+
+    fn to_bytes_le(&self) -> Vec<u8> {
+        todo!()
+    }
+
+    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+
+    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    where
+        Self: Sized,
+    {
+        todo!()
     }
 }
 

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -45,14 +45,14 @@ where
         todo!()
     }
 
-    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
         todo!()
     }
 
-    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -39,26 +39,26 @@ where
 {
     #[cfg(feature = "std")]
     fn to_bytes_be(&self) -> Vec<u8> {
-        todo!()
+        unimplemented!()
     }
 
     #[cfg(feature = "std")]
     fn to_bytes_le(&self) -> Vec<u8> {
-        todo!()
+        unimplemented!()
     }
 
     fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        todo!()
+        unimplemented!()
     }
 
     fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -37,10 +37,12 @@ impl<F> ByteConversion for [FieldElement<F>; 2]
 where
     F: IsField,
 {
+    #[cfg(feature = "std")]
     fn to_bytes_be(&self) -> Vec<u8> {
         todo!()
     }
 
+    #[cfg(feature = "std")]
     fn to_bytes_le(&self) -> Vec<u8> {
         todo!()
     }

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -470,7 +470,7 @@ mod tests_u384_prime_fields {
         let x = U384F23Element::from(11_u64);
         let x_serialized = serde_json::to_string(&x).unwrap();
         let x_deserialized: U384F23Element = serde_json::from_str(&x_serialized).unwrap();
-        assert_eq!(x_serialized, "{\"value\":\"0xb\"}");
+        // assert_eq!(x_serialized, "{\"value\":\"0xb\"}"); // serialization is no longer as hex string
         assert_eq!(x_deserialized, x);
     }
 

--- a/math/src/field/fields/p448_goldilocks_prime_field.rs
+++ b/math/src/field/fields/p448_goldilocks_prime_field.rs
@@ -31,13 +31,15 @@ impl ByteConversion for U56x8 {
 
     fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
-        Self: Sized {
+        Self: Sized,
+    {
         todo!()
     }
 
     fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
-        Self: Sized {
+        Self: Sized,
+    {
         todo!()
     }
 }

--- a/math/src/field/fields/p448_goldilocks_prime_field.rs
+++ b/math/src/field/fields/p448_goldilocks_prime_field.rs
@@ -21,10 +21,12 @@ pub struct U56x8 {
 }
 
 impl ByteConversion for U56x8 {
+    #[cfg(feature = "std")]
     fn to_bytes_be(&self) -> Vec<u8> {
         todo!()
     }
 
+    #[cfg(feature = "std")]
     fn to_bytes_le(&self) -> Vec<u8> {
         todo!()
     }

--- a/math/src/field/fields/p448_goldilocks_prime_field.rs
+++ b/math/src/field/fields/p448_goldilocks_prime_field.rs
@@ -29,13 +29,13 @@ impl ByteConversion for U56x8 {
         todo!()
     }
 
-    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized {
         todo!()
     }
 
-    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized {
         todo!()

--- a/math/src/field/fields/p448_goldilocks_prime_field.rs
+++ b/math/src/field/fields/p448_goldilocks_prime_field.rs
@@ -23,26 +23,26 @@ pub struct U56x8 {
 impl ByteConversion for U56x8 {
     #[cfg(feature = "std")]
     fn to_bytes_be(&self) -> Vec<u8> {
-        todo!()
+        unimplemented!()
     }
 
     #[cfg(feature = "std")]
     fn to_bytes_le(&self) -> Vec<u8> {
-        todo!()
+        unimplemented!()
     }
 
     fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        todo!()
+        unimplemented!()
     }
 
     fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/math/src/field/fields/p448_goldilocks_prime_field.rs
+++ b/math/src/field/fields/p448_goldilocks_prime_field.rs
@@ -1,6 +1,7 @@
 use crate::errors::CreationError;
 use crate::field::errors::FieldError;
 use crate::field::traits::{IsField, IsPrimeField};
+use crate::traits::ByteConversion;
 use crate::unsigned_integer::element::UnsignedInteger;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17,6 +18,28 @@ pub const P448_GOLDILOCKS_PRIME_FIELD_ORDER: U448 =
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct U56x8 {
     limbs: [u64; 8],
+}
+
+impl ByteConversion for U56x8 {
+    fn to_bytes_be(&self) -> Vec<u8> {
+        todo!()
+    }
+
+    fn to_bytes_le(&self) -> Vec<u8> {
+        todo!()
+    }
+
+    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    where
+        Self: Sized {
+        todo!()
+    }
+
+    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    where
+        Self: Sized {
+        todo!()
+    }
 }
 
 impl IsField for P448GoldilocksPrimeField {

--- a/math/src/field/fields/u64_goldilocks_field.rs
+++ b/math/src/field/fields/u64_goldilocks_field.rs
@@ -7,7 +7,7 @@ use crate::{
         errors::FieldError,
         extensions::quadratic::{HasQuadraticNonResidue, QuadraticExtensionField},
         traits::{IsField, IsPrimeField},
-    },
+    }, traits::ByteConversion,
 };
 
 /// Goldilocks Prime Field F_p where p = 2^64 - 2^32 + 1;
@@ -18,6 +18,28 @@ impl Goldilocks64Field {
     pub const ORDER: u64 = 0xFFFF_FFFF_0000_0001;
     // Two's complement of `ORDER` i.e. `2^64 - ORDER = 2^32 - 1`
     pub const NEG_ORDER: u64 = Self::ORDER.wrapping_neg();
+}
+
+impl ByteConversion for u64 {
+    fn to_bytes_be(&self) -> Vec<u8> {
+        todo!()
+    }
+
+    fn to_bytes_le(&self) -> Vec<u8> {
+        todo!()
+    }
+
+    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    where
+        Self: Sized {
+        todo!()
+    }
+
+    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    where
+        Self: Sized {
+        todo!()
+    }
 }
 
 //NOTE: This implementation was inspired by and borrows from the work done by the Plonky3 team

--- a/math/src/field/fields/u64_goldilocks_field.rs
+++ b/math/src/field/fields/u64_goldilocks_field.rs
@@ -22,10 +22,12 @@ impl Goldilocks64Field {
 }
 
 impl ByteConversion for u64 {
+    #[cfg(feature = "std")]
     fn to_bytes_be(&self) -> Vec<u8> {
         todo!()
     }
 
+    #[cfg(feature = "std")]
     fn to_bytes_le(&self) -> Vec<u8> {
         todo!()
     }

--- a/math/src/field/fields/u64_goldilocks_field.rs
+++ b/math/src/field/fields/u64_goldilocks_field.rs
@@ -7,7 +7,8 @@ use crate::{
         errors::FieldError,
         extensions::quadratic::{HasQuadraticNonResidue, QuadraticExtensionField},
         traits::{IsField, IsPrimeField},
-    }, traits::ByteConversion,
+    },
+    traits::ByteConversion,
 };
 
 /// Goldilocks Prime Field F_p where p = 2^64 - 2^32 + 1;
@@ -31,13 +32,15 @@ impl ByteConversion for u64 {
 
     fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
-        Self: Sized {
+        Self: Sized,
+    {
         todo!()
     }
 
     fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
-        Self: Sized {
+        Self: Sized,
+    {
         todo!()
     }
 }

--- a/math/src/field/fields/u64_goldilocks_field.rs
+++ b/math/src/field/fields/u64_goldilocks_field.rs
@@ -29,13 +29,13 @@ impl ByteConversion for u64 {
         todo!()
     }
 
-    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized {
         todo!()
     }
 
-    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized {
         todo!()

--- a/math/src/field/fields/u64_goldilocks_field.rs
+++ b/math/src/field/fields/u64_goldilocks_field.rs
@@ -24,26 +24,26 @@ impl Goldilocks64Field {
 impl ByteConversion for u64 {
     #[cfg(feature = "std")]
     fn to_bytes_be(&self) -> Vec<u8> {
-        todo!()
+        unimplemented!()
     }
 
     #[cfg(feature = "std")]
     fn to_bytes_le(&self) -> Vec<u8> {
-        todo!()
+        unimplemented!()
     }
 
     fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        todo!()
+        unimplemented!()
     }
 
     fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -12,26 +12,26 @@ pub struct U32Field<const MODULUS: u32>;
 impl ByteConversion for u32 {
     #[cfg(feature = "std")]
     fn to_bytes_be(&self) -> Vec<u8> {
-        todo!()
+        unimplemented!()
     }
 
     #[cfg(feature = "std")]
     fn to_bytes_le(&self) -> Vec<u8> {
-        todo!()
+        unimplemented!()
     }
 
     fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        todo!()
+        unimplemented!()
     }
 
     fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -1,7 +1,8 @@
 use crate::{
     errors::CreationError,
     field::errors::FieldError,
-    field::traits::{IsFFTField, IsField, IsPrimeField}, traits::ByteConversion,
+    field::traits::{IsFFTField, IsField, IsPrimeField},
+    traits::ByteConversion,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17,15 +18,17 @@ impl ByteConversion for u32 {
         todo!()
     }
 
-    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
-        Self: Sized {
+        Self: Sized,
+    {
         todo!()
     }
 
-    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
-        Self: Sized {
+        Self: Sized,
+    {
         todo!()
     }
 }

--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -10,10 +10,12 @@ use crate::{
 pub struct U32Field<const MODULUS: u32>;
 
 impl ByteConversion for u32 {
+    #[cfg(feature = "std")]
     fn to_bytes_be(&self) -> Vec<u8> {
         todo!()
     }
 
+    #[cfg(feature = "std")]
     fn to_bytes_le(&self) -> Vec<u8> {
         todo!()
     }

--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -1,12 +1,34 @@
 use crate::{
     errors::CreationError,
     field::errors::FieldError,
-    field::traits::{IsFFTField, IsField, IsPrimeField},
+    field::traits::{IsFFTField, IsField, IsPrimeField}, traits::ByteConversion,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 
 pub struct U32Field<const MODULUS: u32>;
+
+impl ByteConversion for u32 {
+    fn to_bytes_be(&self) -> Vec<u8> {
+        todo!()
+    }
+
+    fn to_bytes_le(&self) -> Vec<u8> {
+        todo!()
+    }
+
+    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    where
+        Self: Sized {
+        todo!()
+    }
+
+    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    where
+        Self: Sized {
+        todo!()
+    }
+}
 
 impl<const MODULUS: u32> IsField for U32Field<MODULUS> {
     type BaseType = u32;

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -1,5 +1,5 @@
 use super::{element::FieldElement, errors::FieldError};
-use crate::{errors::CreationError, unsigned_integer::traits::IsUnsignedInteger};
+use crate::{errors::CreationError, unsigned_integer::traits::IsUnsignedInteger, traits::ByteConversion};
 use core::fmt::Debug;
 
 /// Represents different configurations that powers of roots of unity can be in. Some of these may
@@ -52,7 +52,7 @@ pub trait IsFFTField: IsPrimeField {
 pub trait IsField: Debug + Clone {
     /// The underlying base type for representing elements from the field.
     // TODO: Relax Unpin for non cuda usage
-    type BaseType: Clone + Debug + Unpin;
+    type BaseType: Clone + Debug + Unpin + ByteConversion;
 
     /// Returns the sum of `a` and `b`.
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType;

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -1,5 +1,7 @@
 use super::{element::FieldElement, errors::FieldError};
-use crate::{errors::CreationError, unsigned_integer::traits::IsUnsignedInteger, traits::ByteConversion};
+use crate::{
+    errors::CreationError, traits::ByteConversion, unsigned_integer::traits::IsUnsignedInteger,
+};
 use core::fmt::Debug;
 
 /// Represents different configurations that powers of roots of unity can be in. Some of these may

--- a/provers/cairo/Cargo.toml
+++ b/provers/cairo/Cargo.toml
@@ -40,7 +40,6 @@ rayon = { version = "1.8.0", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 serde-wasm-bindgen = { version = "0.5", optional = true }
 web-sys = { version = "0.3.64", features = ['console'], optional = true }
-rmp-serde = "1.1.2"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/provers/cairo/Cargo.toml
+++ b/provers/cairo/Cargo.toml
@@ -21,7 +21,7 @@ lambdaworks-crypto = { workspace = true }
 stark-platinum-prover = { workspace = true, features = ["wasm"] }
 thiserror = "1.0.38"
 log = "0.4.17"
-bincode = { version = "2.0.0-rc.2", tag = "v2.0.0-rc.2", git = "https://github.com/bincode-org/bincode.git" }
+bincode = { version = "2.0.0-rc.2", tag = "v2.0.0-rc.2", git = "https://github.com/bincode-org/bincode.git", features= ['serde'] }
 cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm", rev = "e763cef", default-features = false, features = [
     "cairo-1-hints",
 ]}
@@ -40,7 +40,7 @@ rayon = { version = "1.8.0", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 serde-wasm-bindgen = { version = "0.5", optional = true }
 web-sys = { version = "0.3.64", features = ['console'], optional = true }
-serde_bare = "0.5.0"
+rmp-serde = "1.1.2"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/provers/cairo/Cargo.toml
+++ b/provers/cairo/Cargo.toml
@@ -40,6 +40,7 @@ rayon = { version = "1.8.0", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 serde-wasm-bindgen = { version = "0.5", optional = true }
 web-sys = { version = "0.3.64", features = ['console'], optional = true }
+serde_bare = "0.5.0"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/provers/cairo/src/main.rs
+++ b/provers/cairo/src/main.rs
@@ -167,7 +167,7 @@ fn write_proof(
     proof_path: String,
 ) {
     let mut bytes = vec![];
-    let proof_bytes: Vec<u8> = serde_cbor::to_vec(&proof).unwrap();
+    let proof_bytes: Vec<u8> = serde_bare::ser::to_vec(&proof).unwrap();
     bytes.extend(proof_bytes.len().to_be_bytes());
     bytes.extend(proof_bytes);
     bytes.extend(pub_inputs.serialize());
@@ -223,7 +223,7 @@ fn main() {
                 eprintln!("Error reading proof from file: {}", args.proof_path);
                 return;
             }
-            let Ok(proof) = serde_cbor::from_slice(&bytes[0..proof_len]) else {
+            let Ok(proof) = serde_bare::from_slice(&bytes[0..proof_len]) else {
                 println!("Error reading proof from file: {}", args.proof_path);
                 return;
             };

--- a/provers/cairo/src/main.rs
+++ b/provers/cairo/src/main.rs
@@ -201,7 +201,6 @@ fn main() {
                 eprintln!("\nYou are trying to prove a non compiled Cairo program. Please compile it before sending it to the prover.\n");
                 return;
             }
-            println!("{:?}", args.program_path);
 
             let Some((proof, pub_inputs)) = generate_proof(&args.program_path, &proof_options)
             else {

--- a/provers/cairo/src/main.rs
+++ b/provers/cairo/src/main.rs
@@ -168,18 +168,8 @@ fn write_proof(
 ) {
     let mut bytes = vec![];
 
-    // cbor serialization (original)
-    let proof_bytes: Vec<u8> = serde_cbor::ser::to_vec(&proof).unwrap();
-    println!("Cbor: proof size: {} bytes", proof_bytes.len());
-
-    // rmp serialization
-    let proof_bytes: Vec<u8> = rmp_serde::to_vec(&proof).unwrap();
-    println!("Rmp: proof size: {} bytes", proof_bytes.len());
-
-    // bincode serialization
     let proof_bytes: Vec<u8> =
         bincode::serde::encode_to_vec(&proof, bincode::config::standard()).unwrap();
-    println!("Bincode: proof size: {} bytes", proof_bytes.len());
 
     bytes.extend(proof_bytes.len().to_be_bytes());
     bytes.extend(proof_bytes);
@@ -211,6 +201,7 @@ fn main() {
                 eprintln!("\nYou are trying to prove a non compiled Cairo program. Please compile it before sending it to the prover.\n");
                 return;
             }
+            println!("{:?}", args.program_path);
 
             let Some((proof, pub_inputs)) = generate_proof(&args.program_path, &proof_options)
             else {
@@ -252,7 +243,6 @@ fn main() {
             };
 
             verify_proof(proof, pub_inputs, &proof_options);
-            let foo: u32 = -1;
         }
         commands::ProverEntity::ProveAndVerify(args) => {
             if args.program_path.contains(".cairo") {
@@ -297,24 +287,5 @@ fn main() {
                 }
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    // use super::;
-
-    #[test]
-    fn test_field_serialization() {
-        type F = lambdaworks_math::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
-        type FE = stark_platinum_prover::fri::FieldElement<F>;
-        let field: FE = FE::from(26);
-
-        let serial = bincode::serde::encode_to_vec(&field, bincode::config::standard()).unwrap();
-
-        let (field_deserial, _): (FE, _) =
-            bincode::serde::decode_from_slice(&serial, bincode::config::standard()).unwrap();
-
-        assert_eq!(field, field_deserial);
     }
 }


### PR DESCRIPTION
# Proof serialization - reduced size

## Description

The aim of this pr is to replace the current `cbor` serializer with `bincode`, which creates a serialized file of around half the original size.

Note that to make this implementation work, the `BaseType` type is now bound to the `ByteConversion` trait. Fields that previously didn't implement `ByteConversion` have the barebones implementations needed filled with `todo!()`, so a followup pr should be added with the proper implementations. 

## Type of change

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [ ] Benchmarks added/run
