### PR TITLE
perf: multiply by zerofier after fold

### DIFF
--- a/provers/stark/src/constraints/evaluator.rs
+++ b/provers/stark/src/constraints/evaluator.rs
@@ -201,23 +201,19 @@ impl<F: IsFFTField> ConstraintEvaluator<F> {
                 // Add each term of the transition constraints to the
                 // composition polynomial, including the zerofier, the
                 // challenge and the exemption polynomial if it is necessary.
-                let acc_transition = evaluations_transition
+                let acc_transition = zerofier * evaluations_transition
                     .iter()
                     .zip(&air.context().transition_exemptions)
                     .zip(transition_coefficients)
                     .fold(FieldElement::zero(), |acc, ((eval, exemption), beta)| {
-                        #[cfg(feature = "parallel")]
-                        let zerofier = zerofier.clone();
-
                         // If there's no exemption, then
                         // the zerofier remains as it was.
                         if *exemption == 0 {
-                            acc + zerofier * beta * eval
+                            acc + beta * eval
                         } else {
                             //TODO: change how exemptions are indexed!
                             if num_exemptions == 1 {
-                                acc + zerofier
-                                    * beta
+                                acc + beta
                                     * eval
                                     * &transition_exemptions_evaluations[0][i]
                             } else {
@@ -235,8 +231,7 @@ impl<F: IsFFTField> ConstraintEvaluator<F> {
                                     .position(|elem_2| elem_2 == exemption)
                                     .expect("is there");
 
-                                acc + zerofier
-                                    * beta
+                                acc + beta
                                     * eval
                                     * &transition_exemptions_evaluations[index][i]
                             }

--- a/provers/stark/src/constraints/evaluator.rs
+++ b/provers/stark/src/constraints/evaluator.rs
@@ -201,7 +201,7 @@ impl<F: IsFFTField> ConstraintEvaluator<F> {
                 // Add each term of the transition constraints to the
                 // composition polynomial, including the zerofier, the
                 // challenge and the exemption polynomial if it is necessary.
-                let acc_transition = zerofier * evaluations_transition
+                let acc_transition = evaluations_transition
                     .iter()
                     .zip(&air.context().transition_exemptions)
                     .zip(transition_coefficients)
@@ -213,9 +213,7 @@ impl<F: IsFFTField> ConstraintEvaluator<F> {
                         } else {
                             //TODO: change how exemptions are indexed!
                             if num_exemptions == 1 {
-                                acc + beta
-                                    * eval
-                                    * &transition_exemptions_evaluations[0][i]
+                                acc + beta * eval * &transition_exemptions_evaluations[0][i]
                             } else {
                                 // This case is not used for Cairo Programs, it can be improved in the future
                                 let vector = air
@@ -231,12 +229,11 @@ impl<F: IsFFTField> ConstraintEvaluator<F> {
                                     .position(|elem_2| elem_2 == exemption)
                                     .expect("is there");
 
-                                acc + beta
-                                    * eval
-                                    * &transition_exemptions_evaluations[index][i]
+                                acc + beta * eval * &transition_exemptions_evaluations[index][i]
                             }
                         }
-                    });
+                    })
+                    * zerofier;
                 // TODO: Remove clones
 
                 acc_transition + boundary


### PR DESCRIPTION
This is mostly for purism, as the gain is marginal, but we've been repeating the same multiplication by each zerofier many times. The PR fixes that.

## Type of change

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added/run

## Benchmark Results
```shell
# ./bench.sh 
Benchmark 1: base_seq
  Time (mean ± σ):     122.824 s ±  0.250 s    [User: 117.360 s, System: 5.456 s]
  Range (min … max):   122.539 s … 123.185 s    10 runs
 
Benchmark 2: zero_seq
  Time (mean ± σ):     119.827 s ±  0.249 s    [User: 114.387 s, System: 5.426 s]
  Range (min … max):   119.595 s … 120.479 s    10 runs
 
Summary
  zero_seq ran
    1.03 ± 0.00 times faster than base_seq

Benchmark 1: base_par
  Time (mean ± σ):     70.212 s ±  0.094 s    [User: 175.395 s, System: 7.495 s]
  Range (min … max):   70.052 s … 70.336 s    10 runs
 
Benchmark 2: zero_par
  Time (mean ± σ):     69.243 s ±  0.110 s    [User: 171.014 s, System: 7.563 s]
  Range (min … max):   69.114 s … 69.432 s    10 runs
 
Summary
  zero_par ran
    1.01 ± 0.00 times faster than base_par
```

Proved `fibonacci(70000)` on `lambdaworks-benchmarks-x86-64-dedicated`.