### PR TITLE
feat(math): Add to_hex(&self) -> String to FieldElement of a IsPrimeF…

### DIFF
--- a/exercises/message/src/starks/fri/mod.rs
+++ b/exercises/message/src/starks/fri/mod.rs
@@ -61,7 +61,7 @@ where
 
     let last_value = last_poly
         .coefficients()
-        .get(0)
+        .first()
         .unwrap_or(&FieldElement::zero())
         .clone();
 

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -488,8 +488,9 @@ impl<F: IsPrimeField> FieldElement<F> {
             value: F::from_hex(hex_string)?,
         })
     }
-
+    
     /// Creates a hexstring from a `FieldElement` without `0x`.
+    #[cfg(feature = "std")]
     pub fn to_hex(&self) -> String {
         F::to_hex(&self.value)
     }

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -488,8 +488,8 @@ impl<F: IsPrimeField> FieldElement<F> {
             value: F::from_hex(hex_string)?,
         })
     }
-    
-    /// Creates a hexstring from a `FieldElement` without `0x`.
+
+    // Creates a hexstring from a `FieldElement` without `0x`.
     #[cfg(feature = "std")]
     pub fn to_hex(&self) -> String {
         F::to_hex(&self.value)

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -488,6 +488,11 @@ impl<F: IsPrimeField> FieldElement<F> {
             value: F::from_hex(hex_string)?,
         })
     }
+
+    /// Creates a hexstring from a `FieldElement` without `0x`.
+    pub fn to_hex(&self) -> String {
+        F::to_hex(&self.value)
+    }
 }
 
 #[cfg(feature = "lambdaworks-serde-binary")]

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -489,8 +489,8 @@ impl<F: IsPrimeField> FieldElement<F> {
         })
     }
 
-    // Creates a hexstring from a `FieldElement` without `0x`.
     #[cfg(feature = "std")]
+    /// Creates a hexstring from a `FieldElement` without `0x`.
     pub fn to_hex(&self) -> String {
         F::to_hex(&self.value)
     }

--- a/math/src/field/fields/mersenne31/field.rs
+++ b/math/src/field/fields/mersenne31/field.rs
@@ -174,6 +174,7 @@ impl IsPrimeField for Mersenne31Field {
         u32::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
     }
 
+    #[cfg(feature = "std")]
     fn to_hex(x: &u32) -> String {
         format!("{:X}", x)
     }
@@ -404,6 +405,7 @@ mod tests {
         assert_eq!(b, F::one());
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn to_hex_test() {
         let num = F::from_hex("B").unwrap();

--- a/math/src/field/fields/mersenne31/field.rs
+++ b/math/src/field/fields/mersenne31/field.rs
@@ -173,6 +173,10 @@ impl IsPrimeField for Mersenne31Field {
         }
         u32::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
     }
+
+    fn to_hex(x: &u32) -> String {
+        format!("{:X}", x)
+    }
 }
 
 impl FieldElement<Mersenne31Field> {
@@ -398,5 +402,11 @@ mod tests {
     fn from_base_type_test() {
         let b = F::from_base_type(1u32);
         assert_eq!(b, F::one());
+    }
+
+    #[test]
+    fn to_hex_test() {
+        let num = F::from_hex("B").unwrap();
+        assert_eq!(F::to_hex(&num), "B");
     }
 }

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -309,6 +309,10 @@ where
             &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::MU,
         ))
     }
+
+    fn to_hex(x: &Self::BaseType) -> String {
+        Self::BaseType::to_hex(x)
+    }
 }
 
 impl<M, const NUM_LIMBS: usize> FieldElement<MontgomeryBackendPrimeField<M, NUM_LIMBS>> where
@@ -1127,6 +1131,32 @@ mod tests_u256_prime_fields {
         let a = U256F29Element::from_hex_unchecked("1d");
         let b = U256F29Element::zero();
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn to_hex_test_works_1() {
+        let a = U256FP1Element::from_hex_unchecked("eb235f6144d9e91f4b14");
+        let b = U256FP1Element::new(U256 {
+            limbs: [0, 0, 60195, 6872850209053821716],
+        });
+
+        assert_eq!(U256FP1Element::to_hex(&a), U256FP1Element::to_hex(&b));
+    }
+
+    #[test]
+    fn to_hex_test_works_2() {
+        let a = U256F29Element::from_hex_unchecked("1d");
+        let b = U256F29Element::zero();
+
+        assert_eq!(U256F29Element::to_hex(&a), U256F29Element::to_hex(&b));
+    }
+
+    #[test]
+    fn to_hex_test_works_3() {
+        let a = U256F29Element::from_hex_unchecked("aa");
+        let b = U256F29Element::from(25);
+
+        assert_eq!(U256F29Element::to_hex(&a), U256F29Element::to_hex(&b));
     }
 
     // Goldilocks

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -310,6 +310,7 @@ where
         ))
     }
 
+    #[cfg(feature = "std")]
     fn to_hex(x: &Self::BaseType) -> String {
         Self::BaseType::to_hex(x)
     }
@@ -1133,6 +1134,7 @@ mod tests_u256_prime_fields {
         assert_eq!(a, b);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn to_hex_test_works_1() {
         let a = U256FP1Element::from_hex_unchecked("eb235f6144d9e91f4b14");
@@ -1143,6 +1145,7 @@ mod tests_u256_prime_fields {
         assert_eq!(U256FP1Element::to_hex(&a), U256FP1Element::to_hex(&b));
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn to_hex_test_works_2() {
         let a = U256F29Element::from_hex_unchecked("1d");
@@ -1151,6 +1154,7 @@ mod tests_u256_prime_fields {
         assert_eq!(U256F29Element::to_hex(&a), U256F29Element::to_hex(&b));
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn to_hex_test_works_3() {
         let a = U256F29Element::from_hex_unchecked("aa");

--- a/math/src/field/fields/p448_goldilocks_prime_field.rs
+++ b/math/src/field/fields/p448_goldilocks_prime_field.rs
@@ -217,6 +217,7 @@ impl IsPrimeField for P448GoldilocksPrimeField {
         U56x8::from_hex(hex_string)
     }
 
+    #[cfg(feature = "std")]
     fn to_hex(x: &U56x8) -> String {
         U56x8::to_hex(x)
     }
@@ -315,6 +316,7 @@ impl U56x8 {
         Ok(U56x8 { limbs: result })
     }
 
+    #[cfg(feature = "std")]
     pub fn to_hex(&self) -> String {
         let mut hex_string = String::new();
         for &limb in self.limbs.iter().rev() {
@@ -448,6 +450,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn to_hex_test() {
         let mut limbs = [0u64; 8];

--- a/math/src/field/fields/p448_goldilocks_prime_field.rs
+++ b/math/src/field/fields/p448_goldilocks_prime_field.rs
@@ -217,6 +217,10 @@ impl IsPrimeField for P448GoldilocksPrimeField {
         U56x8::from_hex(hex_string)
     }
 
+    fn to_hex(x: &U56x8) -> String {
+        U56x8::to_hex(x)
+    }
+
     fn field_bit_size() -> usize {
         448
     }
@@ -309,6 +313,14 @@ impl U56x8 {
         result[limb_index] = limb;
 
         Ok(U56x8 { limbs: result })
+    }
+
+    pub fn to_hex(&self) -> String {
+        let mut hex_string = String::new();
+        for &limb in self.limbs.iter().rev() {
+            hex_string.push_str(&format!("{:014X}", limb));
+        }
+        hex_string.trim_start_matches('0').to_string()
     }
 }
 
@@ -434,5 +446,14 @@ mod tests {
             num2,
             U56x8::from_hex("564a75b90ae34f8155d5821d7e9484").unwrap()
         );
+    }
+
+    #[test]
+    fn to_hex_test() {
+        let mut limbs = [0u64; 8];
+        limbs[0] = 15372427657916355716u64;
+        limbs[1] = 6217911673150459564u64;
+        let num = U56x8::from_hex("564A75B90AE34F8155D5821D7E9484").unwrap();
+        assert_eq!(U56x8::to_hex(&num), "564A75B90AE34F8155D5821D7E9484")
     }
 }

--- a/math/src/field/fields/u64_goldilocks_field.rs
+++ b/math/src/field/fields/u64_goldilocks_field.rs
@@ -177,6 +177,10 @@ impl IsPrimeField for Goldilocks64Field {
         }
         u64::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
     }
+
+    fn to_hex(x: &u64) -> String {
+        format!("{:X}", x)
+    }
 }
 
 #[inline(always)]
@@ -472,5 +476,11 @@ mod tests {
     fn from_base_type_test() {
         let b = F::from_base_type(1u64);
         assert_eq!(b, F::one());
+    }
+
+    #[test]
+    fn to_hex_test() {
+        let num = F::from_hex("B").unwrap();
+        assert_eq!(F::to_hex(&num), "B");
     }
 }

--- a/math/src/field/fields/u64_goldilocks_field.rs
+++ b/math/src/field/fields/u64_goldilocks_field.rs
@@ -178,6 +178,7 @@ impl IsPrimeField for Goldilocks64Field {
         u64::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
     }
 
+    #[cfg(feature = "std")]
     fn to_hex(x: &u64) -> String {
         format!("{:X}", x)
     }
@@ -478,6 +479,7 @@ mod tests {
         assert_eq!(b, F::one());
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn to_hex_test() {
         let num = F::from_hex("B").unwrap();

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -102,6 +102,10 @@ impl<const MODULUS: u64> IsPrimeField for U64PrimeField<MODULUS> {
 
         u64::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
     }
+
+    fn to_hex(x: &u64) -> String {
+        format!("{:X}", x)
+    }
 }
 
 /// Represents an element in Fp. (E.g: 0, 1, 2 are the elements of F3)
@@ -174,6 +178,18 @@ mod tests {
     #[test]
     fn from_hex_for_0x1_a_is_26() {
         assert_eq!(F::from_hex("0x1a").unwrap(), 26);
+    }
+
+    #[test]
+    fn to_hex_test_works_1() {
+        let num = F::from_hex("B").unwrap();
+        assert_eq!(F::to_hex(&num), "B");
+    }
+
+    #[test]
+    fn to_hex_test_works_2() {
+        let num = F::from_hex("0x1a").unwrap();
+        assert_eq!(F::to_hex(&num), "1A");
     }
 
     #[test]

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -103,6 +103,7 @@ impl<const MODULUS: u64> IsPrimeField for U64PrimeField<MODULUS> {
         u64::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
     }
 
+    #[cfg(feature = "std")]
     fn to_hex(x: &u64) -> String {
         format!("{:X}", x)
     }
@@ -180,12 +181,14 @@ mod tests {
         assert_eq!(F::from_hex("0x1a").unwrap(), 26);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn to_hex_test_works_1() {
         let num = F::from_hex("B").unwrap();
         assert_eq!(F::to_hex(&num), "B");
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn to_hex_test_works_2() {
         let num = F::from_hex("0x1a").unwrap();

--- a/math/src/field/fields/winterfell.rs
+++ b/math/src/field/fields/winterfell.rs
@@ -31,7 +31,7 @@ impl IsPrimeField for Felt {
         todo!()
     }
 
-    fn to_hex(a: &Self::BaseType) -> String {
+    fn to_hex(_a: &Self::BaseType) -> String {
         todo!()
     }
 

--- a/math/src/field/fields/winterfell.rs
+++ b/math/src/field/fields/winterfell.rs
@@ -31,6 +31,10 @@ impl IsPrimeField for Felt {
         todo!()
     }
 
+    fn to_hex(a: &Self::BaseType) -> String {
+        todo!()
+    }
+
     fn field_bit_size() -> usize {
         128 // TODO
     }

--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -116,6 +116,10 @@ impl<const MODULUS: u32> IsPrimeField for U32Field<MODULUS> {
 
         u32::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
     }
+
+    fn to_hex(x: &u32) -> String {
+        format!("{:X}", x)
+    }
 }
 
 // 15 * 2^27 + 1;
@@ -134,6 +138,12 @@ mod tests_u32_test_field {
     #[test]
     fn from_hex_for_b_is_11() {
         assert_eq!(U32TestField::from_hex("B").unwrap(), 11);
+    }
+
+    #[test]
+    fn to_hex_test() {
+        let num = U32TestField::from_hex("B").unwrap();
+        assert_eq!(U32TestField::to_hex(&num), "B");
     }
 
     #[test]

--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -117,6 +117,7 @@ impl<const MODULUS: u32> IsPrimeField for U32Field<MODULUS> {
         u32::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
     }
 
+    #[cfg(feature = "std")]
     fn to_hex(x: &u32) -> String {
         format!("{:X}", x)
     }
@@ -140,6 +141,7 @@ mod tests_u32_test_field {
         assert_eq!(U32TestField::from_hex("B").unwrap(), 11);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn to_hex_test() {
         let num = U32TestField::from_hex("B").unwrap();

--- a/math/src/field/test_fields/u64_test_field.rs
+++ b/math/src/field/test_fields/u64_test_field.rs
@@ -88,6 +88,10 @@ impl<const MODULUS: u64> IsPrimeField for U64Field<MODULUS> {
 
         u64::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
     }
+
+    fn to_hex(x: &u64) -> String {
+        format!("{:X}", x)
+    }
 }
 
 pub type U64TestField = U64Field<18446744069414584321>;
@@ -138,5 +142,11 @@ mod tests_u64_test_field {
         ]);
         let b = a.to_subfield_vec::<U64TestField>();
         assert_eq!(b, vec![FieldElement::from(1), FieldElement::from(3)]);
+    }
+
+    #[test]
+    fn to_hex_test() {
+        let num = U64TestField::from_hex("B").unwrap();
+        assert_eq!(U64TestField::to_hex(&num), "B");
     }
 }

--- a/math/src/field/test_fields/u64_test_field.rs
+++ b/math/src/field/test_fields/u64_test_field.rs
@@ -89,6 +89,7 @@ impl<const MODULUS: u64> IsPrimeField for U64Field<MODULUS> {
         u64::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
     }
 
+    #[cfg(feature = "std")]
     fn to_hex(x: &u64) -> String {
         format!("{:X}", x)
     }
@@ -144,6 +145,7 @@ mod tests_u64_test_field {
         assert_eq!(b, vec![FieldElement::from(1), FieldElement::from(3)]);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn to_hex_test() {
         let num = U64TestField::from_hex("B").unwrap();

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -204,6 +204,7 @@ pub trait IsPrimeField: IsField {
     fn from_hex(hex_string: &str) -> Result<Self::BaseType, CreationError>;
 
     #[cfg(feature = "std")]
+    /// Creates a hexstring from a `FieldElement` without `0x`.
     fn to_hex(a: &Self::BaseType) -> String;
 
     /// Returns the number of bits of the max element of the field, as per field documentation, not internal representation.

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -203,6 +203,7 @@ pub trait IsPrimeField: IsField {
     /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring
     fn from_hex(hex_string: &str) -> Result<Self::BaseType, CreationError>;
 
+    #[cfg(feature = "std")]
     fn to_hex(a: &Self::BaseType) -> String;
 
     /// Returns the number of bits of the max element of the field, as per field documentation, not internal representation.

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -203,6 +203,8 @@ pub trait IsPrimeField: IsField {
     /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring
     fn from_hex(hex_string: &str) -> Result<Self::BaseType, CreationError>;
 
+    fn to_hex(a: &Self::BaseType) -> String;
+
     /// Returns the number of bits of the max element of the field, as per field documentation, not internal representation.
     /// This is `log2(max FE)` rounded up
     fn field_bit_size() -> usize;

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -486,6 +486,14 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         UnsignedInteger { limbs: result }
     }
 
+    pub fn to_hex(&self) -> String {
+        let mut hex_string = String::new();
+        for &limb in self.limbs.iter() {
+            hex_string.push_str(&format!("{:014X}", limb));
+        }
+        hex_string.trim_start_matches('0').to_string()
+    }
+
     pub const fn const_ne(a: &UnsignedInteger<NUM_LIMBS>, b: &UnsignedInteger<NUM_LIMBS>) -> bool {
         let mut i = 0;
         while i < NUM_LIMBS {
@@ -2967,5 +2975,11 @@ mod tests_u256 {
                 U256::from_u128(12368508650766)
             )
         );
+    }
+
+    #[test]
+    fn to_hex_test() {
+        let a = U256::from_hex_unchecked("390aa99bead76bc0093b1bc1a8101f5ce");
+        assert_eq!(U256::to_hex(&a), "390AA99BEAD76BC0093B1BC1A8101F5CE")
     }
 }

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -486,6 +486,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         UnsignedInteger { limbs: result }
     }
 
+    /// Creates a hexstring from a `FieldElement` without `0x`.
     #[cfg(feature = "std")]
     pub fn to_hex(&self) -> String {
         let mut hex_string = String::new();

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -486,6 +486,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         UnsignedInteger { limbs: result }
     }
 
+    #[cfg(feature = "std")]
     pub fn to_hex(&self) -> String {
         let mut hex_string = String::new();
         for &limb in self.limbs.iter() {
@@ -2977,6 +2978,7 @@ mod tests_u256 {
         );
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn to_hex_test() {
         let a = U256::from_hex_unchecked("390aa99bead76bc0093b1bc1a8101f5ce");

--- a/provers/stark/src/fri/mod.rs
+++ b/provers/stark/src/fri/mod.rs
@@ -64,7 +64,7 @@ where
 
     let last_value = last_poly
         .coefficients()
-        .get(0)
+        .first()
         .unwrap_or(&FieldElement::zero())
         .clone();
 


### PR DESCRIPTION
# Add to_hex(&self) -> String to FieldElement of a IsPrimeField

## Description
This is PR closes #104
Add to_hex(&self) -> String function to FieldElement and implement it where needed

This function should create an hexstring representing the number in FieldElement. It should abstract the user from the internal representation, so if the number is in Montgomery form, it should convert it back to the original form before returning the element.

## Type of change
- [x] New feature

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
