### PR TITLE
perf: replace assert with debug_assert for data validation

### DIFF
--- a/provers/stark/src/table.rs
+++ b/provers/stark/src/table.rs
@@ -28,7 +28,7 @@ impl<'t, F: IsFFTField> Table<F> {
         }
 
         // Check that the one-dimensional data makes sense to be interpreted as a 2D one.
-        assert!(crate::debug::validate_2d_structure(&data, width));
+        debug_assert!(crate::debug::validate_2d_structure(&data, width));
         let height = data.len() / width;
 
         Self {


### PR DESCRIPTION
Only validate the structure in debug builds.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] This change is an Optimization
  - [x] Benchmarks added/run

## Results

Proving fibonacci(70000) on `lambdaworks-benchmarks-x86-64-dedicated`:
```
root@lambdaworks-benchmarks-x86-64-dedicated:~/pelito/bench# ./bench.sh 
Benchmark 1: stone
  Time (mean ± σ):     180.437 s ±  0.066 s    [User: 686.640 s, System: 4.958 s]
  Range (min … max):   180.369 s … 180.500 s    3 runs
 
Benchmark 2: base_seq
  Time (mean ± σ):     119.385 s ±  0.264 s    [User: 108.821 s, System: 10.552 s]
  Range (min … max):   119.085 s … 119.584 s    3 runs
 
Benchmark 3: base_par
  Time (mean ± σ):     78.523 s ±  0.280 s    [User: 148.442 s, System: 13.152 s]
  Range (min … max):   78.265 s … 78.820 s    3 runs
 
Benchmark 4: nodbg_seq
  Time (mean ± σ):     112.671 s ±  0.112 s    [User: 107.565 s, System: 5.086 s]
  Range (min … max):   112.547 s … 112.766 s    3 runs
 
Benchmark 5: nodbg_par
  Time (mean ± σ):     71.430 s ±  0.438 s    [User: 148.230 s, System: 7.221 s]
  Range (min … max):   71.122 s … 71.932 s    3 runs
 
Summary
  nodbg_par ran
    1.10 ± 0.01 times faster than base_par
    1.58 ± 0.01 times faster than nodbg_seq
    1.67 ± 0.01 times faster than base_seq
    2.53 ± 0.02 times faster than stone
```

### Benchmark platform

CPU: AMD EPYC Processor (4 logical cores)
CPU Family: 25
CPU Model: 1
CPU Stepping: 1
Microcode: 0x1000065
Cache Size: 512kB
Freq: 2445.404MHz
Memory: 16GiB