### PR TITLE
Generalize Pedersen hash function over the elliptic curve

### DIFF
--- a/benches/benches/point.rs
+++ b/benches/benches/point.rs
@@ -1,7 +1,10 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use lambdaworks_math::{
     cyclic_group::IsGroup,
-    elliptic_curve::{short_weierstrass::curves::stark_curve::StarkCurve, traits::IsEllipticCurve},
+    elliptic_curve::{
+        short_weierstrass::curves::stark_curve::StarkCurve,
+        traits::{IsEllipticCurve, IsProjectivePoint},
+    },
 };
 use starknet_curve::{curve_params::GENERATOR, AffinePoint, ProjectivePoint};
 use std::ops::{Add, AddAssign};

--- a/crypto/src/hash/pedersen/mod.rs
+++ b/crypto/src/hash/pedersen/mod.rs
@@ -1,7 +1,10 @@
 use lambdaworks_math::{
     cyclic_group::IsGroup,
-    elliptic_curve::short_weierstrass::{
-        curves::stark_curve::StarkCurve, point::ShortWeierstrassProjectivePoint,
+    elliptic_curve::{
+        short_weierstrass::{
+            curves::stark_curve::StarkCurve, point::ShortWeierstrassProjectivePoint,
+        },
+        traits::IsProjectivePoint,
     },
     field::{
         element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,

--- a/crypto/src/hash/pedersen/parameters.rs
+++ b/crypto/src/hash/pedersen/parameters.rs
@@ -1,36 +1,59 @@
-use lambdaworks_math::elliptic_curve::short_weierstrass::{
-    curves::stark_curve::StarkCurve, point::ShortWeierstrassProjectivePoint,
+use lambdaworks_math::{
+    elliptic_curve::{
+        short_weierstrass::{
+            curves::stark_curve::StarkCurve, point::ShortWeierstrassProjectivePoint,
+        },
+        traits::{IsEllipticCurve, IsProjectivePoint},
+    },
+    field::{
+        element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
+    },
 };
+use std::marker::PhantomData;
 
 use crate::hash::pedersen::constants::*;
 
-pub struct PedersenParameters {
-    pub curve_const_bits: usize,
+pub struct PedersenParameters<EC, P, I>
+where
+    EC: IsEllipticCurve,
+    P: IsProjectivePoint<EC>,
+{
+    pub chunk_size_bits: usize,
     pub table_size: usize,
-    pub shift_point: ShortWeierstrassProjectivePoint<StarkCurve>,
-    pub points_p1: [ShortWeierstrassProjectivePoint<StarkCurve>; 930],
-    pub points_p2: [ShortWeierstrassProjectivePoint<StarkCurve>; 15],
-    pub points_p3: [ShortWeierstrassProjectivePoint<StarkCurve>; 930],
-    pub points_p4: [ShortWeierstrassProjectivePoint<StarkCurve>; 15],
+    pub num_low_bits: usize,
+    pub num_high_bits: usize,
+    pub shift_point: P,
+    pub points_p1: Vec<P>,
+    pub points_p2: Vec<P>,
+    pub points_p3: Vec<P>,
+    pub points_p4: Vec<P>,
+    pub input_to_bits_le: fn(&I) -> Vec<bool>,
+    phantom: PhantomData<EC>,
 }
 
-impl Default for PedersenParameters {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PedersenParameters {
-    pub fn new() -> Self {
-        let curve_const_bits = 4;
+impl
+    PedersenParameters<
+        StarkCurve,
+        ShortWeierstrassProjectivePoint<StarkCurve>,
+        FieldElement<Stark252PrimeField>,
+    >
+{
+    pub fn starknet_params() -> Self {
+        let chunk_size_bits = 4;
         Self {
-            curve_const_bits,
-            table_size: (1 << curve_const_bits) - 1,
+            chunk_size_bits,
+            table_size: (1 << chunk_size_bits) - 1,
+            num_low_bits: 248,
+            num_high_bits: 4,
             shift_point: shift_point(),
-            points_p1: points_p1(),
-            points_p2: points_p2(),
-            points_p3: points_p3(),
-            points_p4: points_p4(),
+            points_p1: points_p1().to_vec(),
+            points_p2: points_p2().to_vec(),
+            points_p3: points_p3().to_vec(),
+            points_p4: points_p4().to_vec(),
+            input_to_bits_le: |x: &FieldElement<Stark252PrimeField>| {
+                x.to_bits_le()[0..252].to_vec()
+            },
+            phantom: PhantomData,
         }
     }
 }

--- a/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
+++ b/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
@@ -46,8 +46,10 @@ mod tests {
 
     use super::*;
     use crate::{
-        cyclic_group::IsGroup, elliptic_curve::traits::EllipticCurveError,
-        field::element::FieldElement, unsigned_integer::element::U256,
+        cyclic_group::IsGroup,
+        elliptic_curve::traits::{EllipticCurveError, IsProjectivePoint},
+        field::element::FieldElement,
+        unsigned_integer::element::U256,
     };
 
     #[allow(clippy::upper_case_acronyms)]

--- a/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
+++ b/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
@@ -37,7 +37,8 @@ impl IsEdwards for Ed448Goldilocks {
 mod tests {
     use super::*;
     use crate::{
-        cyclic_group::IsGroup, elliptic_curve::traits::EllipticCurveError,
+        cyclic_group::IsGroup,
+        elliptic_curve::traits::{EllipticCurveError, IsProjectivePoint},
         field::element::FieldElement,
     };
 

--- a/math/src/elliptic_curve/edwards/point.rs
+++ b/math/src/elliptic_curve/edwards/point.rs
@@ -2,7 +2,7 @@ use crate::{
     cyclic_group::IsGroup,
     elliptic_curve::{
         point::ProjectivePoint,
-        traits::{EllipticCurveError, FromAffine, IsEllipticCurve},
+        traits::{EllipticCurveError, FromAffine, IsEllipticCurve, IsProjectivePoint},
     },
     field::element::FieldElement,
 };
@@ -16,33 +16,6 @@ impl<E: IsEllipticCurve> EdwardsProjectivePoint<E> {
     /// Creates an elliptic curve point giving the projective [x: y: z] coordinates.
     pub fn new(value: [FieldElement<E::BaseField>; 3]) -> Self {
         Self(ProjectivePoint::new(value))
-    }
-
-    /// Returns the `x` coordinate of the point.
-    pub fn x(&self) -> &FieldElement<E::BaseField> {
-        self.0.x()
-    }
-
-    /// Returns the `y` coordinate of the point.
-    pub fn y(&self) -> &FieldElement<E::BaseField> {
-        self.0.y()
-    }
-
-    /// Returns the `z` coordinate of the point.
-    pub fn z(&self) -> &FieldElement<E::BaseField> {
-        self.0.z()
-    }
-
-    /// Returns a tuple [x, y, z] with the coordinates of the point.
-    pub fn coordinates(&self) -> &[FieldElement<E::BaseField>; 3] {
-        self.0.coordinates()
-    }
-
-    /// Creates the same point in affine coordinates. That is,
-    /// returns [x / z: y / z: 1] where `self` is [x: y: z].
-    /// Panics if `self` is the point at infinity.
-    pub fn to_affine(&self) -> Self {
-        Self(self.0.to_affine())
     }
 }
 
@@ -113,13 +86,42 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
     }
 }
 
+impl<E: IsEdwards> IsProjectivePoint<E> for EdwardsProjectivePoint<E> {
+    /// Returns the `x` coordinate of the point.
+    fn x(&self) -> &FieldElement<E::BaseField> {
+        self.0.x()
+    }
+
+    /// Returns the `y` coordinate of the point.
+    fn y(&self) -> &FieldElement<E::BaseField> {
+        self.0.y()
+    }
+
+    /// Returns the `z` coordinate of the point.
+    fn z(&self) -> &FieldElement<E::BaseField> {
+        self.0.z()
+    }
+
+    /// Returns a tuple [x, y, z] with the coordinates of the point.
+    fn coordinates(&self) -> &[FieldElement<E::BaseField>; 3] {
+        self.0.coordinates()
+    }
+
+    /// Creates the same point in affine coordinates. That is,
+    /// returns [x / z: y / z: 1] where `self` is [x: y: z].
+    /// Panics if `self` is the point at infinity.
+    fn to_affine(&self) -> Self {
+        Self(self.0.to_affine())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
         cyclic_group::IsGroup,
         elliptic_curve::{
             edwards::{curves::tiny_jub_jub::TinyJubJubEdwards, point::EdwardsProjectivePoint},
-            traits::{EllipticCurveError, IsEllipticCurve},
+            traits::{EllipticCurveError, IsEllipticCurve, IsProjectivePoint},
         },
         field::element::FieldElement,
     };

--- a/math/src/elliptic_curve/montgomery/point.rs
+++ b/math/src/elliptic_curve/montgomery/point.rs
@@ -2,7 +2,7 @@ use crate::{
     cyclic_group::IsGroup,
     elliptic_curve::{
         point::ProjectivePoint,
-        traits::{EllipticCurveError, FromAffine, IsEllipticCurve},
+        traits::{EllipticCurveError, FromAffine, IsEllipticCurve, IsProjectivePoint},
     },
     field::element::FieldElement,
 };
@@ -16,33 +16,6 @@ impl<E: IsEllipticCurve> MontgomeryProjectivePoint<E> {
     /// Creates an elliptic curve point giving the projective [x: y: z] coordinates.
     pub fn new(value: [FieldElement<E::BaseField>; 3]) -> Self {
         Self(ProjectivePoint::new(value))
-    }
-
-    /// Returns the `x` coordinate of the point.
-    pub fn x(&self) -> &FieldElement<E::BaseField> {
-        self.0.x()
-    }
-
-    /// Returns the `y` coordinate of the point.
-    pub fn y(&self) -> &FieldElement<E::BaseField> {
-        self.0.y()
-    }
-
-    /// Returns the `z` coordinate of the point.
-    pub fn z(&self) -> &FieldElement<E::BaseField> {
-        self.0.z()
-    }
-
-    /// Returns a tuple [x, y, z] with the coordinates of the point.
-    pub fn coordinates(&self) -> &[FieldElement<E::BaseField>; 3] {
-        self.0.coordinates()
-    }
-
-    /// Creates the same point in affine coordinates. That is,
-    /// returns [x / z: y / z: 1] where `self` is [x: y: z].
-    /// Panics if `self` is the point at infinity.
-    pub fn to_affine(&self) -> Self {
-        Self(self.0.to_affine())
     }
 }
 
@@ -137,6 +110,35 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
     }
 }
 
+impl<E: IsMontgomery> IsProjectivePoint<E> for MontgomeryProjectivePoint<E> {
+    /// Returns the `x` coordinate of the point.
+    fn x(&self) -> &FieldElement<E::BaseField> {
+        self.0.x()
+    }
+
+    /// Returns the `y` coordinate of the point.
+    fn y(&self) -> &FieldElement<E::BaseField> {
+        self.0.y()
+    }
+
+    /// Returns the `z` coordinate of the point.
+    fn z(&self) -> &FieldElement<E::BaseField> {
+        self.0.z()
+    }
+
+    /// Returns a tuple [x, y, z] with the coordinates of the point.
+    fn coordinates(&self) -> &[FieldElement<E::BaseField>; 3] {
+        self.0.coordinates()
+    }
+
+    /// Creates the same point in affine coordinates. That is,
+    /// returns [x / z: y / z: 1] where `self` is [x: y: z].
+    /// Panics if `self` is the point at infinity.
+    fn to_affine(&self) -> Self {
+        Self(self.0.to_affine())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -145,7 +147,7 @@ mod tests {
             montgomery::{
                 curves::tiny_jub_jub::TinyJubJubMontgomery, point::MontgomeryProjectivePoint,
             },
-            traits::{EllipticCurveError, IsEllipticCurve},
+            traits::{EllipticCurveError, IsEllipticCurve, IsProjectivePoint},
         },
         field::element::FieldElement,
     };

--- a/math/src/elliptic_curve/point.rs
+++ b/math/src/elliptic_curve/point.rs
@@ -74,7 +74,7 @@ mod tests {
     use crate::field::element::FieldElement;
     use crate::unsigned_integer::element::U384;
     //use crate::elliptic_curve::curves::test_curve_2::TestCurve2;
-    use crate::elliptic_curve::traits::{EllipticCurveError, IsEllipticCurve};
+    use crate::elliptic_curve::traits::{EllipticCurveError, IsEllipticCurve, IsProjectivePoint};
     use crate::field::extensions::quadratic::QuadraticExtensionFieldElement;
 
     #[allow(clippy::upper_case_acronyms)]

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
@@ -36,7 +36,8 @@ impl IsShortWeierstrass for BLS12377Curve {
 mod tests {
     use super::*;
     use crate::{
-        cyclic_group::IsGroup, elliptic_curve::traits::EllipticCurveError,
+        cyclic_group::IsGroup,
+        elliptic_curve::traits::{EllipticCurveError, IsProjectivePoint},
         field::element::FieldElement,
     };
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
@@ -7,7 +7,9 @@ use crate::unsigned_integer::element::U256;
 
 #[cfg(feature = "std")]
 use crate::{
-    elliptic_curve::traits::FromAffine, errors::ByteConversionError, traits::ByteConversion,
+    elliptic_curve::traits::{FromAffine, IsProjectivePoint},
+    errors::ByteConversionError,
+    traits::ByteConversion,
 };
 #[cfg(feature = "std")]
 use std::{cmp::Ordering, ops::Neg};
@@ -104,7 +106,7 @@ pub fn compress_g1_point(point: &G1Point) -> Vec<u8> {
 mod tests {
     use super::{BLS12381FieldElement, G1Point};
     use crate::elliptic_curve::short_weierstrass::curves::bls12_381::curve::BLS12381Curve;
-    use crate::elliptic_curve::traits::{FromAffine, IsEllipticCurve};
+    use crate::elliptic_curve::traits::{FromAffine, IsEllipticCurve, IsProjectivePoint};
 
     #[cfg(feature = "std")]
     use super::{compress_g1_point, decompress_g1_point};

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
@@ -39,7 +39,8 @@ impl IsShortWeierstrass for BLS12381Curve {
 mod tests {
     use super::*;
     use crate::{
-        cyclic_group::IsGroup, elliptic_curve::traits::EllipticCurveError,
+        cyclic_group::IsGroup,
+        elliptic_curve::traits::{EllipticCurveError, IsProjectivePoint},
         field::element::FieldElement,
     };
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -1,7 +1,11 @@
 use super::field_extension::{Degree12ExtensionField, Degree2ExtensionField};
 use crate::{
-    elliptic_curve::short_weierstrass::curves::bls12_381::field_extension::Degree6ExtensionField,
-    field::element::FieldElement, unsigned_integer::element::UnsignedInteger,
+    elliptic_curve::{
+        short_weierstrass::curves::bls12_381::field_extension::Degree6ExtensionField,
+        traits::IsProjectivePoint,
+    },
+    field::element::FieldElement,
+    unsigned_integer::element::UnsignedInteger,
 };
 
 use super::{curve::BLS12381Curve, twist::BLS12381TwistCurve};

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -1,6 +1,6 @@
 use crate::cyclic_group::IsGroup;
 use crate::elliptic_curve::short_weierstrass::point::ShortWeierstrassProjectivePoint;
-use crate::elliptic_curve::traits::IsEllipticCurve;
+use crate::elliptic_curve::traits::{IsEllipticCurve, IsProjectivePoint};
 use crate::unsigned_integer::element::U384;
 use crate::{
     elliptic_curve::short_weierstrass::traits::IsShortWeierstrass, field::element::FieldElement,
@@ -87,7 +87,7 @@ mod tests {
                 curves::bls12_381::field_extension::{BLS12381PrimeField, Degree2ExtensionField},
                 traits::IsShortWeierstrass,
             },
-            traits::IsEllipticCurve,
+            traits::{IsEllipticCurve, IsProjectivePoint},
         },
         field::element::FieldElement,
         unsigned_integer::element::U384,

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -2,7 +2,7 @@ use crate::{
     cyclic_group::IsGroup,
     elliptic_curve::{
         point::ProjectivePoint,
-        traits::{EllipticCurveError, FromAffine, IsEllipticCurve},
+        traits::{EllipticCurveError, FromAffine, IsEllipticCurve, IsProjectivePoint},
     },
     errors::DeserializationError,
     field::element::FieldElement,
@@ -21,33 +21,6 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
     /// Creates an elliptic curve point giving the projective [x: y: z] coordinates.
     pub const fn new(value: [FieldElement<E::BaseField>; 3]) -> Self {
         Self(ProjectivePoint::new(value))
-    }
-
-    /// Returns the `x` coordinate of the point.
-    pub fn x(&self) -> &FieldElement<E::BaseField> {
-        self.0.x()
-    }
-
-    /// Returns the `y` coordinate of the point.
-    pub fn y(&self) -> &FieldElement<E::BaseField> {
-        self.0.y()
-    }
-
-    /// Returns the `z` coordinate of the point.
-    pub fn z(&self) -> &FieldElement<E::BaseField> {
-        self.0.z()
-    }
-
-    /// Returns a tuple [x, y, z] with the coordinates of the point.
-    pub fn coordinates(&self) -> &[FieldElement<E::BaseField>; 3] {
-        self.0.coordinates()
-    }
-
-    /// Creates the same point in affine coordinates. That is,
-    /// returns [x / z: y / z: 1] where `self` is [x: y: z].
-    /// Panics if `self` is the point at infinity.
-    pub fn to_affine(&self) -> Self {
-        Self(self.0.to_affine())
     }
 
     fn double(&self) -> Self {
@@ -206,6 +179,35 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
     fn neg(&self) -> Self {
         let [px, py, pz] = self.coordinates();
         Self::new([px.clone(), -py, pz.clone()])
+    }
+}
+
+impl<E: IsShortWeierstrass> IsProjectivePoint<E> for ShortWeierstrassProjectivePoint<E> {
+    /// Returns the `x` coordinate of the point.
+    fn x(&self) -> &FieldElement<E::BaseField> {
+        self.0.x()
+    }
+
+    /// Returns the `y` coordinate of the point.
+    fn y(&self) -> &FieldElement<E::BaseField> {
+        self.0.y()
+    }
+
+    /// Returns the `z` coordinate of the point.
+    fn z(&self) -> &FieldElement<E::BaseField> {
+        self.0.z()
+    }
+
+    /// Returns a tuple [x, y, z] with the coordinates of the point.
+    fn coordinates(&self) -> &[FieldElement<E::BaseField>; 3] {
+        self.0.coordinates()
+    }
+
+    /// Creates the same point in affine coordinates. That is,
+    /// returns [x / z: y / z: 1] where `self` is [x: y: z].
+    /// Panics if `self` is the point at infinity.
+    fn to_affine(&self) -> Self {
+        Self(self.0.to_affine())
     }
 }
 

--- a/math/src/elliptic_curve/traits.rs
+++ b/math/src/elliptic_curve/traits.rs
@@ -49,3 +49,24 @@ pub trait IsPairing {
         Self::compute_batch(&[(p, q)])
     }
 }
+
+pub trait IsProjectivePoint<E: IsEllipticCurve>:
+    PartialEq + Eq + FromAffine<E::BaseField> + IsGroup
+{
+    /// Returns the `x` coordinate of the point
+    fn x(&self) -> &FieldElement<E::BaseField>;
+
+    /// Returns the `y` coordinate of the point
+    fn y(&self) -> &FieldElement<E::BaseField>;
+
+    /// Returns the `z` coordinate of the point
+    fn z(&self) -> &FieldElement<E::BaseField>;
+
+    /// Returns a tuple [x, y, z] with the coordinates of the point.
+    fn coordinates(&self) -> &[FieldElement<E::BaseField>; 3];
+
+    /// Creates the same point in affine coordinates. That is,
+    /// returns [x / z: y / z: 1] where `self` is [x: y: z].
+    /// Panics if `self` is the point at infinity.
+    fn to_affine(&self) -> Self;
+}


### PR DESCRIPTION

This PR attempts a very basic generalization of the Pedersen Hash over the Elliptic Curve. It currently only abstracts out the elliptic curve from the [Starknet Crypto equivalent](https://docs.starkware.co/starkex/crypto/pedersen-hash-function.html) implementation.

From what I can tell, the current Starknet equivalent implementation uses a simplified version of the generalized Pedersen Hash described in the [Iden3 docs](https://iden3-docs.readthedocs.io/en/latest/iden3_repos/research/publications/zkproof-standards-workshop-2/pedersen-hash/pedersen.html). Please let me know if it instead needs to be implemented in its full generality.

Aims to address the 3rd checkpoint of #592.