### PR TITLE
Math: Implement subfield logic

### DIFF
--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -118,7 +118,7 @@ impl IsSubFieldOf<Degree2ExtensionField> for BLS12381PrimeField {
         b: &<Degree2ExtensionField as IsField>::BaseType,
     ) -> <Degree2ExtensionField as IsField>::BaseType {
         let c0 = FieldElement::from_raw(<Self as IsField>::add(a, b[0].value()));
-        let c1 = FieldElement::from_raw(b[1].value().clone());
+        let c1 = FieldElement::from_raw(*b[1].value());
         [c0, c1]
     }
 
@@ -371,7 +371,7 @@ mod tests {
     }
 
     #[test]
-    fn add_base_field_with_degree_2_extension(){
+    fn add_base_field_with_degree_2_extension() {
         let a = FieldElement::<BLS12381PrimeField>::from(3);
         let a_extension = FieldElement::<Degree2ExtensionField>::from(3);
         let b = FieldElement::<Degree2ExtensionField>::from(2);
@@ -379,7 +379,7 @@ mod tests {
     }
 
     #[test]
-    fn mul_base_field_with_degree_2_extension(){
+    fn mul_base_field_with_degree_2_extension() {
         let a = FieldElement::<BLS12381PrimeField>::from(3);
         let a_extension = FieldElement::<Degree2ExtensionField>::from(3);
         let b = FieldElement::<Degree2ExtensionField>::from(2);
@@ -387,7 +387,7 @@ mod tests {
     }
 
     #[test]
-    fn sub_base_field_with_degree_2_extension(){
+    fn sub_base_field_with_degree_2_extension() {
         let a = FieldElement::<BLS12381PrimeField>::from(3);
         let a_extension = FieldElement::<Degree2ExtensionField>::from(3);
         let b = FieldElement::<Degree2ExtensionField>::from(2);
@@ -395,7 +395,7 @@ mod tests {
     }
 
     #[test]
-    fn div_base_field_with_degree_2_extension(){
+    fn div_base_field_with_degree_2_extension() {
         let a = FieldElement::<BLS12381PrimeField>::from(3);
         let a_extension = FieldElement::<Degree2ExtensionField>::from(3);
         let b = FieldElement::<Degree2ExtensionField>::from(2);
@@ -403,7 +403,7 @@ mod tests {
     }
 
     #[test]
-    fn embed_base_field_with_degree_2_extension(){
+    fn embed_base_field_with_degree_2_extension() {
         let a = FieldElement::<BLS12381PrimeField>::from(3);
         let a_extension = FieldElement::<Degree2ExtensionField>::from(3);
         assert_eq!(a.to_extension::<Degree2ExtensionField>(), a_extension);

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -105,8 +105,9 @@ impl IsField for Degree2ExtensionField {
 
 impl IsSubFieldOf<Degree2ExtensionField> for BLS12381PrimeField {
     fn mul(a: &Self::BaseType, b: &<Degree2ExtensionField as IsField>::BaseType) -> <Degree2ExtensionField as IsField>::BaseType {
-        let a = FieldElement::<Self>::from(a);
-        [&a * &b[0], a * &b[1]]
+        let c0 = FieldElement::from_raw(<Self as IsField>::mul(a, b[0].value()));
+        let c1 = FieldElement::from_raw(<Self as IsField>::mul(a, b[1].value()));
+        [c0, c1]
     }
 
     fn add(a: &Self::BaseType, b: &<Degree2ExtensionField as IsField>::BaseType) -> <Degree2ExtensionField as IsField>::BaseType {

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -1,6 +1,6 @@
 use super::{
     curve::{BLS12381Curve, MILLER_LOOP_CONSTANT},
-    field_extension::{Degree12ExtensionField, Degree2ExtensionField, BLS12381PrimeField},
+    field_extension::{BLS12381PrimeField, Degree12ExtensionField, Degree2ExtensionField},
     twist::BLS12381TwistCurve,
 };
 use crate::{
@@ -121,7 +121,7 @@ fn add_accumulate_line(
     let e = &lambda * &d;
     let f = z1 * c;
     let g = x1 * d;
-    let h = &e + f -  FieldElement::<BLS12381PrimeField>::from(2) * &g;
+    let h = &e + f - FieldElement::<BLS12381PrimeField>::from(2) * &g;
     let i = y1 * &e;
 
     let x3 = &lambda * &h;
@@ -196,7 +196,7 @@ fn frobenius_square(
     let f0 = FieldElement::new([a0.clone(), a1 * &omega_3, a2 * &omega_3_squared]);
     let f1 = FieldElement::new([b0.clone(), b1 * omega_3, b2 * omega_3_squared]);
 
-    FieldElement::new([f0, w_raised_to_p_squared_minus_one * f1 ])
+    FieldElement::new([f0, w_raised_to_p_squared_minus_one * f1])
 }
 
 // To understand more about how to reduce the final exponentiation

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -1,6 +1,6 @@
 use super::{
     curve::{BLS12381Curve, MILLER_LOOP_CONSTANT},
-    field_extension::{Degree12ExtensionField, Degree2ExtensionField},
+    field_extension::{Degree12ExtensionField, Degree2ExtensionField, BLS12381PrimeField},
     twist::BLS12381TwistCurve,
 };
 use crate::{
@@ -56,22 +56,23 @@ fn double_accumulate_line(
     let [px, py, _] = p.coordinates();
     let residue = LevelTwoResidue::residue();
     let two_inv = FieldElement::<Degree2ExtensionField>::new_base("d0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd556");
+    let three = FieldElement::<BLS12381PrimeField>::from(3);
 
     let a = &two_inv * x1 * y1;
     let b = y1.square();
     let c = z1.square();
-    let d = FieldElement::from(3) * &c;
+    let d = &three * &c;
     let e = BLS12381TwistCurve::b() * d;
-    let f = FieldElement::from(3) * &e;
+    let f = &three * &e;
     let g = two_inv * (&b + &f);
     let h = (y1 + z1).square() - (&b + &c);
 
     let x3 = &a * (&b - &f);
-    let y3 = g.square() - (FieldElement::from(3) * e.square());
+    let y3 = g.square() - (&three * e.square());
     let z3 = &b * &h;
 
     let [h0, h1] = h.value();
-    let x1_sq_3 = FieldElement::from(3) * x1.square();
+    let x1_sq_3 = three * x1.square();
     let [x1_sq_30, x1_sq_31] = x1_sq_3.value();
 
     t.0.value = [x3, y3, z3];
@@ -120,7 +121,7 @@ fn add_accumulate_line(
     let e = &lambda * &d;
     let f = z1 * c;
     let g = x1 * d;
-    let h = &e + f - FieldElement::from(2) * &g;
+    let h = &e + f -  FieldElement::<BLS12381PrimeField>::from(2) * &g;
     let i = y1 * &e;
 
     let x3 = &lambda * &h;
@@ -195,7 +196,7 @@ fn frobenius_square(
     let f0 = FieldElement::new([a0.clone(), a1 * &omega_3, a2 * &omega_3_squared]);
     let f1 = FieldElement::new([b0.clone(), b1 * omega_3, b2 * omega_3_squared]);
 
-    FieldElement::new([f0, f1 * w_raised_to_p_squared_minus_one])
+    FieldElement::new([f0, w_raised_to_p_squared_minus_one * f1 ])
 }
 
 // To understand more about how to reduce the final exponentiation

--- a/math/src/fft/gpu/metal/ops.rs
+++ b/math/src/fft/gpu/metal/ops.rs
@@ -55,7 +55,7 @@ pub fn fft<F: IsFFTField>(
 
     let result = MetalState::retrieve_contents(&input_buffer);
     let result = bitrev_permutation::<F, _>(&result, state)?;
-    Ok(result.iter().map(FieldElement::<F>::from_raw).collect())
+    Ok(result.into_iter().map(FieldElement::<F>::from_raw).collect())
 }
 
 /// Generates 2^{`order-1`} twiddle factors in parallel, with a certain `config`, in Metal.

--- a/math/src/fft/gpu/metal/ops.rs
+++ b/math/src/fft/gpu/metal/ops.rs
@@ -55,7 +55,7 @@ pub fn fft<F: IsFFTField>(
 
     let result = MetalState::retrieve_contents(&input_buffer);
     let result = bitrev_permutation::<F, _>(&result, state)?;
-    Ok(result.into_iter().map(FieldElement::<F>::from_raw).collect())
+    Ok(result.into_iter().map(FieldElement::from_raw).collect())
 }
 
 /// Generates 2^{`order-1`} twiddle factors in parallel, with a certain `config`, in Metal.

--- a/math/src/fft/gpu/metal/ops.rs
+++ b/math/src/fft/gpu/metal/ops.rs
@@ -89,7 +89,7 @@ pub fn gen_twiddles<F: IsFFTField>(
         let (command_buffer, command_encoder) =
             state.setup_command(&pipeline, Some(&[(0, &result_buffer)]));
 
-        let root = F::get_primitive_root_of_unity::<F>(order).unwrap();
+        let root = F::get_primitive_root_of_unity(order).unwrap();
         command_encoder.set_bytes(1, mem::size_of::<F::BaseType>() as u64, void_ptr(&root));
 
         let grid_size = MTLSize::new(len as u64, 1, 1);
@@ -103,7 +103,7 @@ pub fn gen_twiddles<F: IsFFTField>(
     });
 
     let result = MetalState::retrieve_contents(&result_buffer);
-    Ok(result.iter().map(FieldElement::from_raw).collect())
+    Ok(result.into_iter().map(FieldElement::from_raw).collect())
 }
 
 /// Executes a parallel bit-reverse permutation with the elements of `input`, in Metal.

--- a/math/src/fft/gpu/metal/ops.rs
+++ b/math/src/fft/gpu/metal/ops.rs
@@ -55,7 +55,7 @@ pub fn fft<F: IsFFTField>(
 
     let result = MetalState::retrieve_contents(&input_buffer);
     let result = bitrev_permutation::<F, _>(&result, state)?;
-    Ok(result.iter().map(FieldElement::from_raw).collect())
+    Ok(result.iter().map(FieldElement::<F>::from_raw).collect())
 }
 
 /// Generates 2^{`order-1`} twiddle factors in parallel, with a certain `config`, in Metal.

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -32,7 +32,7 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 use serde::Deserialize;
 
 use super::fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField};
-use super::traits::{IsPrimeField, LegendreSymbol};
+use super::traits::{IsPrimeField, IsSubFieldOf, LegendreSymbol};
 
 /// A field element with operations algorithms defined in `F`
 #[allow(clippy::derived_hash_with_manual_eq)]
@@ -119,59 +119,64 @@ where
 impl<F> Eq for FieldElement<F> where F: IsField {}
 
 /// Addition operator overloading for field elements
-impl<F> Add<&FieldElement<F>> for &FieldElement<F>
+impl<F, L> Add<&FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn add(self, rhs: &FieldElement<F>) -> Self::Output {
+    fn add(self, rhs: &FieldElement<L>) -> Self::Output {
         Self::Output {
-            value: F::add(&self.value, &rhs.value),
+            value: <F as IsSubFieldOf<L>>::add(&self.value, &rhs.value),
         }
     }
 }
 
-impl<F> Add<FieldElement<F>> for FieldElement<F>
+impl<F, L> Add<FieldElement<L>> for FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn add(self, rhs: FieldElement<F>) -> Self::Output {
+    fn add(self, rhs: FieldElement<L>) -> Self::Output {
         &self + &rhs
     }
 }
 
-impl<F> Add<&FieldElement<F>> for FieldElement<F>
+impl<F, L> Add<&FieldElement<L>> for FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn add(self, rhs: &FieldElement<F>) -> Self::Output {
+    fn add(self, rhs: &FieldElement<L>) -> Self::Output {
         &self + rhs
     }
 }
 
-impl<F> Add<FieldElement<F>> for &FieldElement<F>
+impl<F, L> Add<FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn add(self, rhs: FieldElement<F>) -> Self::Output {
+    fn add(self, rhs: FieldElement<L>) -> Self::Output {
         self + &rhs
     }
 }
 
 /// AddAssign operator overloading for field elements
-impl<F> AddAssign<FieldElement<F>> for FieldElement<F>
+impl<F, L> AddAssign<FieldElement<F>> for FieldElement<L>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
     fn add_assign(&mut self, rhs: FieldElement<F>) {
-        self.value = F::add(&self.value, &rhs.value);
+        self.value = <F as IsSubFieldOf<L>>::add(&rhs.value, &self.value);
     }
 }
 
@@ -186,142 +191,154 @@ where
 }
 
 /// Subtraction operator overloading for field elements*/
-impl<F> Sub<&FieldElement<F>> for &FieldElement<F>
+impl<F, L> Sub<&FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn sub(self, rhs: &FieldElement<F>) -> Self::Output {
+    fn sub(self, rhs: &FieldElement<L>) -> Self::Output {
         Self::Output {
-            value: F::sub(&self.value, &rhs.value),
+            value: <F as IsSubFieldOf<L>>::sub(&self.value, &rhs.value),
         }
     }
 }
 
-impl<F> Sub<FieldElement<F>> for FieldElement<F>
+impl<F, L> Sub<FieldElement<L>> for FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn sub(self, rhs: FieldElement<F>) -> Self::Output {
+    fn sub(self, rhs: FieldElement<L>) -> Self::Output {
         &self - &rhs
     }
 }
 
-impl<F> Sub<&FieldElement<F>> for FieldElement<F>
+impl<F, L> Sub<&FieldElement<L>> for FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn sub(self, rhs: &FieldElement<F>) -> Self::Output {
+    fn sub(self, rhs: &FieldElement<L>) -> Self::Output {
         &self - rhs
     }
 }
 
-impl<F> Sub<FieldElement<F>> for &FieldElement<F>
+impl<F, L> Sub<FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn sub(self, rhs: FieldElement<F>) -> Self::Output {
+    fn sub(self, rhs: FieldElement<L>) -> Self::Output {
         self - &rhs
     }
 }
 
 /// Multiplication operator overloading for field elements*/
-impl<F> Mul<&FieldElement<F>> for &FieldElement<F>
+impl<F, L> Mul<&FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn mul(self, rhs: &FieldElement<F>) -> Self::Output {
+    fn mul(self, rhs: &FieldElement<L>) -> Self::Output {
         Self::Output {
-            value: F::mul(&self.value, &rhs.value),
+            value: <F as IsSubFieldOf<L>>::mul(&self.value, &rhs.value),
         }
     }
 }
 
-impl<F> Mul<FieldElement<F>> for FieldElement<F>
+impl<F, L> Mul<FieldElement<L>> for FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn mul(self, rhs: FieldElement<F>) -> Self::Output {
+    fn mul(self, rhs: FieldElement<L>) -> Self::Output {
         &self * &rhs
     }
 }
 
-impl<F> Mul<&FieldElement<F>> for FieldElement<F>
+impl<F, L> Mul<&FieldElement<L>> for FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn mul(self, rhs: &FieldElement<F>) -> Self::Output {
+    fn mul(self, rhs: &FieldElement<L>) -> Self::Output {
         &self * rhs
     }
 }
 
-impl<F> Mul<FieldElement<F>> for &FieldElement<F>
+impl<F, L> Mul<FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn mul(self, rhs: FieldElement<F>) -> Self::Output {
+    fn mul(self, rhs: FieldElement<L>) -> Self::Output {
         self * &rhs
     }
 }
 
 /// Division operator overloading for field elements*/
-impl<F> Div<&FieldElement<F>> for &FieldElement<F>
+impl<F, L> Div<&FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn div(self, rhs: &FieldElement<F>) -> Self::Output {
+    fn div(self, rhs: &FieldElement<L>) -> Self::Output {
         Self::Output {
-            value: F::div(&self.value, &rhs.value),
+            value: <F as IsSubFieldOf<L>>::div(&self.value, &rhs.value),
         }
     }
 }
 
-impl<F> Div<FieldElement<F>> for FieldElement<F>
+impl<F, L> Div<FieldElement<L>> for FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn div(self, rhs: FieldElement<F>) -> Self::Output {
+    fn div(self, rhs: FieldElement<L>) -> Self::Output {
         &self / &rhs
     }
 }
 
-impl<F> Div<&FieldElement<F>> for FieldElement<F>
+impl<F, L> Div<&FieldElement<L>> for FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn div(self, rhs: &FieldElement<F>) -> Self::Output {
+    fn div(self, rhs: &FieldElement<L>) -> Self::Output {
         &self / rhs
     }
 }
 
-impl<F> Div<FieldElement<F>> for &FieldElement<F>
+impl<F, L> Div<FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField,
+    F: IsField + IsSubFieldOf<L>,
+    L: IsField,
 {
-    type Output = FieldElement<F>;
+    type Output = FieldElement<L>;
 
-    fn div(self, rhs: FieldElement<F>) -> Self::Output {
+    fn div(self, rhs: FieldElement<L>) -> Self::Output {
         self / &rhs
     }
 }
@@ -418,6 +435,16 @@ where
     pub fn zero() -> Self {
         Self { value: F::zero() }
     }
+
+    #[inline(always)]
+    pub fn to_extension<L: IsField>(self) -> FieldElement<L>
+    where
+        F: IsSubFieldOf<L>,
+    {
+        FieldElement {
+            value: <F as IsSubFieldOf<L>>::embed(self.value),
+        }
+    }
 }
 
 impl<F: IsPrimeField> FieldElement<F> {
@@ -450,7 +477,11 @@ impl<F: IsPrimeField> FieldElement<F> {
 }
 
 #[cfg(feature = "lambdaworks-serde-binary")]
-impl<F: IsPrimeField> Serialize for FieldElement<F> {
+impl<F> Serialize for FieldElement<F>
+where
+    F: IsField,
+    F::BaseType: ByteConversion,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -478,7 +509,11 @@ impl<F: IsPrimeField> Serialize for FieldElement<F> {
 }
 
 #[cfg(feature = "lambdaworks-serde-binary")]
-impl<'de, F: IsPrimeField> Deserialize<'de> for FieldElement<F> {
+impl<'de, F> Deserialize<'de> for FieldElement<F>
+where
+    F: IsField,
+    F::BaseType: ByteConversion,
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -491,7 +526,7 @@ impl<'de, F: IsPrimeField> Deserialize<'de> for FieldElement<F> {
 
         struct FieldElementVisitor<F>(PhantomData<fn() -> F>);
 
-        impl<'de, F: IsPrimeField> Visitor<'de> for FieldElementVisitor<F> {
+        impl<'de, F: IsField> Visitor<'de> for FieldElementVisitor<F> {
             type Value = FieldElement<F>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -95,9 +95,9 @@ where
     F::BaseType: Clone,
     F: IsField,
 {
-    pub fn from_raw(value: &F::BaseType) -> Self {
+    pub fn from_raw(value: F::BaseType) -> Self {
         Self {
-            value: value.clone(),
+            value,
         }
     }
 
@@ -550,7 +550,7 @@ where
                 }
                 let value = value.ok_or_else(|| de::Error::missing_field("value"))?;
                 let val = F::BaseType::from_bytes_be(&value).unwrap();
-                Ok(FieldElement::from_raw(&val))
+                Ok(FieldElement::from_raw(val))
             }
 
             fn visit_seq<S>(self, mut seq: S) -> Result<FieldElement<F>, S::Error>
@@ -566,7 +566,7 @@ where
                 }
                 let value = value.ok_or_else(|| de::Error::missing_field("value"))?;
                 let val = F::BaseType::from_bytes_be(&value).unwrap();
-                Ok(FieldElement::from_raw(&val))
+                Ok(FieldElement::from_raw(val))
             }
         }
 

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -119,7 +119,7 @@ impl<F> Eq for FieldElement<F> where F: IsField {}
 /// Addition operator overloading for field elements
 impl<F, L> Add<&FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -133,7 +133,7 @@ where
 
 impl<F, L> Add<FieldElement<L>> for FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -145,7 +145,7 @@ where
 
 impl<F, L> Add<&FieldElement<L>> for FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -157,7 +157,7 @@ where
 
 impl<F, L> Add<FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -170,7 +170,7 @@ where
 /// AddAssign operator overloading for field elements
 impl<F, L> AddAssign<FieldElement<F>> for FieldElement<L>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     fn add_assign(&mut self, rhs: FieldElement<F>) {
@@ -191,7 +191,7 @@ where
 /// Subtraction operator overloading for field elements*/
 impl<F, L> Sub<&FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -205,7 +205,7 @@ where
 
 impl<F, L> Sub<FieldElement<L>> for FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -217,7 +217,7 @@ where
 
 impl<F, L> Sub<&FieldElement<L>> for FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -229,7 +229,7 @@ where
 
 impl<F, L> Sub<FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -242,7 +242,7 @@ where
 /// Multiplication operator overloading for field elements*/
 impl<F, L> Mul<&FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -256,7 +256,7 @@ where
 
 impl<F, L> Mul<FieldElement<L>> for FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -268,7 +268,7 @@ where
 
 impl<F, L> Mul<&FieldElement<L>> for FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -280,7 +280,7 @@ where
 
 impl<F, L> Mul<FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -293,7 +293,7 @@ where
 /// Division operator overloading for field elements*/
 impl<F, L> Div<&FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -307,7 +307,7 @@ where
 
 impl<F, L> Div<FieldElement<L>> for FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -319,7 +319,7 @@ where
 
 impl<F, L> Div<&FieldElement<L>> for FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;
@@ -331,7 +331,7 @@ where
 
 impl<F, L> Div<FieldElement<L>> for &FieldElement<F>
 where
-    F: IsField + IsSubFieldOf<L>,
+    F: IsSubFieldOf<L>,
     L: IsField,
 {
     type Output = FieldElement<L>;

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -96,9 +96,7 @@ where
     F: IsField,
 {
     pub fn from_raw(value: F::BaseType) -> Self {
-        Self {
-            value,
-        }
+        Self { value }
     }
 
     pub const fn const_from_raw(value: F::BaseType) -> Self {

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -106,7 +106,7 @@ where
     fn inv(
         a: &[FieldElement<Q::BaseField>; 3],
     ) -> Result<[FieldElement<Q::BaseField>; 3], FieldError> {
-        let three = FieldElement::from(3_u64);
+        let three = FieldElement::<Q::BaseField>::from(3_u64);
 
         let d = a[0].pow(3_u64)
             + a[1].pow(3_u64) * Q::residue()

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -19,7 +19,6 @@ pub trait IsSubFieldOf<F: IsField>: IsField {
     fn add(a: &Self::BaseType, b: &F::BaseType) -> F::BaseType;
     fn div(a: &Self::BaseType, b: &F::BaseType) -> F::BaseType;
     fn sub(a: &Self::BaseType, b: &F::BaseType) -> F::BaseType;
-    fn eq(a: &Self::BaseType, b: &F::BaseType) -> bool;
     fn embed(a: Self::BaseType) -> F::BaseType;
 }
 
@@ -45,11 +44,6 @@ where
     #[inline(always)]
     fn div(a: &Self::BaseType, b: &F::BaseType) -> F::BaseType {
         F::div(a, b)
-    }
-
-    #[inline(always)]
-    fn eq(a: &Self::BaseType, b: &F::BaseType) -> bool {
-        F::eq(a, b)
     }
 
     #[inline(always)]

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -14,6 +14,50 @@ pub enum RootsConfig {
     BitReverseInversed, // same as above but exponents are negated.
 }
 
+pub trait IsSubFieldOf<F: IsField>: IsField {
+    fn mul(a: &Self::BaseType, b: &F::BaseType) -> F::BaseType;
+    fn add(a: &Self::BaseType, b: &F::BaseType) -> F::BaseType;
+    fn div(a: &Self::BaseType, b: &F::BaseType) -> F::BaseType;
+    fn sub(a: &Self::BaseType, b: &F::BaseType) -> F::BaseType;
+    fn eq(a: &Self::BaseType, b: &F::BaseType) -> bool;
+    fn embed(a: Self::BaseType) -> F::BaseType;
+}
+
+impl<F> IsSubFieldOf<F> for F
+where
+    F: IsField,
+{
+    #[inline(always)]
+    fn mul(a: &Self::BaseType, b: &F::BaseType) -> F::BaseType {
+        F::mul(a, b)
+    }
+
+    #[inline(always)]
+    fn add(a: &Self::BaseType, b: &F::BaseType) -> F::BaseType {
+        F::add(a, b)
+    }
+
+    #[inline(always)]
+    fn sub(a: &Self::BaseType, b: &F::BaseType) -> F::BaseType {
+        F::sub(a, b)
+    }
+
+    #[inline(always)]
+    fn div(a: &Self::BaseType, b: &F::BaseType) -> F::BaseType {
+        F::div(a, b)
+    }
+
+    #[inline(always)]
+    fn eq(a: &Self::BaseType, b: &F::BaseType) -> bool {
+        F::eq(a, b)
+    }
+
+    #[inline(always)]
+    fn embed(a: Self::BaseType) -> F::BaseType {
+        a
+    }
+}
+
 /// Trait to define necessary parameters for FFT-friendly Fields.
 /// Two-Adic fields are ones whose order is of the form  $2^n k + 1$.
 /// Here $n$ is usually called the *two-adicity* of the field. The
@@ -22,7 +66,7 @@ pub enum RootsConfig {
 /// A two-adic primitive root of unity is a number w that satisfies w^(2^n) = 1
 /// and w^(j) != 1 for every j below 2^n. With this primitive root we can generate
 /// any other root of unity we need to perform FFT.
-pub trait IsFFTField: IsPrimeField {
+pub trait IsFFTField: IsField {
     const TWO_ADICITY: u64;
     const TWO_ADIC_PRIMITVE_ROOT_OF_UNITY: Self::BaseType;
 
@@ -33,18 +77,18 @@ pub trait IsFFTField: IsPrimeField {
     }
 
     /// Returns a primitive root of unity of order $2^{order}$.
-    fn get_primitive_root_of_unity<F: IsFFTField>(
+    fn get_primitive_root_of_unity(
         order: u64,
-    ) -> Result<FieldElement<F>, FieldError> {
+    ) -> Result<FieldElement<Self>, FieldError> {
         let two_adic_primitive_root_of_unity =
-            FieldElement::new(F::TWO_ADIC_PRIMITVE_ROOT_OF_UNITY);
+            FieldElement::new(Self::TWO_ADIC_PRIMITVE_ROOT_OF_UNITY);
         if order == 0 {
             return Ok(FieldElement::one());
         }
-        if order > F::TWO_ADICITY {
+        if order > Self::TWO_ADICITY {
             return Err(FieldError::RootOfUnityError(order));
         }
-        let log_power = F::TWO_ADICITY - order;
+        let log_power = Self::TWO_ADICITY - order;
         let root = (0..log_power).fold(two_adic_primitive_root_of_unity, |acc, _| acc.square());
         Ok(root)
     }

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -71,9 +71,7 @@ pub trait IsFFTField: IsField {
     }
 
     /// Returns a primitive root of unity of order $2^{order}$.
-    fn get_primitive_root_of_unity(
-        order: u64,
-    ) -> Result<FieldElement<Self>, FieldError> {
+    fn get_primitive_root_of_unity(order: u64) -> Result<FieldElement<Self>, FieldError> {
         let two_adic_primitive_root_of_unity =
             FieldElement::new(Self::TWO_ADIC_PRIMITVE_ROOT_OF_UNITY);
         if order == 0 {

--- a/provers/stark/src/debug.rs
+++ b/provers/stark/src/debug.rs
@@ -85,9 +85,7 @@ pub fn validate_trace<F: IsFFTField, A: AIR<Field = F>>(
                 ret = false;
                 error!(
                     "Inconsistent evaluation of transition {} in step {} - expected 0, got {:?}",
-                    i,
-                    step,
-                    eval
+                    i, step, eval
                 );
             }
         })

--- a/provers/stark/src/debug.rs
+++ b/provers/stark/src/debug.rs
@@ -51,7 +51,7 @@ pub fn validate_trace<F: IsFFTField, A: AIR<Field = F>>(
 
             if &boundary_value != trace_value {
                 ret = false;
-                error!("Boundary constraint inconsistency - Expected value {} in step {} and column {}, found: {}", boundary_value.representative(), step, col, trace_value.representative());
+                error!("Boundary constraint inconsistency - Expected value {:?} in step {} and column {}, found: {:?}", boundary_value, step, col, trace_value);
             }
         });
 
@@ -84,10 +84,10 @@ pub fn validate_trace<F: IsFFTField, A: AIR<Field = F>>(
             if step < exemption_steps[i] && eval != &FieldElement::<F>::zero() {
                 ret = false;
                 error!(
-                    "Inconsistent evaluation of transition {} in step {} - expected 0, got {}",
+                    "Inconsistent evaluation of transition {} in step {} - expected 0, got {:?}",
                     i,
                     step,
-                    eval.representative()
+                    eval
                 );
             }
         })

--- a/provers/stark/src/fri/fri_decommit.rs
+++ b/provers/stark/src/fri/fri_decommit.rs
@@ -2,12 +2,12 @@ pub use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
 use lambdaworks_crypto::merkle_tree::proof::Proof;
 
 use lambdaworks_math::field::element::FieldElement;
-use lambdaworks_math::field::traits::IsPrimeField;
+use lambdaworks_math::field::traits::IsField;
 
 use crate::config::Commitment;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct FriDecommitment<F: IsPrimeField> {
+pub struct FriDecommitment<F: IsField> {
     pub layers_auth_paths: Vec<Proof<Commitment>>,
     pub layers_evaluations_sym: Vec<FieldElement<F>>,
 }

--- a/provers/stark/src/prover.rs
+++ b/provers/stark/src/prover.rs
@@ -964,7 +964,7 @@ mod tests {
         for i in 0..(trace_length * blowup_factor) {
             assert_eq!(
                 domain.lde_roots_of_unity_coset[i],
-                FieldElement::from(coset_offset) * primitive_root.pow(i)
+                primitive_root.pow(i) * FieldElement::from(coset_offset) 
             );
         }
     }

--- a/provers/stark/src/prover.rs
+++ b/provers/stark/src/prover.rs
@@ -964,7 +964,7 @@ mod tests {
         for i in 0..(trace_length * blowup_factor) {
             assert_eq!(
                 domain.lde_roots_of_unity_coset[i],
-                primitive_root.pow(i) * FieldElement::from(coset_offset) 
+                primitive_root.pow(i) * FieldElement::from(coset_offset)
             );
         }
     }

--- a/provers/stark/src/transcript.rs
+++ b/provers/stark/src/transcript.rs
@@ -138,7 +138,7 @@ impl IsStarkTranscript<Stark252PrimeField> for StoneProverTranscript {
         while result >= Self::MODULUS_MAX_MULTIPLE {
             result = self.sample_big_int();
         }
-        FieldElement::new(result) * FieldElement::new(Self::R_INV)
+        FieldElement::<Stark252PrimeField>::new(result) * FieldElement::new(Self::R_INV)
     }
 
     fn sample_u64(&mut self, upper_bound: u64) -> u64 {


### PR DESCRIPTION
# Implement subfield logic

## Description

this PR models subfields as a first step towards supporting field towers in the stark prover. Given a field tower L/F, this PR supports operations between elements of F and elements of L.

## Type of change
- [x] New feature

## Checklist
- [x] Unit tests added