### PR TITLE
Stark: Prover and Verifier over field extensions

### DIFF
--- a/math/src/polynomial.rs
+++ b/math/src/polynomial.rs
@@ -1095,7 +1095,7 @@ mod tests {
         }
     }
 
-    use proptest::prelude::*;
+    
     proptest! {
         #[test]
         fn ruffini_inplace_equals_ruffini(p in any::<Vec<u64>>(), b in any::<u64>()) {

--- a/math/src/polynomial.rs
+++ b/math/src/polynomial.rs
@@ -1095,7 +1095,6 @@ mod tests {
         }
     }
 
-    
     proptest! {
         #[test]
         fn ruffini_inplace_equals_ruffini(p in any::<Vec<u64>>(), b in any::<u64>()) {

--- a/math/src/polynomial.rs
+++ b/math/src/polynomial.rs
@@ -157,7 +157,7 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
                 coefficients.push(c.clone());
                 c = coeff + c * b;
             }
-            coefficients = coefficients.into_iter().rev().collect();
+            coefficients.reverse();
             Polynomial::new(&coefficients)
         } else {
             Polynomial::zero()

--- a/math/src/polynomial.rs
+++ b/math/src/polynomial.rs
@@ -90,12 +90,16 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
         Ok(result)
     }
 
-    pub fn evaluate(&self, x: &FieldElement<F>) -> FieldElement<F> {
+    pub fn evaluate<E>(&self, x: &FieldElement<E>) -> FieldElement<E>
+    where
+        E: IsField,
+        F: IsSubFieldOf<E>,
+    {
         self.coefficients
             .iter()
             .rev()
             .fold(FieldElement::zero(), |acc, coeff| {
-                acc * x.to_owned() + coeff
+                coeff + acc * x.to_owned()
             })
     }
 
@@ -131,23 +135,6 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
         self.coefficients().len()
     }
 
-    pub fn pad_with_zero_coefficients_to_length(pa: &mut Self, n: usize) {
-        pa.coefficients.resize(n, FieldElement::zero());
-    }
-
-    /// Pads polynomial representations with minimum number of zeros to match lengths.
-    pub fn pad_with_zero_coefficients(pa: &Self, pb: &Self) -> (Self, Self) {
-        let mut pa = pa.clone();
-        let mut pb = pb.clone();
-
-        if pa.coefficients.len() > pb.coefficients.len() {
-            Self::pad_with_zero_coefficients_to_length(&mut pb, pa.coefficients.len());
-        } else {
-            Self::pad_with_zero_coefficients_to_length(&mut pa, pb.coefficients.len());
-        }
-        (pa, pb)
-    }
-
     /// Computes quotient with `x - b` in place.
     pub fn ruffini_division_inplace(&mut self, b: &FieldElement<F>) {
         let mut c = FieldElement::zero();
@@ -156,6 +143,25 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
             core::mem::swap(coeff, &mut c);
         }
         self.coefficients.pop();
+    }
+
+    pub fn ruffini_division<L>(&self, b: &FieldElement<L>) -> Polynomial<FieldElement<L>>
+    where
+        L: IsField,
+        F: IsSubFieldOf<L>,
+    {
+        if let Some(c) = self.coefficients.last() {
+            let mut c = c.clone().to_extension();
+            let mut coefficients = Vec::with_capacity(self.degree());
+            for coeff in self.coefficients.iter().rev().skip(1) {
+                coefficients.push(c.clone());
+                c = coeff + c * b;
+            }
+            coefficients = coefficients.into_iter().rev().collect();
+            Polynomial::new(&coefficients)
+        } else {
+            Polynomial::zero()
+        }
     }
 
     /// Computes quotient and remainder of polynomial division.
@@ -246,6 +252,42 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
         }
         parts
     }
+
+    pub fn to_extension<L: IsField>(self) -> Polynomial<FieldElement<L>>
+    where
+        F: IsSubFieldOf<L>,
+    {
+        Polynomial {
+            coefficients: self
+                .coefficients
+                .into_iter()
+                .map(|x| x.to_extension::<L>())
+                .collect(),
+        }
+    }
+}
+
+pub fn pad_with_zero_coefficients_to_length<F: IsField>(
+    pa: &mut Polynomial<FieldElement<F>>,
+    n: usize,
+) {
+    pa.coefficients.resize(n, FieldElement::zero());
+}
+
+/// Pads polynomial representations with minimum number of zeros to match lengths.
+pub fn pad_with_zero_coefficients<L: IsField, F: IsSubFieldOf<L>>(
+    pa: &Polynomial<FieldElement<F>>,
+    pb: &Polynomial<FieldElement<L>>,
+) -> (Polynomial<FieldElement<F>>, Polynomial<FieldElement<L>>) {
+    let mut pa = pa.clone();
+    let mut pb = pb.clone();
+
+    if pa.coefficients.len() > pb.coefficients.len() {
+        pad_with_zero_coefficients_to_length(&mut pb, pa.coefficients.len());
+    } else {
+        pad_with_zero_coefficients_to_length(&mut pa, pb.coefficients.len());
+    }
+    (pa, pb)
 }
 
 pub fn compose<F>(
@@ -274,39 +316,55 @@ where
         .expect("xs and ys have equal length and xs are unique")
 }
 
-impl<F: IsField> ops::Add<&Polynomial<FieldElement<F>>> for &Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Add<&Polynomial<FieldElement<L>>> for &Polynomial<FieldElement<F>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn add(self, a_polynomial: &Polynomial<FieldElement<F>>) -> Self::Output {
-        let (pa, pb) = Polynomial::pad_with_zero_coefficients(self, a_polynomial);
+    fn add(self, a_polynomial: &Polynomial<FieldElement<L>>) -> Self::Output {
+        let (pa, pb) = pad_with_zero_coefficients(self, a_polynomial);
         let iter_coeff_pa = pa.coefficients.iter();
         let iter_coeff_pb = pb.coefficients.iter();
         let new_coefficients = iter_coeff_pa.zip(iter_coeff_pb).map(|(x, y)| x + y);
-        let new_coefficients_vec = new_coefficients.collect::<Vec<FieldElement<F>>>();
+        let new_coefficients_vec = new_coefficients.collect::<Vec<FieldElement<L>>>();
         Polynomial::new(&new_coefficients_vec)
     }
 }
 
-impl<F: IsField> ops::Add<Polynomial<FieldElement<F>>> for Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Add<Polynomial<FieldElement<L>>> for Polynomial<FieldElement<F>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn add(self, a_polynomial: Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn add(self, a_polynomial: Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         &self + &a_polynomial
     }
 }
 
-impl<F: IsField> ops::Add<&Polynomial<FieldElement<F>>> for Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Add<&Polynomial<FieldElement<L>>> for Polynomial<FieldElement<F>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn add(self, a_polynomial: &Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn add(self, a_polynomial: &Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         &self + a_polynomial
     }
 }
 
-impl<F: IsField> ops::Add<Polynomial<FieldElement<F>>> for &Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Add<Polynomial<FieldElement<L>>> for &Polynomial<FieldElement<F>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn add(self, a_polynomial: Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn add(self, a_polynomial: Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         self + &a_polynomial
     }
 }
@@ -332,39 +390,58 @@ impl<F: IsField> ops::Neg for Polynomial<FieldElement<F>> {
     }
 }
 
-impl<F: IsField> ops::Sub<Polynomial<FieldElement<F>>> for Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Sub<&Polynomial<FieldElement<L>>> for &Polynomial<FieldElement<F>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn sub(self, substrahend: Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
-        &self - &substrahend
-    }
-}
-
-impl<F: IsField> ops::Sub<&Polynomial<FieldElement<F>>> for Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
-
-    fn sub(self, substrahend: &Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
-        &self - substrahend
-    }
-}
-
-impl<F: IsField> ops::Sub<Polynomial<FieldElement<F>>> for &Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
-
-    fn sub(self, substrahend: Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
-        self - &substrahend
-    }
-}
-
-impl<F: IsField> ops::Sub<&Polynomial<FieldElement<F>>> for &Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
-
-    fn sub(self, substrahend: &Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn sub(self, substrahend: &Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         self + (-substrahend)
     }
 }
 
-impl<F: IsField> ops::Div<Polynomial<FieldElement<F>>> for Polynomial<FieldElement<F>> {
+impl<F, L> ops::Sub<Polynomial<FieldElement<L>>> for Polynomial<FieldElement<F>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
+
+    fn sub(self, substrahend: Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
+        &self - &substrahend
+    }
+}
+
+impl<F, L> ops::Sub<&Polynomial<FieldElement<L>>> for Polynomial<FieldElement<F>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
+
+    fn sub(self, substrahend: &Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
+        &self - substrahend
+    }
+}
+
+impl<F, L> ops::Sub<Polynomial<FieldElement<L>>> for &Polynomial<FieldElement<F>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
+
+    fn sub(self, substrahend: Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
+        self - &substrahend
+    }
+}
+
+impl<F> ops::Div<Polynomial<FieldElement<F>>> for Polynomial<FieldElement<F>>
+where
+    F: IsField,
+{
     type Output = Polynomial<FieldElement<F>>;
 
     fn div(self, dividend: Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
@@ -402,14 +479,18 @@ impl<F: IsField> ops::Mul<&Polynomial<FieldElement<F>>> for Polynomial<FieldElem
 
 /* Operations between Polynomials and field elements */
 /* Multiplication field element at left */
-impl<F: IsField> ops::Mul<FieldElement<F>> for Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Mul<FieldElement<F>> for Polynomial<FieldElement<L>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn mul(self, multiplicand: FieldElement<F>) -> Polynomial<FieldElement<F>> {
+    fn mul(self, multiplicand: FieldElement<F>) -> Polynomial<FieldElement<L>> {
         let new_coefficients = self
             .coefficients
             .iter()
-            .map(|value| value * &multiplicand)
+            .map(|value| &multiplicand * value)
             .collect();
         Polynomial {
             coefficients: new_coefficients,
@@ -417,191 +498,283 @@ impl<F: IsField> ops::Mul<FieldElement<F>> for Polynomial<FieldElement<F>> {
     }
 }
 
-impl<F: IsField> ops::Mul<&FieldElement<F>> for &Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Mul<&FieldElement<F>> for &Polynomial<FieldElement<L>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn mul(self, multiplicand: &FieldElement<F>) -> Polynomial<FieldElement<F>> {
+    fn mul(self, multiplicand: &FieldElement<F>) -> Polynomial<FieldElement<L>> {
         self.clone() * multiplicand.clone()
     }
 }
 
-impl<F: IsField> ops::Mul<FieldElement<F>> for &Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Mul<FieldElement<F>> for &Polynomial<FieldElement<L>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn mul(self, multiplicand: FieldElement<F>) -> Polynomial<FieldElement<F>> {
+    fn mul(self, multiplicand: FieldElement<F>) -> Polynomial<FieldElement<L>> {
         self * &multiplicand
     }
 }
 
-impl<F: IsField> ops::Mul<&FieldElement<F>> for Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Mul<&FieldElement<F>> for Polynomial<FieldElement<L>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn mul(self, multiplicand: &FieldElement<F>) -> Polynomial<FieldElement<F>> {
+    fn mul(self, multiplicand: &FieldElement<F>) -> Polynomial<FieldElement<L>> {
         &self * multiplicand
     }
 }
 
 /* Multiplication field element at right */
-impl<F: IsField> ops::Mul<&Polynomial<FieldElement<F>>> for &FieldElement<F> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Mul<&Polynomial<FieldElement<L>>> for &FieldElement<F>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn mul(self, multiplicand: &Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn mul(self, multiplicand: &Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         multiplicand * self
     }
 }
 
-impl<F: IsField> ops::Mul<Polynomial<FieldElement<F>>> for &FieldElement<F> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Mul<Polynomial<FieldElement<L>>> for &FieldElement<F>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn mul(self, multiplicand: Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn mul(self, multiplicand: Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         &multiplicand * self
     }
 }
 
-impl<F: IsField> ops::Mul<&Polynomial<FieldElement<F>>> for FieldElement<F> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Mul<&Polynomial<FieldElement<L>>> for FieldElement<F>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn mul(self, multiplicand: &Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn mul(self, multiplicand: &Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         multiplicand * self
     }
 }
 
-impl<F: IsField> ops::Mul<Polynomial<FieldElement<F>>> for FieldElement<F> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Mul<Polynomial<FieldElement<L>>> for FieldElement<F>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn mul(self, multiplicand: Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn mul(self, multiplicand: Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         &multiplicand * &self
     }
 }
 
 /* Addition field element at left */
-impl<F: IsField> ops::Add<&FieldElement<F>> for &Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Add<&FieldElement<F>> for &Polynomial<FieldElement<L>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn add(self, other: &FieldElement<F>) -> Polynomial<FieldElement<F>> {
+    fn add(self, other: &FieldElement<F>) -> Polynomial<FieldElement<L>> {
         Polynomial::new_monomial(other.clone(), 0) + self
     }
 }
 
-impl<F: IsField> ops::Add<FieldElement<F>> for Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Add<FieldElement<F>> for Polynomial<FieldElement<L>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn add(self, other: FieldElement<F>) -> Polynomial<FieldElement<F>> {
+    fn add(self, other: FieldElement<F>) -> Polynomial<FieldElement<L>> {
         &self + &other
     }
 }
 
-impl<F: IsField> ops::Add<FieldElement<F>> for &Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Add<FieldElement<F>> for &Polynomial<FieldElement<L>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn add(self, other: FieldElement<F>) -> Polynomial<FieldElement<F>> {
+    fn add(self, other: FieldElement<F>) -> Polynomial<FieldElement<L>> {
         self + &other
     }
 }
 
-impl<F: IsField> ops::Add<&FieldElement<F>> for Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Add<&FieldElement<F>> for Polynomial<FieldElement<L>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn add(self, other: &FieldElement<F>) -> Polynomial<FieldElement<F>> {
+    fn add(self, other: &FieldElement<F>) -> Polynomial<FieldElement<L>> {
         &self + other
     }
 }
 
 /* Addition field element at right */
-impl<F: IsField> ops::Add<&Polynomial<FieldElement<F>>> for &FieldElement<F> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Add<&Polynomial<FieldElement<L>>> for &FieldElement<F>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn add(self, other: &Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn add(self, other: &Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         Polynomial::new_monomial(self.clone(), 0) + other
     }
 }
 
-impl<F: IsField> ops::Add<Polynomial<FieldElement<F>>> for FieldElement<F> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Add<Polynomial<FieldElement<L>>> for FieldElement<F>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn add(self, other: Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn add(self, other: Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         &self + &other
     }
 }
 
-impl<F: IsField> ops::Add<Polynomial<FieldElement<F>>> for &FieldElement<F> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Add<Polynomial<FieldElement<L>>> for &FieldElement<F>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn add(self, other: Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn add(self, other: Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         self + &other
     }
 }
 
-impl<F: IsField> ops::Add<&Polynomial<FieldElement<F>>> for FieldElement<F> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Add<&Polynomial<FieldElement<L>>> for FieldElement<F>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn add(self, other: &Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn add(self, other: &Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         &self + other
     }
 }
 
 /* Substraction field element at left */
-impl<F: IsField> ops::Sub<&FieldElement<F>> for &Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Sub<&FieldElement<F>> for &Polynomial<FieldElement<L>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn sub(self, other: &FieldElement<F>) -> Polynomial<FieldElement<F>> {
-        self - Polynomial::new_monomial(other.clone(), 0)
+    fn sub(self, other: &FieldElement<F>) -> Polynomial<FieldElement<L>> {
+        -Polynomial::new_monomial(other.clone(), 0) + self
     }
 }
 
-impl<F: IsField> ops::Sub<FieldElement<F>> for Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Sub<FieldElement<F>> for Polynomial<FieldElement<L>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn sub(self, other: FieldElement<F>) -> Polynomial<FieldElement<F>> {
+    fn sub(self, other: FieldElement<F>) -> Polynomial<FieldElement<L>> {
         &self - &other
     }
 }
 
-impl<F: IsField> ops::Sub<FieldElement<F>> for &Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Sub<FieldElement<F>> for &Polynomial<FieldElement<L>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn sub(self, other: FieldElement<F>) -> Polynomial<FieldElement<F>> {
+    fn sub(self, other: FieldElement<F>) -> Polynomial<FieldElement<L>> {
         self - &other
     }
 }
 
-impl<F: IsField> ops::Sub<&FieldElement<F>> for Polynomial<FieldElement<F>> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Sub<&FieldElement<F>> for Polynomial<FieldElement<L>>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn sub(self, other: &FieldElement<F>) -> Polynomial<FieldElement<F>> {
+    fn sub(self, other: &FieldElement<F>) -> Polynomial<FieldElement<L>> {
         &self - other
     }
 }
 
 /* Substraction field element at right */
-impl<F: IsField> ops::Sub<&Polynomial<FieldElement<F>>> for &FieldElement<F> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Sub<&Polynomial<FieldElement<L>>> for &FieldElement<F>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn sub(self, other: &Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn sub(self, other: &Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         Polynomial::new_monomial(self.clone(), 0) - other
     }
 }
 
-impl<F: IsField> ops::Sub<Polynomial<FieldElement<F>>> for FieldElement<F> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Sub<Polynomial<FieldElement<L>>> for FieldElement<F>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn sub(self, other: Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn sub(self, other: Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         &self - &other
     }
 }
 
-impl<F: IsField> ops::Sub<Polynomial<FieldElement<F>>> for &FieldElement<F> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Sub<Polynomial<FieldElement<L>>> for &FieldElement<F>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn sub(self, other: Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn sub(self, other: Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         self - &other
     }
 }
 
-impl<F: IsField> ops::Sub<&Polynomial<FieldElement<F>>> for FieldElement<F> {
-    type Output = Polynomial<FieldElement<F>>;
+impl<F, L> ops::Sub<&Polynomial<FieldElement<L>>> for FieldElement<F>
+where
+    L: IsField,
+    F: IsSubFieldOf<L>,
+{
+    type Output = Polynomial<FieldElement<L>>;
 
-    fn sub(self, other: &Polynomial<FieldElement<F>>) -> Polynomial<FieldElement<F>> {
+    fn sub(self, other: &Polynomial<FieldElement<L>>) -> Polynomial<FieldElement<L>> {
         &self - other
     }
 }
@@ -711,7 +884,7 @@ mod tests {
         let p2 = Polynomial::new(&[FE::new(3)]);
 
         assert_eq!(p2.coefficients, &[FE::new(3)]);
-        let (pp1, pp2) = Polynomial::pad_with_zero_coefficients(&p1, &p2);
+        let (pp1, pp2) = pad_with_zero_coefficients(&p1, &p2);
         assert_eq!(pp1, p1);
         assert_eq!(pp2.coefficients, &[FE::new(3), FE::new(0)]);
     }
@@ -909,7 +1082,7 @@ mod tests {
     use proptest::prelude::*;
     proptest! {
         #[test]
-        fn ruffini_equals_division(p in any::<Vec<u64>>(), b in any::<u64>()) {
+        fn ruffini_inplace_equals_division(p in any::<Vec<u64>>(), b in any::<u64>()) {
             let p: Vec<_> = p.into_iter().map(FE::from).collect();
             let mut p = Polynomial::new(&p);
             let b = FE::from(b);
@@ -919,6 +1092,19 @@ mod tests {
 
             p.ruffini_division_inplace(&b);
             prop_assert_eq!(p, p_ref / m);
+        }
+    }
+
+    use proptest::prelude::*;
+    proptest! {
+        #[test]
+        fn ruffini_inplace_equals_ruffini(p in any::<Vec<u64>>(), b in any::<u64>()) {
+            let p: Vec<_> = p.into_iter().map(FE::from).collect();
+            let mut p = Polynomial::new(&p);
+            let b = FE::from(b);
+            let q = p.ruffini_division(&b);
+            p.ruffini_division_inplace(&b);
+            prop_assert_eq!(q, p);
         }
     }
 }

--- a/provers/cairo/src/air.rs
+++ b/provers/cairo/src/air.rs
@@ -615,6 +615,7 @@ fn generate_range_check_permutation_argument_column(
 
 impl AIR for CairoAIR {
     type Field = Stark252PrimeField;
+    type FieldExtension = Stark252PrimeField;
     type RAPChallenges = CairoRAPChallenges;
     type PublicInputs = PublicInputs;
 

--- a/provers/cairo/src/tests/integration_tests.rs
+++ b/provers/cairo/src/tests/integration_tests.rs
@@ -141,7 +141,7 @@ fn check_simple_cairo_trace_evaluates_to_zero() {
     let program_content = std::fs::read(cairo0_program_path("simple_program.json")).unwrap();
     let (main_trace, public_input) =
         generate_prover_args(&program_content, CairoLayout::Plain).unwrap();
-    let mut trace_polys = main_trace.compute_trace_polys();
+    let mut trace_polys = main_trace.compute_trace_polys::<Stark252PrimeField>();
     let mut transcript = StoneProverTranscript::new(&[]);
 
     let proof_options = ProofOptions::default_test_options();
@@ -149,7 +149,7 @@ fn check_simple_cairo_trace_evaluates_to_zero() {
     let rap_challenges = cairo_air.build_rap_challenges(&mut transcript);
 
     let aux_trace = cairo_air.build_auxiliary_trace(&main_trace, &rap_challenges);
-    let aux_polys = aux_trace.compute_trace_polys();
+    let aux_polys = aux_trace.compute_trace_polys::<Stark252PrimeField>();
 
     trace_polys.extend_from_slice(&aux_polys);
 

--- a/provers/plonk/src/prover.rs
+++ b/provers/plonk/src/prover.rs
@@ -9,7 +9,10 @@ use crate::setup::{
     new_strong_fiat_shamir_transcript, CommonPreprocessedInput, VerificationKey, Witness,
 };
 use lambdaworks_crypto::commitments::traits::IsCommitmentScheme;
-use lambdaworks_math::{field::element::FieldElement, polynomial::Polynomial};
+use lambdaworks_math::{
+    field::element::FieldElement,
+    polynomial::{self, Polynomial},
+};
 use lambdaworks_math::{field::traits::IsField, traits::ByteConversion};
 
 /// Plonk proof.
@@ -318,7 +321,7 @@ where
             .expect("xs and ys have equal length and xs are unique");
 
         let z_h = Polynomial::new_monomial(FieldElement::one(), common_preprocessed_input.n)
-            - FieldElement::one();
+            - FieldElement::<F>::one();
         let p_a = self.blind_polynomial(&p_a, &z_h, 2);
         let p_b = self.blind_polynomial(&p_b, &z_h, 2);
         let p_c = self.blind_polynomial(&p_c, &z_h, 2);
@@ -366,7 +369,7 @@ where
         let p_z = Polynomial::interpolate_fft::<F>(&coefficients)
             .expect("xs and ys have equal length and xs are unique");
         let z_h = Polynomial::new_monomial(FieldElement::one(), common_preprocessed_input.n)
-            - FieldElement::one();
+            - FieldElement::<F>::one();
         let p_z = self.blind_polynomial(&p_z, &z_h, 3);
         let z_1 = self.commitment_scheme.commit(&p_z);
         Round2Result {
@@ -392,7 +395,7 @@ where
 
         let one = Polynomial::new_monomial(FieldElement::one(), 0);
         let p_x = &Polynomial::new_monomial(FieldElement::<F>::one(), 1);
-        let zh = Polynomial::new_monomial(FieldElement::one(), cpi.n) - &one;
+        let zh = Polynomial::new_monomial(FieldElement::<F>::one(), cpi.n) - &one;
 
         let z_x_omega_coefficients: Vec<FieldElement<F>> = p_z
             .coefficients()
@@ -503,7 +506,7 @@ where
             .collect();
         let mut t = Polynomial::interpolate_offset_fft(&c, offset).unwrap();
 
-        Polynomial::pad_with_zero_coefficients_to_length(&mut t, 3 * (&cpi.n + 2));
+        polynomial::pad_with_zero_coefficients_to_length(&mut t, 3 * (&cpi.n + 2));
         let p_t_lo = Polynomial::new(&t.coefficients[..&cpi.n + 2]);
         let p_t_mid = Polynomial::new(&t.coefficients[&cpi.n + 2..2 * (&cpi.n + 2)]);
         let p_t_hi = Polynomial::new(&t.coefficients[2 * (&cpi.n + 2)..3 * (&cpi.n + 2)]);
@@ -573,7 +576,7 @@ where
 
         let l1_zeta = (&r4.zeta.pow(cpi.n as u64) - FieldElement::<F>::one())
             / (&r4.zeta - FieldElement::<F>::one())
-            / FieldElement::from(cpi.n as u64);
+            / FieldElement::<F>::from(cpi.n as u64);
 
         let mut p_non_constant = &cpi.qm * &r4.a_zeta * &r4.b_zeta
             + &r4.a_zeta * &cpi.ql

--- a/provers/stark/src/constraints/evaluator.rs
+++ b/provers/stark/src/constraints/evaluator.rs
@@ -1,7 +1,10 @@
 use itertools::Itertools;
 use lambdaworks_math::{
     fft::{cpu::roots_of_unity::get_powers_of_primitive_root_coset, errors::FFTError},
-    field::{element::FieldElement, traits::IsFFTField},
+    field::{
+        element::FieldElement,
+        traits::{IsFFTField, IsField, IsSubFieldOf},
+    },
     polynomial::Polynomial,
     traits::Serializable,
 };
@@ -20,7 +23,7 @@ use crate::traits::AIR;
 use crate::{frame::Frame, prover::evaluate_polynomial_on_lde_domain};
 
 pub struct ConstraintEvaluator<A: AIR> {
-    boundary_constraints: BoundaryConstraints<A::Field>,
+    boundary_constraints: BoundaryConstraints<A::FieldExtension>,
 }
 impl<A: AIR> ConstraintEvaluator<A> {
     pub fn new(air: &A, rap_challenges: &A::RAPChallenges) -> Self {
@@ -252,10 +255,10 @@ impl<A: AIR> ConstraintEvaluator<A> {
     }
 }
 
-fn evaluate_transition_exemptions<F: IsFFTField>(
-    transition_exemptions: Vec<Polynomial<FieldElement<F>>>,
+fn evaluate_transition_exemptions<F: IsFFTField + IsSubFieldOf<E>, E: IsField>(
+    transition_exemptions: Vec<Polynomial<FieldElement<E>>>,
     domain: &Domain<F>,
-) -> Vec<Vec<FieldElement<F>>>
+) -> Vec<Vec<FieldElement<E>>>
 where
     FieldElement<F>: Send + Sync + Serializable,
     Polynomial<FieldElement<F>>: Send + Sync,

--- a/provers/stark/src/constraints/evaluator.rs
+++ b/provers/stark/src/constraints/evaluator.rs
@@ -45,6 +45,7 @@ impl<A: AIR> ConstraintEvaluator<A> {
     ) -> Vec<FieldElement<A::FieldExtension>>
     where
         FieldElement<A::Field>: Serializable + Send + Sync,
+        FieldElement<A::FieldExtension>: Serializable + Send + Sync,
         A: Send + Sync,
         A::RAPChallenges: Send + Sync,
     {
@@ -261,6 +262,7 @@ fn evaluate_transition_exemptions<F: IsFFTField + IsSubFieldOf<E>, E: IsField>(
 ) -> Vec<Vec<FieldElement<E>>>
 where
     FieldElement<F>: Send + Sync + Serializable,
+    FieldElement<E>: Send + Sync + Serializable,
     Polynomial<FieldElement<F>>: Send + Sync,
 {
     #[cfg(feature = "parallel")]

--- a/provers/stark/src/debug.rs
+++ b/provers/stark/src/debug.rs
@@ -46,7 +46,7 @@ pub fn validate_trace<A: AIR>(
             let boundary_value = constraint.value.clone();
             let trace_value = trace.get(step, col);
 
-            if &boundary_value.to_extension() != trace_value {
+            if &boundary_value.clone().to_extension() != trace_value {
                 ret = false;
                 error!("Boundary constraint inconsistency - Expected value {:?} in step {} and column {}, found: {:?}", boundary_value, step, col, trace_value);
             }

--- a/provers/stark/src/debug.rs
+++ b/provers/stark/src/debug.rs
@@ -4,7 +4,10 @@ use crate::trace::TraceTable;
 use super::domain::Domain;
 use super::traits::AIR;
 use lambdaworks_math::{
-    field::{element::FieldElement, traits::{IsFFTField, IsField}},
+    field::{
+        element::FieldElement,
+        traits::{IsFFTField, IsField},
+    },
     polynomial::Polynomial,
 };
 use log::{error, info};
@@ -22,7 +25,8 @@ pub fn validate_trace<A: AIR>(
     let trace_columns: Vec<_> = trace_polys
         .iter()
         .map(|poly| {
-            Polynomial::evaluate_fft::<A::Field>(poly, 1, Some(domain.interpolation_domain_size)).unwrap()
+            Polynomial::evaluate_fft::<A::Field>(poly, 1, Some(domain.interpolation_domain_size))
+                .unwrap()
         })
         .collect();
 
@@ -32,7 +36,8 @@ pub fn validate_trace<A: AIR>(
         .get_periodic_column_polynomials()
         .iter()
         .map(|poly| {
-            Polynomial::evaluate_fft::<A::Field>(poly, 1, Some(domain.interpolation_domain_size)).unwrap()
+            Polynomial::evaluate_fft::<A::Field>(poly, 1, Some(domain.interpolation_domain_size))
+                .unwrap()
         })
         .collect();
 

--- a/provers/stark/src/examples/dummy_air.rs
+++ b/provers/stark/src/examples/dummy_air.rs
@@ -21,6 +21,7 @@ pub struct DummyAIR {
 
 impl AIR for DummyAIR {
     type Field = Stark252PrimeField;
+    type FieldExtension = Stark252PrimeField;
     type RAPChallenges = ();
     type PublicInputs = ();
 
@@ -55,7 +56,7 @@ impl AIR for DummyAIR {
 
     fn build_rap_challenges(
         &self,
-        _transcript: &mut impl IsStarkTranscript<Self::Field>,
+        _transcript: &mut impl IsStarkTranscript<Self::FieldExtension>,
     ) -> Self::RAPChallenges {
     }
     fn compute_transition(

--- a/provers/stark/src/examples/fibonacci_2_cols_shifted.rs
+++ b/provers/stark/src/examples/fibonacci_2_cols_shifted.rs
@@ -53,6 +53,7 @@ where
     F: IsFFTField,
 {
     type Field = F;
+    type FieldExtension = F;
     type RAPChallenges = ();
     type PublicInputs = PublicInputs<Self::Field>;
 
@@ -88,7 +89,7 @@ where
 
     fn build_rap_challenges(
         &self,
-        _transcript: &mut impl IsStarkTranscript<Self::Field>,
+        _transcript: &mut impl IsStarkTranscript<Self::FieldExtension>,
     ) -> Self::RAPChallenges {
     }
 

--- a/provers/stark/src/examples/fibonacci_2_columns.rs
+++ b/provers/stark/src/examples/fibonacci_2_columns.rs
@@ -29,6 +29,7 @@ where
     F: IsFFTField,
 {
     type Field = F;
+    type FieldExtension = F;
     type RAPChallenges = ();
     type PublicInputs = FibonacciPublicInputs<Self::Field>;
 
@@ -64,7 +65,7 @@ where
 
     fn build_rap_challenges(
         &self,
-        _transcript: &mut impl IsStarkTranscript<Self::Field>,
+        _transcript: &mut impl IsStarkTranscript<Self::FieldExtension>,
     ) -> Self::RAPChallenges {
     }
 

--- a/provers/stark/src/examples/fibonacci_rap.rs
+++ b/provers/stark/src/examples/fibonacci_rap.rs
@@ -42,6 +42,7 @@ where
     FieldElement<F>: ByteConversion,
 {
     type Field = F;
+    type FieldExtension = F;
     type RAPChallenges = FieldElement<Self::Field>;
     type PublicInputs = FibonacciRAPPublicInputs<Self::Field>;
 

--- a/provers/stark/src/examples/quadratic_air.rs
+++ b/provers/stark/src/examples/quadratic_air.rs
@@ -33,6 +33,7 @@ where
     F: IsFFTField,
 {
     type Field = F;
+    type FieldExtension = F;
     type RAPChallenges = ();
     type PublicInputs = QuadraticPublicInputs<Self::Field>;
 
@@ -68,7 +69,7 @@ where
 
     fn build_rap_challenges(
         &self,
-        _transcript: &mut impl IsStarkTranscript<Self::Field>,
+        _transcript: &mut impl IsStarkTranscript<Self::FieldExtension>,
     ) -> Self::RAPChallenges {
     }
 

--- a/provers/stark/src/examples/simple_fibonacci.rs
+++ b/provers/stark/src/examples/simple_fibonacci.rs
@@ -34,6 +34,7 @@ where
     F: IsFFTField,
 {
     type Field = F;
+    type FieldExtension = F;
     type RAPChallenges = ();
     type PublicInputs = FibonacciPublicInputs<Self::Field>;
 
@@ -73,7 +74,7 @@ where
 
     fn build_rap_challenges(
         &self,
-        _transcript: &mut impl IsStarkTranscript<Self::Field>,
+        _transcript: &mut impl IsStarkTranscript<Self::FieldExtension>,
     ) -> Self::RAPChallenges {
     }
 

--- a/provers/stark/src/examples/simple_periodic_cols.rs
+++ b/provers/stark/src/examples/simple_periodic_cols.rs
@@ -48,6 +48,7 @@ where
     F: IsFFTField,
 {
     type Field = F;
+    type FieldExtension = F;
     type RAPChallenges = ();
     type PublicInputs = SimplePeriodicPublicInputs<Self::Field>;
 
@@ -87,7 +88,7 @@ where
 
     fn build_rap_challenges(
         &self,
-        _transcript: &mut impl IsStarkTranscript<Self::Field>,
+        _transcript: &mut impl IsStarkTranscript<Self::FieldExtension>,
     ) -> Self::RAPChallenges {
     }
 

--- a/provers/stark/src/frame.rs
+++ b/provers/stark/src/frame.rs
@@ -1,16 +1,16 @@
 use super::trace::TraceTable;
 use crate::trace::StepView;
-use lambdaworks_math::field::traits::IsFFTField;
+use lambdaworks_math::field::traits::{IsFFTField, IsField};
 
 /// A frame represents a collection of trace steps.
 /// The collected steps are all the necessary steps for
 /// all transition costraints over a trace to be evaluated.
 #[derive(Clone, Debug, PartialEq)]
-pub struct Frame<'t, F: IsFFTField> {
+pub struct Frame<'t, F: IsField> {
     steps: Vec<StepView<'t, F>>,
 }
 
-impl<'t, F: IsFFTField> Frame<'t, F> {
+impl<'t, F: IsField> Frame<'t, F> {
     pub fn new(steps: Vec<StepView<'t, F>>) -> Self {
         Self { steps }
     }

--- a/provers/stark/src/frame.rs
+++ b/provers/stark/src/frame.rs
@@ -1,6 +1,6 @@
 use super::trace::TraceTable;
 use crate::trace::StepView;
-use lambdaworks_math::field::traits::{IsField};
+use lambdaworks_math::field::traits::IsField;
 
 /// A frame represents a collection of trace steps.
 /// The collected steps are all the necessary steps for

--- a/provers/stark/src/frame.rs
+++ b/provers/stark/src/frame.rs
@@ -1,6 +1,6 @@
 use super::trace::TraceTable;
 use crate::trace::StepView;
-use lambdaworks_math::field::traits::{IsFFTField, IsField};
+use lambdaworks_math::field::traits::{IsField};
 
 /// A frame represents a collection of trace steps.
 /// The collected steps are all the necessary steps for

--- a/provers/stark/src/fri/fri_commitment.rs
+++ b/provers/stark/src/fri/fri_commitment.rs
@@ -22,7 +22,7 @@ where
 
 impl<F, B> FriLayer<F, B>
 where
-    F: IsField + IsFFTField,
+    F: IsField,
     FieldElement<F>: Serializable,
     B: IsMerkleTreeBackend,
 {

--- a/provers/stark/src/fri/fri_commitment.rs
+++ b/provers/stark/src/fri/fri_commitment.rs
@@ -2,7 +2,7 @@ use lambdaworks_crypto::merkle_tree::{merkle::MerkleTree, traits::IsMerkleTreeBa
 use lambdaworks_math::{
     field::{
         element::FieldElement,
-        traits::{IsFFTField, IsField},
+        traits::{IsField},
     },
     traits::Serializable,
 };

--- a/provers/stark/src/fri/fri_commitment.rs
+++ b/provers/stark/src/fri/fri_commitment.rs
@@ -1,9 +1,6 @@
 use lambdaworks_crypto::merkle_tree::{merkle::MerkleTree, traits::IsMerkleTreeBackend};
 use lambdaworks_math::{
-    field::{
-        element::FieldElement,
-        traits::{IsField},
-    },
+    field::{element::FieldElement, traits::IsField},
     traits::Serializable,
 };
 

--- a/provers/stark/src/fri/fri_functions.rs
+++ b/provers/stark/src/fri/fri_functions.rs
@@ -1,5 +1,5 @@
 use super::Polynomial;
-use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+use lambdaworks_math::{field::{element::FieldElement, traits::IsField}, polynomial};
 
 pub fn fold_polynomial<F>(
     poly: &Polynomial<FieldElement<F>>,
@@ -19,7 +19,7 @@ where
         .map(|v| (v.clone()) * beta)
         .collect();
 
-    let (even_poly, odd_poly) = Polynomial::pad_with_zero_coefficients(
+    let (even_poly, odd_poly) = polynomial::pad_with_zero_coefficients(
         &Polynomial::new(&even_coef),
         &Polynomial::new(&odd_coef_mul_beta),
     );

--- a/provers/stark/src/fri/fri_functions.rs
+++ b/provers/stark/src/fri/fri_functions.rs
@@ -1,5 +1,8 @@
 use super::Polynomial;
-use lambdaworks_math::{field::{element::FieldElement, traits::IsField}, polynomial};
+use lambdaworks_math::{
+    field::{element::FieldElement, traits::IsField},
+    polynomial,
+};
 
 pub fn fold_polynomial<F>(
     poly: &Polynomial<FieldElement<F>>,

--- a/provers/stark/src/fri/mod.rs
+++ b/provers/stark/src/fri/mod.rs
@@ -48,7 +48,7 @@ where
         domain_size /= 2;
 
         // Compute layer polynomial and domain
-        current_poly = fold_polynomial(&current_poly, &zeta) * FieldElement::from(2);
+        current_poly =  FieldElement::<F>::from(2) * fold_polynomial(&current_poly, &zeta);
         current_layer = new_fri_layer(&current_poly, &coset_offset, domain_size);
         let new_data = &current_layer.merkle_tree.root;
         fri_layer_list.push(current_layer.clone()); // TODO: remove this clone
@@ -60,7 +60,7 @@ where
     // <<<< Receive challenge: 𝜁ₙ₋₁
     let zeta = transcript.sample_field_element();
 
-    let last_poly = fold_polynomial(&current_poly, &zeta) * FieldElement::from(2);
+    let last_poly =  FieldElement::<F>::from(2) * fold_polynomial(&current_poly, &zeta);
 
     let last_value = last_poly
         .coefficients()

--- a/provers/stark/src/fri/mod.rs
+++ b/provers/stark/src/fri/mod.rs
@@ -48,7 +48,7 @@ where
         domain_size /= 2;
 
         // Compute layer polynomial and domain
-        current_poly =  FieldElement::<F>::from(2) * fold_polynomial(&current_poly, &zeta);
+        current_poly = FieldElement::<F>::from(2) * fold_polynomial(&current_poly, &zeta);
         current_layer = new_fri_layer(&current_poly, &coset_offset, domain_size);
         let new_data = &current_layer.merkle_tree.root;
         fri_layer_list.push(current_layer.clone()); // TODO: remove this clone
@@ -60,7 +60,7 @@ where
     // <<<< Receive challenge: 𝜁ₙ₋₁
     let zeta = transcript.sample_field_element();
 
-    let last_poly =  FieldElement::<F>::from(2) * fold_polynomial(&current_poly, &zeta);
+    let last_poly = FieldElement::<F>::from(2) * fold_polynomial(&current_poly, &zeta);
 
     let last_value = last_poly
         .coefficients()
@@ -133,5 +133,10 @@ where
 
     let merkle_tree = BatchedMerkleTree::build(&to_commit);
 
-    FriLayer::new(&evaluation, merkle_tree, coset_offset.clone().to_extension(), domain_size)
+    FriLayer::new(
+        &evaluation,
+        merkle_tree,
+        coset_offset.clone().to_extension(),
+        domain_size,
+    )
 }

--- a/provers/stark/src/proof/stark.rs
+++ b/provers/stark/src/proof/stark.rs
@@ -3,9 +3,8 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use lambdaworks_crypto::merkle_tree::proof::Proof;
 use lambdaworks_math::{
     field::{
-        element::FieldElement,
-        fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
-        traits::{IsField},
+        element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
+        traits::IsField,
     },
     traits::Serializable,
 };

--- a/provers/stark/src/proof/stark.rs
+++ b/provers/stark/src/proof/stark.rs
@@ -4,7 +4,7 @@ use lambdaworks_crypto::merkle_tree::proof::Proof;
 use lambdaworks_math::{
     field::{
         element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
-        traits::IsFFTField,
+        traits::{IsFFTField, IsField},
     },
     traits::Serializable,
 };
@@ -22,7 +22,7 @@ use crate::{
 use super::options::ProofOptions;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct DeepPolynomialOpening<F: IsFFTField> {
+pub struct DeepPolynomialOpening<F: IsField> {
     pub lde_composition_poly_proof: Proof<Commitment>,
     pub lde_composition_poly_parts_evaluation: Vec<FieldElement<F>>,
     pub lde_trace_merkle_proofs: Vec<Proof<Commitment>>,
@@ -32,7 +32,7 @@ pub struct DeepPolynomialOpening<F: IsFFTField> {
 pub type DeepPolynomialOpenings<F> = Vec<DeepPolynomialOpening<F>>;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub struct StarkProof<F: IsFFTField> {
+pub struct StarkProof<F: IsField> {
     // Length of the execution trace
     pub trace_length: usize,
     // Commitments of the trace columns
@@ -69,7 +69,7 @@ impl StoneCompatibleSerializer {
         options: &ProofOptions,
     ) -> Vec<u8>
     where
-        A: AIR<Field = Stark252PrimeField>,
+        A: AIR<Field = Stark252PrimeField, FieldExtension = Stark252PrimeField>,
         A::PublicInputs: Serializable,
     {
         let mut output = Vec::new();
@@ -409,7 +409,7 @@ impl StoneCompatibleSerializer {
         proof_options: &ProofOptions,
     ) -> Vec<usize>
     where
-        A: AIR<Field = Stark252PrimeField>,
+        A: AIR<Field = Stark252PrimeField, FieldExtension = Stark252PrimeField>,
         A::PublicInputs: Serializable,
     {
         let mut transcript = StoneProverTranscript::new(&public_inputs.serialize());

--- a/provers/stark/src/proof/stark.rs
+++ b/provers/stark/src/proof/stark.rs
@@ -3,7 +3,8 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use lambdaworks_crypto::merkle_tree::proof::Proof;
 use lambdaworks_math::{
     field::{
-        element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
+        element::FieldElement,
+        fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
         traits::{IsFFTField, IsField},
     },
     traits::Serializable,

--- a/provers/stark/src/proof/stark.rs
+++ b/provers/stark/src/proof/stark.rs
@@ -5,7 +5,7 @@ use lambdaworks_math::{
     field::{
         element::FieldElement,
         fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
-        traits::{IsFFTField, IsField},
+        traits::{IsField},
     },
     traits::Serializable,
 };

--- a/provers/stark/src/prover.rs
+++ b/provers/stark/src/prover.rs
@@ -5,6 +5,7 @@ use lambdaworks_crypto::merkle_tree::proof::Proof;
 use lambdaworks_math::fft::cpu::bit_reversing::{in_place_bit_reverse_permute, reverse_index};
 use lambdaworks_math::fft::errors::FFTError;
 use lambdaworks_math::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
+use lambdaworks_math::field::traits::{IsField, IsSubFieldOf};
 use lambdaworks_math::traits::Serializable;
 use lambdaworks_math::{
     field::{element::FieldElement, traits::IsFFTField},
@@ -36,6 +37,7 @@ pub struct Prover;
 
 impl IsStarkProver for Prover {
     type Field = Stark252PrimeField;
+    type FieldExtension = Stark252PrimeField;
 }
 
 #[derive(Debug)]
@@ -43,22 +45,21 @@ pub enum ProvingError {
     WrongParameter(String),
 }
 
-pub struct Round1<F, A>
+pub struct Round1<A>
 where
-    F: IsFFTField,
-    A: AIR<Field = F>,
-    FieldElement<F>: Serializable + Sync + Send,
+    A: AIR,
+    FieldElement<A::FieldExtension>: Serializable + Sync + Send,
 {
-    pub(crate) trace_polys: Vec<Polynomial<FieldElement<F>>>,
-    pub(crate) lde_trace: TraceTable<F>,
-    pub(crate) lde_trace_merkle_trees: Vec<BatchedMerkleTree<F>>,
+    pub(crate) trace_polys: Vec<Polynomial<FieldElement<A::FieldExtension>>>,
+    pub(crate) lde_trace: TraceTable<A::FieldExtension>,
+    pub(crate) lde_trace_merkle_trees: Vec<BatchedMerkleTree<A::FieldExtension>>,
     pub(crate) lde_trace_merkle_roots: Vec<Commitment>,
     pub(crate) rap_challenges: A::RAPChallenges,
 }
 
 pub struct Round2<F>
 where
-    F: IsFFTField,
+    F: IsField,
     FieldElement<F>: Serializable + Sync + Send,
 {
     pub(crate) composition_poly_parts: Vec<Polynomial<FieldElement<F>>>,
@@ -67,12 +68,12 @@ where
     pub(crate) composition_poly_root: Commitment,
 }
 
-pub struct Round3<F: IsFFTField> {
+pub struct Round3<F: IsField> {
     trace_ood_evaluations: Vec<Vec<FieldElement<F>>>,
     composition_poly_parts_ood_evaluation: Vec<FieldElement<F>>,
 }
 
-pub struct Round4<F: IsFFTField> {
+pub struct Round4<F: IsField> {
     fri_last_value: FieldElement<F>,
     fri_layers_merkle_roots: Vec<Commitment>,
     deep_poly_openings: DeepPolynomialOpenings<F>,
@@ -80,14 +81,15 @@ pub struct Round4<F: IsFFTField> {
     query_list: Vec<FriDecommitment<F>>,
     nonce: Option<u64>,
 }
-pub fn evaluate_polynomial_on_lde_domain<F>(
-    p: &Polynomial<FieldElement<F>>,
+pub fn evaluate_polynomial_on_lde_domain<F, E>(
+    p: &Polynomial<FieldElement<E>>,
     blowup_factor: usize,
     domain_size: usize,
     offset: &FieldElement<F>,
-) -> Result<Vec<FieldElement<F>>, FFTError>
+) -> Result<Vec<FieldElement<E>>, FFTError>
 where
-    F: IsFFTField,
+    F: IsFFTField + IsSubFieldOf<E>,
+    E: IsField,
 {
     let evaluations = Polynomial::evaluate_offset_fft(p, blowup_factor, Some(domain_size), offset)?;
     let step = evaluations.len() / (domain_size * blowup_factor);
@@ -98,35 +100,38 @@ where
 }
 
 pub trait IsStarkProver {
-    type Field: IsFFTField;
+    type Field: IsFFTField + IsSubFieldOf<Self::FieldExtension>;
+    type FieldExtension: IsField;
 
     fn batch_commit(
-        vectors: &[Vec<FieldElement<Self::Field>>],
-    ) -> (BatchedMerkleTree<Self::Field>, Commitment)
+        vectors: &[Vec<FieldElement<Self::FieldExtension>>],
+    ) -> (BatchedMerkleTree<Self::FieldExtension>, Commitment)
     where
         FieldElement<Self::Field>: Serializable + Sync + Send,
+        FieldElement<Self::FieldExtension>: Serializable + Sync + Send,
     {
-        let tree = BatchedMerkleTree::<Self::Field>::build(vectors);
+        let tree = BatchedMerkleTree::<Self::FieldExtension>::build(vectors);
         let commitment = tree.root;
         (tree, commitment)
     }
 
     #[allow(clippy::type_complexity)]
     fn interpolate_and_commit<A>(
-        trace: &TraceTable<Self::Field>,
+        trace: &TraceTable<Self::FieldExtension>,
         domain: &Domain<Self::Field>,
-        transcript: &mut impl IsStarkTranscript<Self::Field>,
+        transcript: &mut impl IsStarkTranscript<Self::FieldExtension>,
     ) -> (
-        Vec<Polynomial<FieldElement<Self::Field>>>,
-        Vec<Vec<FieldElement<Self::Field>>>,
-        BatchedMerkleTree<Self::Field>,
+        Vec<Polynomial<FieldElement<Self::FieldExtension>>>,
+        Vec<Vec<FieldElement<Self::FieldExtension>>>,
+        BatchedMerkleTree<Self::FieldExtension>,
         Commitment,
     )
     where
         A: AIR<Field = Self::Field>,
         FieldElement<Self::Field>: Serializable + Send + Sync,
+        FieldElement<Self::FieldExtension>: Serializable + Send + Sync,
     {
-        let trace_polys = trace.compute_trace_polys();
+        let trace_polys = trace.compute_trace_polys::<Self::Field>();
 
         // Evaluate those polynomials t_j on the large domain D_LDE.
         let lde_trace_evaluations = Self::compute_lde_trace_evaluations(&trace_polys, domain);
@@ -153,9 +158,9 @@ pub trait IsStarkProver {
     }
 
     fn compute_lde_trace_evaluations(
-        trace_polys: &[Polynomial<FieldElement<Self::Field>>],
+        trace_polys: &[Polynomial<FieldElement<Self::FieldExtension>>],
         domain: &Domain<Self::Field>,
-    ) -> Vec<Vec<FieldElement<Self::Field>>>
+    ) -> Vec<Vec<FieldElement<Self::FieldExtension>>>
     where
         FieldElement<Self::Field>: Send + Sync,
     {
@@ -173,19 +178,20 @@ pub trait IsStarkProver {
                     &domain.coset_offset,
                 )
             })
-            .collect::<Result<Vec<Vec<FieldElement<Self::Field>>>, FFTError>>()
+            .collect::<Result<Vec<Vec<FieldElement<Self::FieldExtension>>>, FFTError>>()
             .unwrap()
     }
 
     fn round_1_randomized_air_with_preprocessing<A>(
         air: &A,
-        main_trace: &TraceTable<Self::Field>,
+        main_trace: &TraceTable<Self::FieldExtension>,
         domain: &Domain<Self::Field>,
-        transcript: &mut impl IsStarkTranscript<Self::Field>,
-    ) -> Result<Round1<Self::Field, A>, ProvingError>
+        transcript: &mut impl IsStarkTranscript<Self::FieldExtension>,
+    ) -> Result<Round1<A>, ProvingError>
     where
-        A: AIR<Field = Self::Field>,
+        A: AIR<Field = Self::Field, FieldExtension = Self::FieldExtension>,
         FieldElement<Self::Field>: Serializable + Send + Sync,
+        FieldElement<Self::FieldExtension>: Serializable + Send + Sync,
     {
         let (mut trace_polys, mut evaluations, main_merkle_tree, main_merkle_root) =
             Self::interpolate_and_commit::<A>(main_trace, domain, transcript);
@@ -218,10 +224,11 @@ pub trait IsStarkProver {
     }
 
     fn commit_composition_polynomial(
-        lde_composition_poly_parts_evaluations: &[Vec<FieldElement<Self::Field>>],
-    ) -> (BatchedMerkleTree<Self::Field>, Commitment)
+        lde_composition_poly_parts_evaluations: &[Vec<FieldElement<Self::FieldExtension>>],
+    ) -> (BatchedMerkleTree<Self::FieldExtension>, Commitment)
     where
         FieldElement<Self::Field>: Serializable + Sync + Send,
+        FieldElement<Self::FieldExtension>: Serializable + Sync + Send,
     {
         // TODO: Remove clones
         let mut lde_composition_poly_evaluations = Vec::new();
@@ -248,14 +255,15 @@ pub trait IsStarkProver {
     fn round_2_compute_composition_polynomial<A>(
         air: &A,
         domain: &Domain<Self::Field>,
-        round_1_result: &Round1<Self::Field, A>,
-        transition_coefficients: &[FieldElement<Self::Field>],
-        boundary_coefficients: &[FieldElement<Self::Field>],
-    ) -> Round2<Self::Field>
+        round_1_result: &Round1<A>,
+        transition_coefficients: &[FieldElement<Self::FieldExtension>],
+        boundary_coefficients: &[FieldElement<Self::FieldExtension>],
+    ) -> Round2<Self::FieldExtension>
     where
-        A: AIR<Field = Self::Field> + Send + Sync,
+        A: AIR<Field = Self::Field, FieldExtension = Self::FieldExtension> + Send + Sync,
         A::RAPChallenges: Send + Sync,
         FieldElement<Self::Field>: Serializable + Send + Sync,
+        FieldElement<Self::FieldExtension>: Serializable + Send + Sync,
     {
         // Create evaluation table
         let evaluator = ConstraintEvaluator::new(air, &round_1_result.rap_challenges);
@@ -301,15 +309,17 @@ pub trait IsStarkProver {
         }
     }
 
-    fn round_3_evaluate_polynomials_in_out_of_domain_element<A: AIR<Field = Self::Field>>(
+    fn round_3_evaluate_polynomials_in_out_of_domain_element<A>(
         air: &A,
         domain: &Domain<Self::Field>,
-        round_1_result: &Round1<Self::Field, A>,
-        round_2_result: &Round2<Self::Field>,
-        z: &FieldElement<Self::Field>,
-    ) -> Round3<Self::Field>
+        round_1_result: &Round1<A>,
+        round_2_result: &Round2<Self::FieldExtension>,
+        z: &FieldElement<Self::FieldExtension>,
+    ) -> Round3<Self::FieldExtension>
     where
         FieldElement<Self::Field>: Serializable + Sync + Send,
+        FieldElement<Self::FieldExtension>: Serializable + Sync + Send,
+        A: AIR<Field = Self::Field, FieldExtension = Self::FieldExtension>,
     {
         let z_power = z.pow(round_2_result.composition_poly_parts.len());
 
@@ -341,17 +351,19 @@ pub trait IsStarkProver {
         }
     }
 
-    fn round_4_compute_and_run_fri_on_the_deep_composition_polynomial<A: AIR<Field = Self::Field>>(
+    fn round_4_compute_and_run_fri_on_the_deep_composition_polynomial<A>(
         air: &A,
         domain: &Domain<Self::Field>,
-        round_1_result: &Round1<Self::Field, A>,
-        round_2_result: &Round2<Self::Field>,
-        round_3_result: &Round3<Self::Field>,
-        z: &FieldElement<Self::Field>,
-        transcript: &mut impl IsStarkTranscript<Self::Field>,
-    ) -> Round4<Self::Field>
+        round_1_result: &Round1<A>,
+        round_2_result: &Round2<Self::FieldExtension>,
+        round_3_result: &Round3<Self::FieldExtension>,
+        z: &FieldElement<Self::FieldExtension>,
+        transcript: &mut impl IsStarkTranscript<Self::FieldExtension>,
+    ) -> Round4<Self::FieldExtension>
     where
         FieldElement<Self::Field>: Serializable + Send + Sync,
+        FieldElement<Self::FieldExtension>: Serializable + Send + Sync,
+        A: AIR<Field = Self::Field, FieldExtension = Self::FieldExtension>,
     {
         let coset_offset_u64 = air.context().proof_options.coset_offset;
         let coset_offset = FieldElement::<Self::Field>::from(coset_offset_u64);
@@ -388,7 +400,7 @@ pub trait IsStarkProver {
         let domain_size = domain.lde_roots_of_unity_coset.len();
 
         // FRI commit and query phases
-        let (fri_last_value, fri_layers) = fri::commit_phase(
+        let (fri_last_value, fri_layers) = fri::commit_phase::<Self::Field, Self::FieldExtension>(
             domain.root_order as usize,
             deep_composition_poly,
             transcript,
@@ -431,7 +443,7 @@ pub trait IsStarkProver {
     fn sample_query_indexes(
         number_of_queries: usize,
         domain: &Domain<Self::Field>,
-        transcript: &mut impl IsStarkTranscript<Self::Field>,
+        transcript: &mut impl IsStarkTranscript<Self::FieldExtension>,
     ) -> Vec<usize> {
         let domain_size = domain.lde_roots_of_unity_coset.len() as u64;
         (0..number_of_queries)
@@ -445,17 +457,18 @@ pub trait IsStarkProver {
     #[allow(clippy::too_many_arguments)]
     fn compute_deep_composition_poly<A>(
         air: &A,
-        trace_polys: &[Polynomial<FieldElement<Self::Field>>],
-        round_2_result: &Round2<Self::Field>,
-        round_3_result: &Round3<Self::Field>,
-        z: &FieldElement<Self::Field>,
+        trace_polys: &[Polynomial<FieldElement<Self::FieldExtension>>],
+        round_2_result: &Round2<Self::FieldExtension>,
+        round_3_result: &Round3<Self::FieldExtension>,
+        z: &FieldElement<Self::FieldExtension>,
         primitive_root: &FieldElement<Self::Field>,
-        composition_poly_gammas: &[FieldElement<Self::Field>],
-        trace_terms_gammas: &[FieldElement<Self::Field>],
-    ) -> Polynomial<FieldElement<Self::Field>>
+        composition_poly_gammas: &[FieldElement<Self::FieldExtension>],
+        trace_terms_gammas: &[FieldElement<Self::FieldExtension>],
+    ) -> Polynomial<FieldElement<Self::FieldExtension>>
     where
-        A: AIR<Field = Self::Field>,
+        A: AIR<Field = Self::Field, FieldExtension = Self::FieldExtension>,
         FieldElement<Self::Field>: Serializable + Send + Sync,
+        FieldElement<Self::FieldExtension>: Serializable + Send + Sync,
     {
         let z_power = z.pow(round_2_result.composition_poly_parts.len());
 
@@ -523,16 +536,17 @@ pub trait IsStarkProver {
     }
 
     fn compute_trace_term(
-        trace_terms: &Polynomial<FieldElement<Self::Field>>,
-        (i, t_j): (usize, &Polynomial<FieldElement<Self::Field>>),
+        trace_terms: &Polynomial<FieldElement<Self::FieldExtension>>,
+        (i, t_j): (usize, &Polynomial<FieldElement<Self::FieldExtension>>),
         trace_frame_length: usize,
-        trace_terms_gammas: &[FieldElement<Self::Field>],
-        trace_frame_evaluations: &[Vec<FieldElement<Self::Field>>],
+        trace_terms_gammas: &[FieldElement<Self::FieldExtension>],
+        trace_frame_evaluations: &[Vec<FieldElement<Self::FieldExtension>>],
         transition_offsets: &[usize],
-        (z, primitive_root): (&FieldElement<Self::Field>, &FieldElement<Self::Field>),
-    ) -> Polynomial<FieldElement<Self::Field>>
+        (z, primitive_root): (&FieldElement<Self::FieldExtension>, &FieldElement<Self::Field>),
+    ) -> Polynomial<FieldElement<Self::FieldExtension>>
     where
         FieldElement<Self::Field>: Serializable + Send + Sync,
+        FieldElement<Self::FieldExtension>: Serializable + Send + Sync,
     {
         let i_times_trace_frame_evaluation = i * trace_frame_length;
         let iter_trace_gammas = trace_terms_gammas
@@ -548,7 +562,7 @@ pub trait IsStarkProver {
                     // @@@ we can avoid this clone
                     let t_j_z = &eval[i];
                     // @@@ this can be pre-computed
-                    let z_shifted = z * primitive_root.pow(*offset);
+                    let z_shifted = primitive_root.pow(*offset) * z;
                     let mut poly = t_j - t_j_z;
                     poly.ruffini_division_inplace(&z_shifted);
                     trace_agg + poly * trace_gamma
@@ -559,12 +573,13 @@ pub trait IsStarkProver {
     }
 
     fn open_composition_poly(
-        composition_poly_merkle_tree: &BatchedMerkleTree<Self::Field>,
-        lde_composition_poly_evaluations: &[Vec<FieldElement<Self::Field>>],
+        composition_poly_merkle_tree: &BatchedMerkleTree<Self::FieldExtension>,
+        lde_composition_poly_evaluations: &[Vec<FieldElement<Self::FieldExtension>>],
         index: usize,
-    ) -> (Proof<Commitment>, Vec<FieldElement<Self::Field>>)
+    ) -> (Proof<Commitment>, Vec<FieldElement<Self::FieldExtension>>)
     where
         FieldElement<Self::Field>: Serializable + Sync + Send,
+        FieldElement<Self::FieldExtension>: Serializable + Sync + Send,
     {
         let proof = composition_poly_merkle_tree
             .get_proof_by_pos(index)
@@ -585,12 +600,13 @@ pub trait IsStarkProver {
 
     fn open_trace_polys(
         domain: &Domain<Self::Field>,
-        lde_trace_merkle_trees: &[BatchedMerkleTree<Self::Field>],
-        lde_trace: &TraceTable<Self::Field>,
+        lde_trace_merkle_trees: &[BatchedMerkleTree<Self::FieldExtension>],
+        lde_trace: &TraceTable<Self::FieldExtension>,
         index: usize,
-    ) -> (Vec<Proof<Commitment>>, Vec<FieldElement<Self::Field>>)
+    ) -> (Vec<Proof<Commitment>>, Vec<FieldElement<Self::FieldExtension>>)
     where
         FieldElement<Self::Field>: Serializable + Sync + Send,
+        FieldElement<Self::FieldExtension>: Serializable + Sync + Send,
     {
         let domain_size = domain.lde_roots_of_unity_coset.len();
         let lde_trace_evaluations = lde_trace
@@ -612,17 +628,19 @@ pub trait IsStarkProver {
 
     /// Open the deep composition polynomial on a list of indexes
     /// and their symmetric elements.
-    fn open_deep_composition_poly<A: AIR<Field = Self::Field>>(
+    fn open_deep_composition_poly<A>(
         domain: &Domain<Self::Field>,
-        round_1_result: &Round1<Self::Field, A>,
-        round_2_result: &Round2<Self::Field>,
+        round_1_result: &Round1<A>,
+        round_2_result: &Round2<Self::FieldExtension>,
         indexes_to_open: &[usize],
     ) -> (
-        DeepPolynomialOpenings<Self::Field>,
-        DeepPolynomialOpenings<Self::Field>,
+        DeepPolynomialOpenings<Self::FieldExtension>,
+        DeepPolynomialOpenings<Self::FieldExtension>,
     )
     where
-        FieldElement<Self::Field>: Serializable + Sync + Send,
+        FieldElement<Self::Field>: Serializable + Send + Sync,
+        FieldElement<Self::FieldExtension>: Serializable + Send + Sync,
+        A: AIR<Field = Self::Field, FieldExtension = Self::FieldExtension>,
     {
         let mut openings = Vec::new();
         let mut openings_symmetric = Vec::new();
@@ -680,18 +698,29 @@ pub trait IsStarkProver {
         main_trace: &TraceTable<Self::Field>,
         pub_inputs: &A::PublicInputs,
         proof_options: &ProofOptions,
-        mut transcript: impl IsStarkTranscript<Self::Field>,
-    ) -> Result<StarkProof<Self::Field>, ProvingError>
+        mut transcript: impl IsStarkTranscript<Self::FieldExtension>,
+    ) -> Result<StarkProof<Self::FieldExtension>, ProvingError>
     where
-        A: AIR<Field = Self::Field> + Send + Sync,
+        A: AIR<Field = Self::Field, FieldExtension = Self::FieldExtension> + Send + Sync,
         A::RAPChallenges: Send + Sync,
         FieldElement<Self::Field>: Serializable + Send + Sync,
+        FieldElement<Self::FieldExtension>: Serializable + Send + Sync,
     {
         info!("Started proof generation...");
         #[cfg(feature = "instruments")]
         println!("- Started round 0: Air Initialization");
         #[cfg(feature = "instruments")]
         let timer0 = Instant::now();
+
+        let main_trace = TraceTable::<Self::FieldExtension>::from_columns(
+            main_trace
+                .columns()
+                .clone()
+                .into_iter()
+                .map(|col| col.into_iter().map(|x| x.to_extension()).collect())
+                .collect(),
+            A::STEP_SIZE,
+        );
 
         let air = A::new(main_trace.n_rows(), pub_inputs, proof_options);
         let domain = Domain::new(&air);
@@ -712,7 +741,7 @@ pub trait IsStarkProver {
 
         let round_1_result = Self::round_1_randomized_air_with_preprocessing::<A>(
             &air,
-            main_trace,
+            &main_trace,
             &domain,
             &mut transcript,
         )?;
@@ -864,7 +893,7 @@ pub trait IsStarkProver {
             round_1_result.trace_polys.len(),
         );
 
-        Ok(StarkProof {
+        Ok(StarkProof::<Self::FieldExtension> {
             // [tⱼ]
             lde_trace_merkle_roots: round_1_result.lde_trace_merkle_roots,
             // tⱼ(zgᵏ)
@@ -972,7 +1001,7 @@ mod tests {
     fn test_evaluate_polynomial_on_lde_domain_on_trace_polys() {
         let trace = simple_fibonacci::fibonacci_trace([Felt252::from(1), Felt252::from(1)], 8);
         let trace_length = trace.n_rows();
-        let trace_polys = trace.compute_trace_polys();
+        let trace_polys = trace.compute_trace_polys::<Stark252PrimeField>();
         let coset_offset = Felt252::from(3);
         let blowup_factor: usize = 2;
         let domain_size = 8;

--- a/provers/stark/src/prover.rs
+++ b/provers/stark/src/prover.rs
@@ -163,6 +163,7 @@ pub trait IsStarkProver {
     ) -> Vec<Vec<FieldElement<Self::FieldExtension>>>
     where
         FieldElement<Self::Field>: Send + Sync,
+        FieldElement<Self::FieldExtension>: Send + Sync,
     {
         #[cfg(not(feature = "parallel"))]
         let trace_polys_iter = trace_polys.iter();

--- a/provers/stark/src/prover.rs
+++ b/provers/stark/src/prover.rs
@@ -542,7 +542,10 @@ pub trait IsStarkProver {
         trace_terms_gammas: &[FieldElement<Self::FieldExtension>],
         trace_frame_evaluations: &[Vec<FieldElement<Self::FieldExtension>>],
         transition_offsets: &[usize],
-        (z, primitive_root): (&FieldElement<Self::FieldExtension>, &FieldElement<Self::Field>),
+        (z, primitive_root): (
+            &FieldElement<Self::FieldExtension>,
+            &FieldElement<Self::Field>,
+        ),
     ) -> Polynomial<FieldElement<Self::FieldExtension>>
     where
         FieldElement<Self::Field>: Serializable + Send + Sync,
@@ -603,7 +606,10 @@ pub trait IsStarkProver {
         lde_trace_merkle_trees: &[BatchedMerkleTree<Self::FieldExtension>],
         lde_trace: &TraceTable<Self::FieldExtension>,
         index: usize,
-    ) -> (Vec<Proof<Commitment>>, Vec<FieldElement<Self::FieldExtension>>)
+    ) -> (
+        Vec<Proof<Commitment>>,
+        Vec<FieldElement<Self::FieldExtension>>,
+    )
     where
         FieldElement<Self::Field>: Serializable + Sync + Send,
         FieldElement<Self::FieldExtension>: Serializable + Sync + Send,

--- a/provers/stark/src/table.rs
+++ b/provers/stark/src/table.rs
@@ -1,4 +1,4 @@
-use lambdaworks_math::field::{element::FieldElement, traits::IsFFTField};
+use lambdaworks_math::field::{element::FieldElement, traits::{IsFFTField, IsField}};
 
 use crate::{frame::Frame, trace::StepView};
 
@@ -8,13 +8,13 @@ use crate::{frame::Frame, trace::StepView};
 /// Since this struct is a representation of a two-dimensional table, all rows should have the same
 /// length.
 #[derive(Clone, Default, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct Table<F: IsFFTField> {
+pub struct Table<F: IsField> {
     pub data: Vec<FieldElement<F>>,
     pub width: usize,
     pub height: usize,
 }
 
-impl<'t, F: IsFFTField> Table<F> {
+impl<'t, F: IsField> Table<F> {
     /// Crates a new Table instance from a one-dimensional array in row major order
     /// and the intended width of the table.
     pub fn new(data: Vec<FieldElement<F>>, width: usize) -> Self {
@@ -141,14 +141,14 @@ impl<'t, F: IsFFTField> Table<F> {
 
 /// A view of a contiguos subset of rows of a table.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TableView<'t, F: IsFFTField> {
+pub struct TableView<'t, F: IsField> {
     pub data: &'t [FieldElement<F>],
     pub table_row_idx: usize,
     pub width: usize,
     pub height: usize,
 }
 
-impl<'t, F: IsFFTField> TableView<'t, F> {
+impl<'t, F: IsField> TableView<'t, F> {
     pub fn new(
         data: &'t [FieldElement<F>],
         table_row_idx: usize,

--- a/provers/stark/src/table.rs
+++ b/provers/stark/src/table.rs
@@ -1,4 +1,7 @@
-use lambdaworks_math::field::{element::FieldElement, traits::{IsFFTField, IsField}};
+use lambdaworks_math::field::{
+    element::FieldElement,
+    traits::{IsFFTField, IsField},
+};
 
 use crate::{frame::Frame, trace::StepView};
 

--- a/provers/stark/src/table.rs
+++ b/provers/stark/src/table.rs
@@ -1,6 +1,6 @@
 use lambdaworks_math::field::{
     element::FieldElement,
-    traits::{IsFFTField, IsField},
+    traits::{IsField},
 };
 
 use crate::{frame::Frame, trace::StepView};

--- a/provers/stark/src/table.rs
+++ b/provers/stark/src/table.rs
@@ -1,7 +1,4 @@
-use lambdaworks_math::field::{
-    element::FieldElement,
-    traits::{IsField},
-};
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
 
 use crate::{frame::Frame, trace::StepView};
 

--- a/provers/stark/src/trace.rs
+++ b/provers/stark/src/trace.rs
@@ -111,7 +111,9 @@ impl<'t, F: IsField> TraceTable<F> {
         self.table.get(row, col)
     }
 
-    pub fn compute_trace_polys<S: IsFFTField + IsSubFieldOf<F>>(&self) -> Vec<Polynomial<FieldElement<F>>>
+    pub fn compute_trace_polys<S: IsFFTField + IsSubFieldOf<F>>(
+        &self,
+    ) -> Vec<Polynomial<FieldElement<F>>>
     where
         FieldElement<F>: Send + Sync,
     {

--- a/provers/stark/src/traits.rs
+++ b/provers/stark/src/traits.rs
@@ -1,7 +1,10 @@
 use itertools::Itertools;
 use lambdaworks_math::{
     fft::cpu::roots_of_unity::get_powers_of_primitive_root_coset,
-    field::{element::FieldElement, traits::IsFFTField},
+    field::{
+        element::FieldElement,
+        traits::{IsFFTField, IsField, IsSubFieldOf},
+    },
     polynomial::Polynomial,
 };
 
@@ -14,7 +17,8 @@ use super::{
 
 /// AIR is a representation of the Constraints
 pub trait AIR {
-    type Field: IsFFTField;
+    type Field: IsFFTField + IsSubFieldOf<Self::FieldExtension>;
+    type FieldExtension: IsField;
     type RAPChallenges;
     type PublicInputs;
 
@@ -28,13 +32,13 @@ pub trait AIR {
 
     fn build_auxiliary_trace(
         &self,
-        main_trace: &TraceTable<Self::Field>,
+        main_trace: &TraceTable<Self::FieldExtension>,
         rap_challenges: &Self::RAPChallenges,
-    ) -> TraceTable<Self::Field>;
+    ) -> TraceTable<Self::FieldExtension>;
 
     fn build_rap_challenges(
         &self,
-        transcript: &mut impl IsStarkTranscript<Self::Field>,
+        transcript: &mut impl IsStarkTranscript<Self::FieldExtension>,
     ) -> Self::RAPChallenges;
 
     fn number_auxiliary_rap_columns(&self) -> usize;
@@ -43,8 +47,8 @@ pub trait AIR {
 
     fn compute_transition(
         &self,
-        frame: &Frame<Self::Field>,
-        periodic_values: &[FieldElement<Self::Field>],
+        frame: &Frame<Self::FieldExtension>,
+        periodic_values: &[FieldElement<Self::FieldExtension>],
         rap_challenges: &Self::RAPChallenges,
     ) -> Vec<FieldElement<Self::Field>>;
 
@@ -105,8 +109,8 @@ pub trait AIR {
     fn transition_exemptions_verifier(
         &self,
         root: &FieldElement<Self::Field>,
-    ) -> Vec<Polynomial<FieldElement<Self::Field>>> {
-        let x = Polynomial::new_monomial(FieldElement::one(), 1);
+    ) -> Vec<Polynomial<FieldElement<Self::FieldExtension>>> {
+        let x = Polynomial::<FieldElement<Self::FieldExtension>>::new_monomial(FieldElement::one(), 1);
 
         let max = self
             .context()
@@ -118,7 +122,7 @@ pub trait AIR {
             .map(|index| {
                 (1..=index).fold(
                     Polynomial::new_monomial(FieldElement::one(), 0),
-                    |acc, k| acc * (&x - root.pow(k)),
+                    |acc, k| acc * ( - root.pow(k) + &x),
                 )
             })
             .collect()
@@ -128,7 +132,9 @@ pub trait AIR {
         vec![]
     }
 
-    fn get_periodic_column_polynomials(&self) -> Vec<Polynomial<FieldElement<Self::Field>>> {
+    fn get_periodic_column_polynomials(
+        &self,
+    ) -> Vec<Polynomial<FieldElement<Self::FieldExtension>>> {
         let mut result = Vec::new();
         for periodic_column in self.get_periodic_column_values() {
             let values: Vec<_> = periodic_column
@@ -136,6 +142,8 @@ pub trait AIR {
                 .cycle()
                 .take(self.trace_length())
                 .cloned()
+                .into_iter()
+                .map(|x| x.to_extension())
                 .collect();
             let poly = Polynomial::interpolate_fft::<Self::Field>(&values).unwrap();
             result.push(poly);

--- a/provers/stark/src/traits.rs
+++ b/provers/stark/src/traits.rs
@@ -55,9 +55,9 @@ pub trait AIR {
     fn boundary_constraints(
         &self,
         rap_challenges: &Self::RAPChallenges,
-    ) -> BoundaryConstraints<Self::Field>;
+    ) -> BoundaryConstraints<Self::FieldExtension>;
 
-    fn transition_exemptions(&self) -> Vec<Polynomial<FieldElement<Self::Field>>> {
+    fn transition_exemptions(&self) -> Vec<Polynomial<FieldElement<Self::FieldExtension>>> {
         let trace_length = self.trace_length();
         let roots_of_unity_order = trace_length.trailing_zeros();
         let roots_of_unity = get_powers_of_primitive_root_coset(
@@ -122,7 +122,7 @@ pub trait AIR {
             .map(|index| {
                 (1..=index).fold(
                     Polynomial::new_monomial(FieldElement::one(), 0),
-                    |acc, k| acc * ( - root.pow(k) + &x),
+                    |acc, k| acc * (&x - root.pow(k).to_extension()),
                 )
             })
             .collect()

--- a/provers/stark/src/traits.rs
+++ b/provers/stark/src/traits.rs
@@ -143,7 +143,6 @@ pub trait AIR {
                 .cycle()
                 .take(self.trace_length())
                 .cloned()
-                .into_iter()
                 .map(|x| x.to_extension())
                 .collect();
             let poly = Polynomial::interpolate_fft::<Self::Field>(&values).unwrap();

--- a/provers/stark/src/traits.rs
+++ b/provers/stark/src/traits.rs
@@ -110,7 +110,8 @@ pub trait AIR {
         &self,
         root: &FieldElement<Self::Field>,
     ) -> Vec<Polynomial<FieldElement<Self::FieldExtension>>> {
-        let x = Polynomial::<FieldElement<Self::FieldExtension>>::new_monomial(FieldElement::one(), 1);
+        let x =
+            Polynomial::<FieldElement<Self::FieldExtension>>::new_monomial(FieldElement::one(), 1);
 
         let max = self
             .context()

--- a/provers/stark/src/transcript.rs
+++ b/provers/stark/src/transcript.rs
@@ -25,8 +25,8 @@ pub trait IsStarkTranscript<F: IsField> {
     {
         loop {
             let value: FieldElement<F> = self.sample_field_element();
-            if !lde_roots_of_unity_coset.iter().any(|x| x.to_extension() == value)
-                && !trace_roots_of_unity.iter().any(|x| x.to_extension() == value)
+            if !lde_roots_of_unity_coset.iter().any(|x| x.clone().to_extension() == value)
+                && !trace_roots_of_unity.iter().any(|x| x.clone().to_extension() == value)
             {
                 return value;
             }

--- a/provers/stark/src/transcript.rs
+++ b/provers/stark/src/transcript.rs
@@ -2,7 +2,7 @@ use lambdaworks_math::{
     field::{
         element::FieldElement,
         fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
-        traits::{IsFFTField, IsField},
+        traits::{IsFFTField, IsField, IsSubFieldOf},
     },
     traits::{ByteConversion, Serializable},
     unsigned_integer::element::U256,
@@ -15,18 +15,18 @@ pub trait IsStarkTranscript<F: IsField> {
     fn state(&self) -> [u8; 32];
     fn sample_field_element(&mut self) -> FieldElement<F>;
     fn sample_u64(&mut self, upper_bound: u64) -> u64;
-    fn sample_z_ood(
+    fn sample_z_ood<S: IsSubFieldOf<F>>(
         &mut self,
-        lde_roots_of_unity_coset: &[FieldElement<F>],
-        trace_roots_of_unity: &[FieldElement<F>],
+        lde_roots_of_unity_coset: &[FieldElement<S>],
+        trace_roots_of_unity: &[FieldElement<S>],
     ) -> FieldElement<F>
     where
         FieldElement<F>: Serializable,
     {
         loop {
             let value: FieldElement<F> = self.sample_field_element();
-            if !lde_roots_of_unity_coset.iter().any(|x| x == &value)
-                && !trace_roots_of_unity.iter().any(|x| x == &value)
+            if !lde_roots_of_unity_coset.iter().any(|x| x.to_extension() == value)
+                && !trace_roots_of_unity.iter().any(|x| x.to_extension() == value)
             {
                 return value;
             }

--- a/provers/stark/src/transcript.rs
+++ b/provers/stark/src/transcript.rs
@@ -25,8 +25,12 @@ pub trait IsStarkTranscript<F: IsField> {
     {
         loop {
             let value: FieldElement<F> = self.sample_field_element();
-            if !lde_roots_of_unity_coset.iter().any(|x| x.clone().to_extension() == value)
-                && !trace_roots_of_unity.iter().any(|x| x.clone().to_extension() == value)
+            if !lde_roots_of_unity_coset
+                .iter()
+                .any(|x| x.clone().to_extension() == value)
+                && !trace_roots_of_unity
+                    .iter()
+                    .any(|x| x.clone().to_extension() == value)
             {
                 return value;
             }

--- a/winterfell_adapter/src/adapter/air.rs
+++ b/winterfell_adapter/src/adapter/air.rs
@@ -62,6 +62,7 @@ where
     T: Trace<BaseField = AdapterFieldElement> + Clone + FromColumns<AdapterFieldElement>,
 {
     type Field = Stark252PrimeField;
+    type FieldExtension = Stark252PrimeField;
     type RAPChallenges = Vec<AdapterFieldElement>;
     type PublicInputs = AirAdapterPublicInputs<A>;
     const STEP_SIZE: usize = 1;


### PR DESCRIPTION
# Prover and Verifier over field extensions

## Description

This PR is the first step to support field extensions in the stark prover and verifier. 

In summary, this PR
- Adds associated type `FieldExtension` to both `IsStarkProver` and `IsStarkVerifier`.
- The prover casts the trace to the field extension at the very beginning of the prove method and continues as before.
- Implements polynomial operations between polynomials with coefficients in a field and a subfield. This will be needed in a subsequent PR.

There is a followup PR that improves the way the prover handles the trace and avoids casting it to the field extension. This is so dividided in two PRs to make reviewing easier.

## Type of change

- [x] New feature