### PR TITLE
Make fn `ShortWeierstrassProjectivePoint::double` public

### DIFF
--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -50,7 +50,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         Self(self.0.to_affine())
     }
 
-    fn double(&self) -> Self {
+    pub fn double(&self) -> Self {
         let [px, py, pz] = self.coordinates();
 
         let px_square = px * px;

--- a/provers/stark/src/fri/mod.rs
+++ b/provers/stark/src/fri/mod.rs
@@ -64,7 +64,7 @@ where
 
     let last_value = last_poly
         .coefficients()
-        .get(0)
+        .first()
         .unwrap_or(&FieldElement::zero())
         .clone();
 


### PR DESCRIPTION
We want to use this method in the ec_op builtin runner implementation in cairo-vm
