### PR TITLE
Improvements over plonk

### DIFF
--- a/provers/plonk/src/setup.rs
+++ b/provers/plonk/src/setup.rs
@@ -75,7 +75,7 @@ impl<F: IsFFTField> CommonPreprocessedInput<F> {
 
         let permutation = get_permutation(&lro);
         let permuted =
-            generate_permutation_coefficients(&omega, n, &permutation, order_r_minus_1_root_unity);
+            generate_permutation_coefficients(&domain, &permutation, order_r_minus_1_root_unity);
 
         let s1_lagrange: Vec<_> = permuted[..n].to_vec();
         let s2_lagrange: Vec<_> = permuted[n..2 * n].to_vec();

--- a/provers/plonk/src/test_utils/circuit_1.rs
+++ b/provers/plonk/src/test_utils/circuit_1.rs
@@ -24,8 +24,7 @@ pub fn test_common_preprocessed_input_1() -> CommonPreprocessedInput<FrField> {
     let omega = FrField::get_primitive_root_of_unity(2).unwrap();
     let domain = generate_domain(&omega, n);
     let permuted = generate_permutation_coefficients(
-        &omega,
-        n,
+        &domain,
         &[11, 3, 0, 1, 2, 4, 6, 10, 5, 8, 7, 9],
         &ORDER_R_MINUS_1_ROOT_UNITY,
     );

--- a/provers/plonk/src/test_utils/circuit_2.rs
+++ b/provers/plonk/src/test_utils/circuit_2.rs
@@ -28,7 +28,7 @@ pub fn test_common_preprocessed_input_2() -> CommonPreprocessedInput<FrField> {
         23, 4, 0, 18, 1, 2, 5, 6, 7, 8, 10, 9, 19, 11, 13, 14, 15, 16, 3, 12, 17, 20, 21, 22,
     ];
     let permuted =
-        generate_permutation_coefficients(&omega, n, permutation, &ORDER_R_MINUS_1_ROOT_UNITY);
+        generate_permutation_coefficients(&domain, permutation, &ORDER_R_MINUS_1_ROOT_UNITY);
 
     let s1_lagrange: Vec<FrElement> = permuted[..8].to_vec();
     let s2_lagrange: Vec<FrElement> = permuted[8..16].to_vec();

--- a/provers/plonk/src/test_utils/circuit_json.rs
+++ b/provers/plonk/src/test_utils/circuit_json.rs
@@ -40,8 +40,7 @@ pub fn common_preprocessed_input_from_json(
     let omega = FrField::get_primitive_root_of_unity(n.trailing_zeros() as u64).unwrap();
     let domain = generate_domain(&omega, n);
     let permuted = generate_permutation_coefficients(
-        &omega,
-        n,
+        &domain,
         &json_input.Permutation,
         &ORDER_R_MINUS_1_ROOT_UNITY,
     );

--- a/provers/plonk/src/test_utils/utils.rs
+++ b/provers/plonk/src/test_utils/utils.rs
@@ -34,9 +34,12 @@ pub fn test_srs(n: usize) -> StructuredReferenceString<G1Point, G2Point> {
     let g1 = <BLS12381Curve as IsEllipticCurve>::generator();
     let g2 = <BLS12381TwistCurve as IsEllipticCurve>::generator();
 
-    let powers_main_group: Vec<G1Point> = (0..n + 3)
-        .map(|exp| g1.operate_with_self(s.pow(exp as u64).representative()))
-        .collect();
+    let powers_main_group: Vec<G1Point> =
+        core::iter::successors(Some(FieldElement::from(1)), |acc| Some(acc * &s))
+            .take(n + 3)
+            .map(|power| power.representative())
+            .map(|power| g1.operate_with_self(power))
+            .collect();
     let powers_secondary_group = [g2.clone(), g2.operate_with_self(s.representative())];
 
     StructuredReferenceString::new(&powers_main_group, &powers_secondary_group)
@@ -44,41 +47,42 @@ pub fn test_srs(n: usize) -> StructuredReferenceString<G1Point, G2Point> {
 
 /// Generates a domain to interpolate: 1, omega, omega², ..., omega^size
 pub fn generate_domain<F: IsField>(omega: &FieldElement<F>, size: usize) -> Vec<FieldElement<F>> {
-    (1..size).fold(vec![FieldElement::one()], |mut acc, _| {
-        acc.push(acc.last().unwrap() * omega);
-        acc
-    })
+    core::iter::successors(Some(FieldElement::one()), |prev| Some(prev * omega))
+        .take(size)
+        .collect()
 }
 
 /// Generates the permutation coefficients for the copy constraints.
 /// polynomials S1, S2, S3.
 pub fn generate_permutation_coefficients<F: IsField>(
-    omega: &FieldElement<F>,
-    n: usize,
+    domain: &[FieldElement<F>],
     permutation: &[usize],
     order_r_minus_1_root_unity: &FieldElement<F>,
 ) -> Vec<FieldElement<F>> {
-    let identity = identity_permutation(omega, n, order_r_minus_1_root_unity);
-    let permuted: Vec<FieldElement<F>> = (0..n * 3)
-        .map(|i| identity[permutation[i]].clone())
-        .collect();
-    permuted
+    let identity = identity_permutation(domain, order_r_minus_1_root_unity);
+    permutation
+        .iter()
+        .map(|perm| identity[*perm].clone())
+        .collect()
 }
 
 /// The identity permutation, auxiliary function to generate the copy constraints.
 fn identity_permutation<F: IsField>(
-    w: &FieldElement<F>,
-    n: usize,
+    domain: &[FieldElement<F>],
     order_r_minus_1_root_unity: &FieldElement<F>,
 ) -> Vec<FieldElement<F>> {
     let u = order_r_minus_1_root_unity;
-    let mut result: Vec<FieldElement<F>> = vec![];
-    for index_column in 0..=2 {
-        for index_row in 0..n {
-            result.push(w.pow(index_row) * u.pow(index_column as u64));
-        }
-    }
-    result
+    let u_powers = [&FieldElement::one(), &u, &(u * u)];
+
+    (0..=2)
+        .map(|col| {
+            domain
+                .iter()
+                .map(|elem| elem * u_powers[col])
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>()
+        .concat()
 }
 
 /// A mock of a random number generator, to have deterministic tests.


### PR DESCRIPTION
## Description

- Satisfies change requested in https://github.com/lambdaclass/lambdaworks/issues/655
- Same domain (powers of omega) was being calculated 4 times. Reduces that to only once
- Introduces successors to some places instead of instantiating a vector and pushing
