### PR TITLE
perf: parallel Merkle tree construction

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,6 +13,7 @@ sha3 = "0.10"
 sha2 = "0.10"
 thiserror = "1.0.38"
 serde = { version = "1.0", features = ["derive"] }
+rayon = { version = "1.8.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.4"
@@ -21,6 +22,7 @@ rand = "0.8.5"
 
 [features]
 test_fiat_shamir = []
+parallel = ["dep:rayon"]
 
 [[bench]]
 name = "criterion_merkle"

--- a/provers/stark/Cargo.toml
+++ b/provers/stark/Cargo.toml
@@ -45,7 +45,7 @@ wasm-bindgen-test = "0.3.0"
 test_fiat_shamir = []
 instruments = []                   # This enables timing prints in prover and verifier
 metal = ["lambdaworks-math/metal"]
-parallel = ["dep:rayon"]
+parallel = ["dep:rayon", "lambdaworks-crypto/parallel"]
 wasm = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen", "dep:web-sys"]
 
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]


### PR DESCRIPTION
perf: add parallel Merkle tree generation feature

- Adds a new `parallel` feature to `lambdaworks-crypto`
- Hashes Merkle tree leaves in parallel when the `parallel` feature is enabled
- The Platinum prover forwards the `parallel` feature to `lambdaworks-crypto` when enabled

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] This change is an Optimization
  - [x] Benchmarks added/run

## Benchmark Results

Server specs:
```sh
# lscpu
Architecture:            x86_64
  CPU op-mode(s):        32-bit, 64-bit
  Address sizes:         40 bits physical, 48 bits virtual
  Byte Order:            Little Endian
CPU(s):                  4           
  On-line CPU(s) list:   0-3         
Vendor ID:               AuthenticAMD
  BIOS Vendor ID:        QEMU        
  Model name:            AMD EPYC Processor                                                                            
    BIOS Model name:     NotSpecified  CPU @ 2.0GHz                                                                    
    BIOS CPU family:     1                                                                                             
    CPU family:          25                                                                                                                                                                                                                   
    Model:               1           
    Thread(s) per core:  2           
    Core(s) per socket:  2                                                                                             
    Socket(s):           1
    Stepping:            1
    BogoMIPS:            4890.80
    Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm rep_good nopl cpuid extd_apicid tsc_known_freq pni pclmulqdq ssse3 
                         fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext perfctr_core invpcid_single ssbd ibrs ibpb stibp 
                         vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves clzero xsaveerptr wbnoinvd arat umip pku ospke rdpid fsrm
Virtualization features: 
  Hypervisor vendor:     KVM
  Virtualization type:   full
Caches (sum of all):     
  L1d:                   64 KiB (2 instances)
  L1i:                   64 KiB (2 instances)
  L2:                    1 MiB (2 instances)
  L3:                    32 MiB (1 instance)
NUMA:                    
  NUMA node(s):          1
  NUMA node0 CPU(s):     0-3

# free -h
               total        used        free      shared  buff/cache   available
Mem:            15Gi       785Mi        11Gi       3.9Mi       3.3Gi        14Gi
Swap:             0B          0B          0B
```

```sh
# ./bench.sh 
Benchmark 1: stone
  Time (mean ± σ):     180.104 s ±  0.087 s    [User: 687.630 s, System: 4.754 s]
  Range (min … max):   180.005 s … 180.167 s    3 runs
 
Benchmark 2: base_seq
  Time (mean ± σ):     122.768 s ±  0.306 s    [User: 117.721 s, System: 5.031 s]
  Range (min … max):   122.590 s … 123.122 s    3 runs

Benchmark 3: base_par
  Time (mean ± σ):     78.712 s ±  0.131 s    [User: 163.179 s, System: 7.017 s]
  Range (min … max):   78.564 s … 78.811 s    3 runs

Benchmark 4: merkle_seq
  Time (mean ± σ):     122.581 s ±  0.122 s    [User: 117.637 s, System: 4.934 s]
  Range (min … max):   122.441 s … 122.662 s    3 runs

Benchmark 5: merkle_par
  Time (mean ± σ):     69.529 s ±  0.117 s    [User: 174.739 s, System: 7.037 s]
  Range (min … max):   69.395 s … 69.612 s    3 runs

Summary
  merkle_par ran
    1.13 ± 0.00 times faster than base_par
    1.76 ± 0.00 times faster than merkle_seq
    1.77 ± 0.01 times faster than base_seq
    2.59 ± 0.00 times faster than stone
```

```sh
# cat bench.sh 
hyperfine -N -r 3 \
        -n "stone" "./cpu_air_prover --out_file=/dev/null --private_input_file=fibonacci_private_input_70k.json --public_input_file=fibonacci_public_input_70k.json --prover_config_file=cpu_air_prover_config.json --parameter_file=cpu_air_params_70k.json" \
        -n "base_seq" "./base_seq prove fibonacci_trace_70k.json fibonacci_memory_70k.json /dev/null" \
        -n "base_par" "./base_par prove fibonacci_trace_70k.json fibonacci_memory_70k.json /dev/null" \
        -n "merkle_seq" "./merkle_seq prove fibonacci_trace_70k.json fibonacci_memory_70k.json /dev/null" \
        -n "merkle_par" "./merkle_par prove fibonacci_trace_70k.json fibonacci_memory_70k.json /dev/null" \
```

`stone`: stone prover
`base_seq`: Platinum main branch compiled without parallel support
`base_par`: Platinum main branch compiled with parallel support
`merkle_seq`: this branch compiled without parallel support
`merkle_par`: this branch compiled with parallel support