### PR TITLE
perf: implement new radix 4 NR NTT

### DIFF
--- a/math/benches/criterion_fft.rs
+++ b/math/benches/criterion_fft.rs
@@ -6,7 +6,7 @@ use utils::stark252_utils;
 
 mod utils;
 
-const SIZE_ORDERS: [u64; 4] = [21, 22, 23, 24];
+const SIZE_ORDERS: [u64; 5] = [20, 21, 22, 23, 24];
 
 pub fn fft_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Ordered FFT");
@@ -22,7 +22,7 @@ pub fn fft_benchmarks(c: &mut Criterion) {
 
         group.bench_with_input(
             "Sequential from NR radix2",
-            &(input_nat, twiddles_bitrev),
+            &(input_nat.clone(), twiddles_bitrev.clone()),
             |bench, (input, twiddles)| {
                 bench.iter_batched(
                     || input.clone(),
@@ -46,6 +46,21 @@ pub fn fft_benchmarks(c: &mut Criterion) {
                 );
             },
         );
+        if order % 2 == 0 {
+            group.bench_with_input(
+                "Sequential from NR radix4",
+                &(input_nat, twiddles_bitrev),
+                |bench, (input, twiddles)| {
+                    bench.iter_batched(
+                        || input.clone(),
+                        |mut input| {
+                            fft_functions::ordered_fft_nr4(&mut input, twiddles);
+                        },
+                        BatchSize::LargeInput,
+                    );
+                },
+            );
+        }
     }
 
     group.finish();

--- a/math/benches/utils/fft_functions.rs
+++ b/math/benches/utils/fft_functions.rs
@@ -3,7 +3,7 @@
 use criterion::black_box;
 use lambdaworks_math::fft::cpu::{
     bit_reversing::in_place_bit_reverse_permute,
-    fft::{in_place_nr_2radix_fft, in_place_rn_2radix_fft},
+    fft::{in_place_nr_2radix_fft, in_place_rn_2radix_fft, in_place_nr_4radix_fft},
     roots_of_unity::get_twiddles,
 };
 use lambdaworks_math::{field::traits::RootsConfig, polynomial::Polynomial};
@@ -16,6 +16,10 @@ pub fn ordered_fft_nr(input: &mut [FE], twiddles: &[FE]) {
 
 pub fn ordered_fft_rn(input: &mut [FE], twiddles: &[FE]) {
     in_place_rn_2radix_fft(input, twiddles);
+}
+
+pub fn ordered_fft_nr4(input: &mut [FE], twiddles: &[FE]) {
+    in_place_nr_4radix_fft(input, twiddles);
 }
 
 pub fn twiddles_generation(order: u64, config: RootsConfig) {

--- a/math/benches/utils/fft_functions.rs
+++ b/math/benches/utils/fft_functions.rs
@@ -3,7 +3,7 @@
 use criterion::black_box;
 use lambdaworks_math::fft::cpu::{
     bit_reversing::in_place_bit_reverse_permute,
-    fft::{in_place_nr_2radix_fft, in_place_rn_2radix_fft, in_place_nr_4radix_fft},
+    fft::{in_place_nr_2radix_fft, in_place_nr_4radix_fft, in_place_rn_2radix_fft},
     roots_of_unity::get_twiddles,
 };
 use lambdaworks_math::{field::traits::RootsConfig, polynomial::Polynomial};

--- a/math/src/fft/cpu/fft.rs
+++ b/math/src/fft/cpu/fft.rs
@@ -122,16 +122,20 @@ where
     E: IsField,
 {
     debug_assert!(input.len().is_power_of_two());
-    //debug_assert!(input.len().ilog2() % 2 == 0); // let k = log2(x), k.is_even() => 2^k == 2^2*k'
-    // with k' = k / 2 => x is power of 4
+    debug_assert!(input.len().ilog2() % 2 == 0); // Even power of 2 => x is power of 4
+
     // divide input in groups, starting with 1, duplicating the number of groups in each stage.
     let mut group_count = 1;
     let mut group_size = input.len();
 
     // for each group, there'll be group_size / 4 butterflies.
-    // a butterfly is the atomic operation of a FFT, e.g: (a, b) = (a + wb, a - wb).
-    // The 0.5 factor is what gives FFT its performance, it recursively halves the problem size
-    // (group size).
+    // a butterfly is the atomic operation of a FFT, e.g:
+    // x' = x + yw2 + zw1 + tw1w2
+    // y' = x - yw2 + zw1 - tw1w2
+    // z' = x + yw3 - zw1 - tw1w3
+    // t' = x - yw3 - zw1 + tw1w3
+    // The 0.25 factor is what gives FFT its performance, it recursively divides the problem size
+    // by 4 (group size).
 
     while group_count < input.len() {
         #[allow(clippy::needless_range_loop)] // the suggestion would obfuscate a bit the algorithm

--- a/math/src/fft/cpu/fft.rs
+++ b/math/src/fft/cpu/fft.rs
@@ -202,7 +202,7 @@ mod tests {
         }
     }
     prop_compose! {
-        fn field_vec_r4(max_exp: u8)(vec in (1..max_exp).prop_flat_map(|i| collection::vec(field_element(), 1 << 2 * i))) -> Vec<FE> {
+        fn field_vec_r4(max_exp: u8)(vec in (1..max_exp).prop_flat_map(|i| collection::vec(field_element(), 1 << (2 * i)))) -> Vec<FE> {
             vec
         }
     }

--- a/math/src/fft/cpu/fft.rs
+++ b/math/src/fft/cpu/fft.rs
@@ -123,7 +123,7 @@ where
 {
     debug_assert!(input.len().is_power_of_two());
     //debug_assert!(input.len().ilog2() % 2 == 0); // let k = log2(x), k.is_even() => 2^k == 2^2*k'
-                                                   // with k' = k / 2 => x is power of 4
+    // with k' = k / 2 => x is power of 4
     // divide input in groups, starting with 1, duplicating the number of groups in each stage.
     let mut group_count = 1;
     let mut group_size = input.len();
@@ -139,10 +139,18 @@ where
             let first_in_group = group * group_size;
             let first_in_next_group = first_in_group + group_size / 4;
 
-            let (w1, w2, w3) = (&twiddles[group], &twiddles[2 * group], &twiddles[2 * group + 1]);
+            let (w1, w2, w3) = (
+                &twiddles[group],
+                &twiddles[2 * group],
+                &twiddles[2 * group + 1],
+            );
 
             for i in first_in_group..first_in_next_group {
-                let (j, k, l) = (i + group_size / 4, i + group_size / 2, i + 3 * group_size / 4);
+                let (j, k, l) = (
+                    i + group_size / 4,
+                    i + group_size / 2,
+                    i + 3 * group_size / 4,
+                );
 
                 let zw1 = w1 * &input[k];
                 let tw1 = w1 * &input[l];

--- a/math/src/fft/cpu/fft.rs
+++ b/math/src/fft/cpu/fft.rs
@@ -104,6 +104,67 @@ where
     }
 }
 
+/// In-Place Radix-4 NR DIT FFT algorithm over a slice of two-adic field elements.
+/// It's required that the twiddle factors are in bit-reverse order. Else this function will not
+/// return fourier transformed values.
+/// Also the input size needs to be a power of two.
+/// It's recommended to use the current safe abstractions instead of this function.
+///
+/// Performs a fast fourier transform with the next attributes:
+/// - In-Place: an auxiliary vector of data isn't needed for the algorithm.
+/// - Radix-4: the algorithm halves the problem size log(n) times.
+/// - NR: natural to reverse order, meaning that the input is naturally ordered and the output will
+/// be bit-reversed ordered.
+/// - DIT: decimation in time
+pub fn in_place_nr_4radix_fft<F, E>(input: &mut [FieldElement<E>], twiddles: &[FieldElement<F>])
+where
+    F: IsFFTField + IsSubFieldOf<E>,
+    E: IsField,
+{
+    debug_assert!(input.len().is_power_of_two());
+    //debug_assert!(input.len().ilog2() % 2 == 0); // let k = log2(x), k.is_even() => 2^k == 2^2*k'
+                                                   // with k' = k / 2 => x is power of 4
+    // divide input in groups, starting with 1, duplicating the number of groups in each stage.
+    let mut group_count = 1;
+    let mut group_size = input.len();
+
+    // for each group, there'll be group_size / 4 butterflies.
+    // a butterfly is the atomic operation of a FFT, e.g: (a, b) = (a + wb, a - wb).
+    // The 0.5 factor is what gives FFT its performance, it recursively halves the problem size
+    // (group size).
+
+    while group_count < input.len() {
+        #[allow(clippy::needless_range_loop)] // the suggestion would obfuscate a bit the algorithm
+        for group in 0..group_count {
+            let first_in_group = group * group_size;
+            let first_in_next_group = first_in_group + group_size / 4;
+
+            let (w1, w2, w3) = (&twiddles[group], &twiddles[2 * group], &twiddles[2 * group + 1]);
+
+            for i in first_in_group..first_in_next_group {
+                let (j, k, l) = (i + group_size / 4, i + group_size / 2, i + 3 * group_size / 4);
+
+                let zw1 = w1 * &input[k];
+                let tw1 = w1 * &input[l];
+                let a = w2 * (&input[j] + &tw1);
+                let b = w3 * (&input[j] - &tw1);
+
+                let x = &input[i] + &zw1 + &a;
+                let y = &input[i] + &zw1 - &a;
+                let z = &input[i] - &zw1 + &b;
+                let t = &input[i] - &zw1 - &b;
+
+                input[i] = x;
+                input[j] = y;
+                input[k] = z;
+                input[l] = t;
+            }
+        }
+        group_count *= 4;
+        group_size /= 4;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::fft::cpu::bit_reversing::in_place_bit_reverse_permute;
@@ -128,7 +189,12 @@ mod tests {
         }
     }
     prop_compose! {
-        fn field_vec(max_exp: u8)(vec in collection::vec(field_element(), 2..1<<max_exp).prop_filter("Avoid polynomials of size not power of two", |vec| vec.len().is_power_of_two())) -> Vec<FE> {
+        fn field_vec(max_exp: u8)(vec in (1..max_exp).prop_flat_map(|i| collection::vec(field_element(), 1 << i))) -> Vec<FE> {
+            vec
+        }
+    }
+    prop_compose! {
+        fn field_vec_r4(max_exp: u8)(vec in (1..max_exp).prop_flat_map(|i| collection::vec(field_element(), 1 << 2 * i))) -> Vec<FE> {
             vec
         }
     }
@@ -162,6 +228,21 @@ mod tests {
             in_place_rn_2radix_fft(&mut result, &twiddles);
 
             prop_assert_eq!(result, expected);
+        }
+
+        // Property-based test that ensures NR Radix-2 FFT gives the same result as a naive DFT.
+        #[test]
+        fn test_nr_4radix_fft_matches_naive_eval(coeffs in field_vec_r4(5)) {
+            let expected = naive_matrix_dft_test(&coeffs);
+
+            let order = coeffs.len().trailing_zeros();
+            let twiddles = get_twiddles(order.into(), RootsConfig::BitReverse).unwrap();
+
+            let mut result = coeffs;
+            in_place_nr_4radix_fft::<F, F>(&mut result, &twiddles);
+            in_place_bit_reverse_permute(&mut result);
+
+            prop_assert_eq!(expected, result);
         }
     }
 }


### PR DESCRIPTION
Measured locally on M1: 4-5% throughput improvement over radix 2.
Criterion benchmark added.

## Type of change

- [x] Optimization

## Checklist
- [x] This change is an Optimization
  - [x] Benchmarks added/run

## Preliminary Results on Development M1

```
# 2^24 elements
Ordered FFT/Sequential from NR radix2
                        time:   [5.1193 s 5.1273 s 5.1355 s]
                        thrpt:  [3.2669 Melem/s 3.2722 Melem/s 3.2773 Melem/s]
Ordered FFT/Sequential from NR radix4
                        time:   [4.8796 s 4.8917 s 4.9056 s]
                        thrpt:  [3.4200 Melem/s 3.4297 Melem/s 3.4382 Melem/s]
```

## Results on `lambdaworks-benchmarks-x86-64-dedicated`
```
# 2^20 elements
Ordered FFT/Sequential from NR radix2
                        time:   [334.31 ms 334.76 ms 335.27 ms]
                        thrpt:  [3.1276 Melem/s 3.1324 Melem/s 3.1365 Melem/s]
Ordered FFT/Sequential from NR radix4
                        time:   [307.61 ms 307.75 ms 307.88 ms]
                        thrpt:  [3.4058 Melem/s 3.4073 Melem/s 3.4088 Melem/s]
# 2^22 elements
Ordered FFT/Sequential from NR radix2
                        time:   [1.4725 s 1.4734 s 1.4744 s]
                        thrpt:  [2.8447 Melem/s 2.8466 Melem/s 2.8484 Melem/s]
Ordered FFT/Sequential from NR radix4
                        time:   [1.3526 s 1.3534 s 1.3544 s]
                        thrpt:  [3.0968 Melem/s 3.0991 Melem/s 3.1010 Melem/s]
# 2^24 elements
Ordered FFT/Sequential from NR radix2
                        time:   [6.4369 s 6.4393 s 6.4419 s]
                        thrpt:  [2.6044 Melem/s 2.6054 Melem/s 2.6064 Melem/s]
Ordered FFT/Sequential from NR radix4
                        time:   [5.9197 s 5.9247 s 5.9301 s]
                        thrpt:  [2.8292 Melem/s 2.8317 Melem/s 2.8341 Melem/s]
```