### PR TITLE
Small AirContext refactor

### DIFF
--- a/provers/cairo/src/air.rs
+++ b/provers/cairo/src/air.rs
@@ -605,16 +605,6 @@ impl AIR for CairoAIR {
         debug_assert!(trace_length.is_power_of_two());
 
         let trace_columns = 59;
-        let transition_degrees = vec![
-            2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // Flags 0-14.
-            1, // Flag 15
-            2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // Other constraints.
-            2, 2, 2, 2, 2, // Increasing memory auxiliary constraints.
-            2, 2, 2, 2, 2, // Consistent memory auxiliary constraints.
-            2, 2, 2, 2, 2, // Permutation auxiliary constraints.
-            2, 2, 2, 2, // range-check increasing constraints.
-            2, 2, 2, 2, // range-check permutation argument constraints.
-        ];
         let transition_exemptions = vec![
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // flags (16)
             0, // inst (1)
@@ -629,24 +619,16 @@ impl AIR for CairoAIR {
         ];
         let num_transition_constraints = 54;
 
-        let num_transition_exemptions = 1_usize;
-
         let context = AirContext {
             proof_options: proof_options.clone(),
             trace_columns,
-            transition_degrees,
             transition_exemptions,
             transition_offsets: vec![0, 1],
             num_transition_constraints,
-            num_transition_exemptions,
         };
 
-        // The number of the transition constraints and the lengths of transition degrees
+        // The number of the transition constraints
         // and transition exemptions should be the same always.
-        debug_assert_eq!(
-            context.transition_degrees.len(),
-            context.num_transition_constraints
-        );
         debug_assert_eq!(
             context.transition_exemptions.len(),
             context.num_transition_constraints

--- a/provers/stark/src/context.rs
+++ b/provers/stark/src/context.rs
@@ -1,10 +1,11 @@
+use std::collections::HashSet;
+
 use super::proof::options::ProofOptions;
 
 #[derive(Clone, Debug)]
 pub struct AirContext {
     pub proof_options: ProofOptions,
     pub trace_columns: usize,
-    pub transition_degrees: Vec<usize>,
 
     /// This is a vector with the indices of all the rows that constitute
     /// an evaluation frame. Note that, because of how we write all constraints
@@ -14,7 +15,6 @@ pub struct AirContext {
     pub transition_offsets: Vec<usize>,
     pub transition_exemptions: Vec<usize>,
     pub num_transition_constraints: usize,
-    pub num_transition_exemptions: usize,
 }
 
 impl AirContext {
@@ -22,11 +22,13 @@ impl AirContext {
         self.num_transition_constraints
     }
 
-    pub fn transition_degrees(&self) -> &[usize] {
-        &self.transition_degrees
-    }
-
-    pub fn transition_degrees_len(&self) -> usize {
-        self.transition_degrees.len()
+    /// Returns the number of non-trivial different
+    /// transition exemptions.
+    pub fn num_transition_exemptions(&self) -> usize {
+        self.transition_exemptions
+            .iter()
+            .filter(|&x| *x != 0)
+            .collect::<HashSet<_>>()
+            .len()
     }
 }

--- a/provers/stark/src/examples/dummy_air.rs
+++ b/provers/stark/src/examples/dummy_air.rs
@@ -34,11 +34,9 @@ impl AIR for DummyAIR {
         let context = AirContext {
             proof_options: proof_options.clone(),
             trace_columns: 2,
-            transition_degrees: vec![2, 1],
             transition_exemptions: vec![0, 2],
             transition_offsets: vec![0, 1, 2],
             num_transition_constraints: 2,
-            num_transition_exemptions: 1,
         };
 
         Self {

--- a/provers/stark/src/examples/fibonacci_2_cols_shifted.rs
+++ b/provers/stark/src/examples/fibonacci_2_cols_shifted.rs
@@ -65,12 +65,10 @@ where
     ) -> Self {
         let context = AirContext {
             proof_options: proof_options.clone(),
-            transition_degrees: vec![1, 1],
             transition_exemptions: vec![1, 1],
             transition_offsets: vec![0, 1],
             num_transition_constraints: 2,
             trace_columns: 2,
-            num_transition_exemptions: 1,
         };
 
         Self {

--- a/provers/stark/src/examples/fibonacci_2_columns.rs
+++ b/provers/stark/src/examples/fibonacci_2_columns.rs
@@ -41,12 +41,10 @@ where
     ) -> Self {
         let context = AirContext {
             proof_options: proof_options.clone(),
-            transition_degrees: vec![1, 1],
             transition_exemptions: vec![1, 1],
             transition_offsets: vec![0, 1],
             num_transition_constraints: 2,
             trace_columns: 2,
-            num_transition_exemptions: 1,
         };
 
         Self {

--- a/provers/stark/src/examples/fibonacci_rap.rs
+++ b/provers/stark/src/examples/fibonacci_rap.rs
@@ -57,11 +57,9 @@ where
         let context = AirContext {
             proof_options: proof_options.clone(),
             trace_columns: 3,
-            transition_degrees: vec![1, 2],
             transition_offsets: vec![0, 1, 2],
             transition_exemptions: vec![exemptions, 1],
             num_transition_constraints: 2,
-            num_transition_exemptions: 2,
         };
 
         Self {

--- a/provers/stark/src/examples/quadratic_air.rs
+++ b/provers/stark/src/examples/quadratic_air.rs
@@ -46,11 +46,9 @@ where
         let context = AirContext {
             proof_options: proof_options.clone(),
             trace_columns: 1,
-            transition_degrees: vec![2],
             transition_exemptions: vec![1],
             transition_offsets: vec![0, 1],
             num_transition_constraints: 1,
-            num_transition_exemptions: 1,
         };
 
         Self {

--- a/provers/stark/src/examples/simple_fibonacci.rs
+++ b/provers/stark/src/examples/simple_fibonacci.rs
@@ -47,11 +47,9 @@ where
         let context = AirContext {
             proof_options: proof_options.clone(),
             trace_columns: 1,
-            transition_degrees: vec![1],
             transition_exemptions: vec![2],
             transition_offsets: vec![0, 1, 2],
             num_transition_constraints: 1,
-            num_transition_exemptions: 1,
         };
 
         Self {

--- a/provers/stark/src/verifier.rs
+++ b/provers/stark/src/verifier.rs
@@ -269,10 +269,9 @@ pub trait IsStarkVerifier {
         let unity = &FieldElement::one();
         let transition_c_i_evaluations_sum = transition_ood_frame_evaluations
             .iter()
-            .zip(&air.context().transition_degrees)
             .zip(&air.context().transition_exemptions)
             .zip(&challenges.transition_coeffs)
-            .fold(FieldElement::zero(), |acc, (((eval, _), except), beta)| {
+            .fold(FieldElement::zero(), |acc, ((eval, except), beta)| {
                 let except = except
                     .checked_sub(1)
                     .map(|i| &exemption[i])

--- a/winterfell_adapter/src/adapter/air.rs
+++ b/winterfell_adapter/src/adapter/air.rs
@@ -89,12 +89,10 @@ where
 
         let lambda_context = stark_platinum_prover::context::AirContext {
             proof_options: lambda_proof_options.clone(),
-            transition_degrees: pub_inputs.transition_degrees.to_owned(),
             transition_exemptions: pub_inputs.transition_exemptions.to_owned(),
             transition_offsets: pub_inputs.transition_offsets.to_owned(),
             num_transition_constraints: winterfell_context.num_transition_constraints(),
             trace_columns: pub_inputs.trace_info.width(),
-            num_transition_exemptions: winterfell_context.num_transition_exemptions(),
         };
 
         Self {
@@ -278,7 +276,6 @@ mod tests {
         );
         let pub_inputs = AirAdapterPublicInputs {
             winterfell_public_inputs: AdapterFieldElement(trace.columns()[1][7]),
-            transition_degrees: vec![1, 1],
             transition_exemptions: vec![1, 1],
             transition_offsets: vec![0, 1],
             composition_poly_degree_bound: 8,
@@ -311,7 +308,6 @@ mod tests {
         let fibonacci_result = trace.columns()[1][15];
         let pub_inputs = AirAdapterPublicInputs {
             winterfell_public_inputs: AdapterFieldElement(fibonacci_result),
-            transition_degrees: vec![1, 1, 2],
             transition_exemptions: vec![1, 1, 1],
             transition_offsets: vec![0, 1],
             composition_poly_degree_bound: 32,

--- a/winterfell_adapter/src/adapter/public_inputs.rs
+++ b/winterfell_adapter/src/adapter/public_inputs.rs
@@ -8,7 +8,6 @@ where
     A::PublicInputs: Clone,
 {
     pub(crate) winterfell_public_inputs: A::PublicInputs,
-    pub(crate) transition_degrees: Vec<usize>,
     pub(crate) transition_exemptions: Vec<usize>,
     pub(crate) transition_offsets: Vec<usize>,
     pub(crate) trace_info: TraceInfo,


### PR DESCRIPTION
While coding the Winterfell/Miden compatibility, I noticed our AirContext needs two parameters: `transition_degrees` and `num_transition_exemptions`. The `transition_degrees` parameter is not being used. The `num_transition_exemptions` can be computed automatically avoiding human errors. Also removes an unused method and adds some comments on the contraint evaluator.