### PR TITLE
Feat(serialization): AsBytes Refactor and Improvements

### DIFF
--- a/crypto/src/commitments/kzg.rs
+++ b/crypto/src/commitments/kzg.rs
@@ -8,7 +8,7 @@ use lambdaworks_math::{
     field::{element::FieldElement, traits::IsPrimeField},
     msm::pippenger::msm,
     polynomial::Polynomial,
-    traits::{Deserializable, Serializable},
+    traits::{AsBytes, Deserializable},
     unsigned_integer::element::UnsignedInteger,
 };
 
@@ -43,12 +43,12 @@ where
     }
 }
 
-impl<G1Point, G2Point> Serializable for StructuredReferenceString<G1Point, G2Point>
+impl<G1Point, G2Point> AsBytes for StructuredReferenceString<G1Point, G2Point>
 where
-    G1Point: IsGroup + Serializable,
-    G2Point: IsGroup + Serializable,
+    G1Point: IsGroup + AsBytes,
+    G2Point: IsGroup + AsBytes,
 {
-    fn serialize(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Vec<u8> {
         let mut serialized_data: Vec<u8> = Vec::new();
         // First 4 bytes encodes protocol version
         let protocol_version: [u8; 4] = [0; 4];
@@ -68,12 +68,12 @@ where
 
         // G1 elements
         for point in &self.powers_main_group {
-            serialized_data.extend(point.serialize());
+            serialized_data.extend(point.as_bytes());
         }
 
         // G2 elements
         for point in &self.powers_secondary_group {
-            serialized_data.extend(point.serialize());
+            serialized_data.extend(point.as_bytes());
         }
 
         serialized_data
@@ -269,7 +269,7 @@ mod tests {
         },
         field::element::FieldElement,
         polynomial::Polynomial,
-        traits::{Deserializable, Serializable},
+        traits::{AsBytes, Deserializable},
         unsigned_integer::element::U256,
     };
 
@@ -404,7 +404,7 @@ mod tests {
     #[test]
     fn serialize_deserialize_srs() {
         let srs = create_srs();
-        let bytes = srs.serialize();
+        let bytes = srs.as_bytes();
         let deserialized: StructuredReferenceString<
             ShortWeierstrassProjectivePoint<BLS12381Curve>,
             ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,

--- a/crypto/src/merkle_tree/backends/field_element.rs
+++ b/crypto/src/merkle_tree/backends/field_element.rs
@@ -4,7 +4,7 @@ use crate::merkle_tree::traits::IsMerkleTreeBackend;
 use core::marker::PhantomData;
 use lambdaworks_math::{
     field::{element::FieldElement, traits::IsField},
-    traits::Serializable,
+    traits::AsBytes,
 };
 use sha3::{
     digest::{generic_array::GenericArray, OutputSizeUser},
@@ -30,7 +30,7 @@ impl<F, D: Digest, const NUM_BYTES: usize> IsMerkleTreeBackend
     for FieldElementBackend<F, D, NUM_BYTES>
 where
     F: IsField,
-    FieldElement<F>: Serializable + Sync + Send,
+    FieldElement<F>: AsBytes + Sync + Send,
     [u8; NUM_BYTES]: From<GenericArray<u8, <D as OutputSizeUser>::OutputSize>>,
 {
     type Node = [u8; NUM_BYTES];
@@ -38,7 +38,7 @@ where
 
     fn hash_data(input: &FieldElement<F>) -> [u8; NUM_BYTES] {
         let mut hasher = D::new();
-        hasher.update(input.serialize());
+        hasher.update(input.as_bytes());
         hasher.finalize().into()
     }
 

--- a/crypto/src/merkle_tree/backends/field_element_vector.rs
+++ b/crypto/src/merkle_tree/backends/field_element_vector.rs
@@ -5,7 +5,7 @@ use crate::merkle_tree::traits::IsMerkleTreeBackend;
 use alloc::vec::Vec;
 use lambdaworks_math::{
     field::{element::FieldElement, traits::IsField},
-    traits::Serializable,
+    traits::AsBytes,
 };
 use sha3::{
     digest::{generic_array::GenericArray, OutputSizeUser},
@@ -31,7 +31,7 @@ impl<F, D: Digest, const NUM_BYTES: usize> IsMerkleTreeBackend
     for FieldElementVectorBackend<F, D, NUM_BYTES>
 where
     F: IsField,
-    FieldElement<F>: Serializable,
+    FieldElement<F>: AsBytes,
     [u8; NUM_BYTES]: From<GenericArray<u8, <D as OutputSizeUser>::OutputSize>>,
     Vec<FieldElement<F>>: Sync + Send,
 {
@@ -41,7 +41,7 @@ where
     fn hash_data(input: &Vec<FieldElement<F>>) -> [u8; NUM_BYTES] {
         let mut hasher = D::new();
         for element in input.iter() {
-            hasher.update(element.serialize());
+            hasher.update(element.as_bytes());
         }
         let mut result_hash = [0_u8; NUM_BYTES];
         result_hash.copy_from_slice(&hasher.finalize());

--- a/exercises/blind_trust/README.md
+++ b/exercises/blind_trust/README.md
@@ -60,7 +60,7 @@ The files `srs` and `proof` can be deserialized using Lambdaworks methods as fol
 use std::{fs, io::{BufReader, Read}};
 use lambdaworks_plonk::prover::Proof;
 use lambdaworks_crypto::commitments::kzg::StructuredReferenceString;
-use lambdaworks_math::traits::{Deserializable, Serializable};
+use lambdaworks_math::traits::{Deserializable, AsBytes};
 use crate::sith_generate_proof::{SithProof, SithSRS};
 
 fn read_challenge_data_from_files() -> (SithSRS, SithProof) {

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::traits::IsShortWeierstrass;
 
 #[cfg(feature = "alloc")]
-use crate::traits::Serializable;
+use crate::traits::AsBytes;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
@@ -343,13 +343,24 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<E> Serializable for ShortWeierstrassProjectivePoint<E>
+impl<E> AsBytes for ShortWeierstrassProjectivePoint<E>
 where
     E: IsShortWeierstrass,
     FieldElement<E::BaseField>: ByteConversion,
 {
-    fn serialize(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> alloc::vec::Vec<u8> {
         self.serialize(PointFormat::Projective, Endianness::LittleEndian)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<E> From<ShortWeierstrassProjectivePoint<E>> for alloc::vec::Vec<u8>
+where
+    E: IsShortWeierstrass,
+    FieldElement<E::BaseField>: ByteConversion,
+{
+    fn from(value: ShortWeierstrassProjectivePoint<E>) -> Self {
+        value.as_bytes()
     }
 }
 

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -1,9 +1,9 @@
 use crate::field::element::FieldElement;
 use crate::field::errors::FieldError;
 use crate::field::traits::IsPrimeField;
-use crate::traits::ByteConversion;
 #[cfg(feature = "alloc")]
-use crate::traits::Serializable;
+use crate::traits::AsBytes;
+use crate::traits::ByteConversion;
 use crate::{
     field::traits::IsField, unsigned_integer::element::UnsignedInteger,
     unsigned_integer::montgomery::MontgomeryAlgorithms,
@@ -362,15 +362,26 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<M, const NUM_LIMBS: usize> Serializable
-    for FieldElement<MontgomeryBackendPrimeField<M, NUM_LIMBS>>
+impl<M, const NUM_LIMBS: usize> AsBytes for FieldElement<MontgomeryBackendPrimeField<M, NUM_LIMBS>>
 where
     M: IsModulus<UnsignedInteger<NUM_LIMBS>> + Clone + Debug,
 {
-    fn serialize(&self) -> alloc::vec::Vec<u8> {
+    fn as_bytes(&self) -> alloc::vec::Vec<u8> {
         self.value().to_bytes_be()
     }
 }
+
+#[cfg(feature = "alloc")]
+impl<M, const NUM_LIMBS: usize> From<FieldElement<MontgomeryBackendPrimeField<M, NUM_LIMBS>>>
+    for alloc::vec::Vec<u8>
+where
+    M: IsModulus<UnsignedInteger<NUM_LIMBS>> + Clone + Debug,
+{
+    fn from(value: FieldElement<MontgomeryBackendPrimeField<M, NUM_LIMBS>>) -> alloc::vec::Vec<u8> {
+        value.value().to_bytes_be()
+    }
+}
+
 #[cfg(test)]
 mod tests_u384_prime_fields {
     use crate::field::element::FieldElement;

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -5,8 +5,6 @@ use crate::errors::DeserializationError;
 use crate::field::element::FieldElement;
 use crate::field::errors::FieldError;
 use crate::field::traits::{IsFFTField, IsField, IsPrimeField};
-#[cfg(feature = "alloc")]
-use crate::traits::Serializable;
 use crate::traits::{ByteConversion, Deserializable};
 
 /// Type representing prime fields over unsigned 64-bit integers.
@@ -142,13 +140,6 @@ impl<const MODULUS: u64> ByteConversion for U64FieldElement<MODULUS> {
     fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError> {
         let bytes: [u8; 8] = bytes[0..8].try_into().map_err(|_| FromLEBytesError)?;
         Ok(Self::from(u64::from_le_bytes(bytes)))
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<const MODULUS: u64> Serializable for FieldElement<U64PrimeField<MODULUS>> {
-    fn serialize(&self) -> alloc::vec::Vec<u8> {
-        self.to_bytes_be()
     }
 }
 

--- a/math/src/field/fields/winterfell.rs
+++ b/math/src/field/fields/winterfell.rs
@@ -7,7 +7,7 @@ use crate::{
         errors::FieldError,
         traits::{IsFFTField, IsField, IsPrimeField, IsSubFieldOf},
     },
-    traits::{ByteConversion, Serializable},
+    traits::{AsBytes, ByteConversion},
     unsigned_integer::element::U256,
 };
 pub use miden_core::Felt;
@@ -92,9 +92,16 @@ impl IsField for Felt {
 }
 
 #[cfg(feature = "alloc")]
-impl Serializable for FieldElement<Felt> {
-    fn serialize(&self) -> Vec<u8> {
+impl AsBytes for FieldElement<Felt> {
+    fn as_bytes(&self) -> Vec<u8> {
         Felt::elements_as_bytes(&[*self.value()]).to_vec()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FieldElement<Felt>> for alloc::vec::Vec<u8> {
+    fn from(value: FieldElement<Felt>) -> Self {
+        value.as_bytes()
     }
 }
 
@@ -167,12 +174,19 @@ impl ByteConversion for QuadFelt {
 }
 
 #[cfg(feature = "alloc")]
-impl Serializable for FieldElement<QuadFelt> {
-    fn serialize(&self) -> Vec<u8> {
+impl AsBytes for FieldElement<QuadFelt> {
+    fn as_bytes(&self) -> Vec<u8> {
         let [b0, b1] = self.value().to_base_elements();
         let mut bytes = b0.to_bytes_be();
         bytes.extend(&b1.to_bytes_be());
         bytes
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FieldElement<QuadFelt>> for alloc::vec::Vec<u8> {
+    fn from(value: FieldElement<QuadFelt>) -> Self {
+        value.as_bytes()
     }
 }
 

--- a/math/src/traits.rs
+++ b/math/src/traits.rs
@@ -30,13 +30,26 @@ pub trait ByteConversion {
 /// Serialize function without args
 /// Used for serialization when formatting options are not relevant
 #[cfg(feature = "alloc")]
-pub trait Serializable {
+pub trait AsBytes {
     /// Default serialize without args
-    fn serialize(&self) -> alloc::vec::Vec<u8>;
+    fn as_bytes(&self) -> alloc::vec::Vec<u8>;
+}
+
+#[cfg(feature = "alloc")]
+impl AsBytes for u32 {
+    fn as_bytes(&self) -> alloc::vec::Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl AsBytes for u64 {
+    fn as_bytes(&self) -> alloc::vec::Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
 }
 
 /// Deserialize function without args
-/// Used along with the Serializable trait
 pub trait Deserializable {
     fn deserialize(bytes: &[u8]) -> Result<Self, DeserializationError>
     where

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -14,6 +14,8 @@ use proptest::{
 
 use crate::errors::ByteConversionError;
 use crate::errors::CreationError;
+#[cfg(feature = "alloc")]
+use crate::traits::AsBytes;
 use crate::traits::ByteConversion;
 use crate::unsigned_integer::traits::IsUnsignedInteger;
 
@@ -959,6 +961,25 @@ impl<const NUM_LIMBS: usize> ByteConversion for UnsignedInteger<NUM_LIMBS> {
 impl<const NUM_LIMBS: usize> From<UnsignedInteger<NUM_LIMBS>> for u16 {
     fn from(value: UnsignedInteger<NUM_LIMBS>) -> Self {
         value.limbs[NUM_LIMBS - 1] as u16
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const NUM_LIMBS: usize> AsBytes for UnsignedInteger<NUM_LIMBS> {
+    fn as_bytes(&self) -> alloc::vec::Vec<u8> {
+        self.limbs
+            .into_iter()
+            .fold(alloc::vec::Vec::new(), |mut acc, limb| {
+                acc.extend_from_slice(&limb.as_bytes());
+                acc
+            })
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const NUM_LIMBS: usize> From<UnsignedInteger<NUM_LIMBS>> for alloc::vec::Vec<u8> {
+    fn from(val: UnsignedInteger<NUM_LIMBS>) -> Self {
+        val.as_bytes()
     }
 }
 

--- a/provers/cairo/src/air.rs
+++ b/provers/cairo/src/air.rs
@@ -4,7 +4,7 @@ use lambdaworks_math::{
     field::{
         element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
     },
-    traits::{ByteConversion, Deserializable, Serializable},
+    traits::{AsBytes, ByteConversion, Deserializable},
 };
 use stark_platinum_prover::{
     constraints::boundary::{BoundaryConstraint, BoundaryConstraints},
@@ -266,8 +266,8 @@ impl PublicInputs {
     }
 }
 
-impl Serializable for PublicInputs {
-    fn serialize(&self) -> Vec<u8> {
+impl AsBytes for PublicInputs {
+    fn as_bytes(&self) -> Vec<u8> {
         let mut bytes = vec![];
         let pc_init_bytes = self.pc_init.to_bytes_be();
         let felt_length = pc_init_bytes.len();
@@ -1420,7 +1420,7 @@ mod test {
 mod prop_test {
     use lambdaworks_math::{
         field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
-        traits::{Deserializable, Serializable},
+        traits::{AsBytes, Deserializable},
     };
     use proptest::{prelude::*, prop_compose, proptest};
     use stark_platinum_prover::proof::{options::ProofOptions, stark::StarkProof};
@@ -1476,7 +1476,7 @@ mod prop_test {
         fn test_public_inputs_serialization(
             public_inputs in some_public_inputs(),
         ){
-            let serialized = Serializable::serialize(&public_inputs);
+            let serialized = AsBytes::as_bytes(&public_inputs);
             let deserialized: PublicInputs = Deserializable::deserialize(&serialized).unwrap();
             prop_assert_eq!(public_inputs.pc_init, deserialized.pc_init);
             prop_assert_eq!(public_inputs.ap_init, deserialized.ap_init);

--- a/provers/groth16/src/prover.rs
+++ b/provers/groth16/src/prover.rs
@@ -1,6 +1,6 @@
 use crate::{common::*, ProvingKey, QuadraticArithmeticProgram};
 use lambdaworks_math::errors::DeserializationError;
-use lambdaworks_math::traits::{Deserializable, Serializable};
+use lambdaworks_math::traits::{AsBytes, Deserializable};
 use lambdaworks_math::{cyclic_group::IsGroup, msm::pippenger::msm};
 use std::mem::size_of;
 
@@ -36,8 +36,8 @@ impl Proof {
         Ok(Self { pi1, pi2, pi3 })
     }
 
-    fn serialize_commitment<Commitment: Serializable>(cm: &Commitment) -> Vec<u8> {
-        cm.serialize()
+    fn serialize_commitment<Commitment: AsBytes>(cm: &Commitment) -> Vec<u8> {
+        cm.as_bytes()
     }
 
     // Repetitive. Same as in plonk/src/prover.rs

--- a/provers/plonk/src/setup.rs
+++ b/provers/plonk/src/setup.rs
@@ -8,7 +8,7 @@ use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
 use lambdaworks_math::field::traits::IsFFTField;
 use lambdaworks_math::field::{element::FieldElement, traits::IsField};
 use lambdaworks_math::polynomial::Polynomial;
-use lambdaworks_math::traits::{ByteConversion, Serializable};
+use lambdaworks_math::traits::{AsBytes, ByteConversion};
 
 // TODO: implement getters
 pub struct Witness<F: IsField> {
@@ -137,18 +137,18 @@ where
     F: IsField,
     FieldElement<F>: ByteConversion,
     CS: IsCommitmentScheme<F>,
-    CS::Commitment: Serializable,
+    CS::Commitment: AsBytes,
 {
     let mut transcript = DefaultTranscript::new();
 
-    transcript.append(&vk.s1_1.serialize());
-    transcript.append(&vk.s2_1.serialize());
-    transcript.append(&vk.s3_1.serialize());
-    transcript.append(&vk.ql_1.serialize());
-    transcript.append(&vk.qr_1.serialize());
-    transcript.append(&vk.qm_1.serialize());
-    transcript.append(&vk.qo_1.serialize());
-    transcript.append(&vk.qc_1.serialize());
+    transcript.append(&vk.s1_1.as_bytes());
+    transcript.append(&vk.s2_1.as_bytes());
+    transcript.append(&vk.s3_1.as_bytes());
+    transcript.append(&vk.ql_1.as_bytes());
+    transcript.append(&vk.qr_1.as_bytes());
+    transcript.append(&vk.qm_1.as_bytes());
+    transcript.append(&vk.qo_1.as_bytes());
+    transcript.append(&vk.qc_1.as_bytes());
 
     for value in public_input.iter() {
         transcript.append(&value.to_bytes_be());

--- a/provers/plonk/src/verifier.rs
+++ b/provers/plonk/src/verifier.rs
@@ -3,7 +3,7 @@ use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
 use lambdaworks_math::cyclic_group::IsGroup;
 use lambdaworks_math::field::element::FieldElement;
 use lambdaworks_math::field::traits::{IsFFTField, IsField, IsPrimeField};
-use lambdaworks_math::traits::{ByteConversion, Serializable};
+use lambdaworks_math::traits::{AsBytes, ByteConversion};
 use std::marker::PhantomData;
 
 use crate::prover::Proof;
@@ -31,23 +31,23 @@ impl<F: IsField + IsFFTField, CS: IsCommitmentScheme<F>> Verifier<F, CS> {
     where
         F: IsField,
         CS: IsCommitmentScheme<F>,
-        CS::Commitment: Serializable,
+        CS::Commitment: AsBytes,
         FieldElement<F>: ByteConversion,
     {
         let mut transcript = new_strong_fiat_shamir_transcript::<F, CS>(vk, public_input);
 
-        transcript.append(&p.a_1.serialize());
-        transcript.append(&p.b_1.serialize());
-        transcript.append(&p.c_1.serialize());
+        transcript.append(&p.a_1.as_bytes());
+        transcript.append(&p.b_1.as_bytes());
+        transcript.append(&p.c_1.as_bytes());
         let beta = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
         let gamma = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
 
-        transcript.append(&p.z_1.serialize());
+        transcript.append(&p.z_1.as_bytes());
         let alpha = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
 
-        transcript.append(&p.t_lo_1.serialize());
-        transcript.append(&p.t_mid_1.serialize());
-        transcript.append(&p.t_hi_1.serialize());
+        transcript.append(&p.t_lo_1.as_bytes());
+        transcript.append(&p.t_mid_1.as_bytes());
+        transcript.append(&p.t_hi_1.as_bytes());
         let zeta = FieldElement::from_bytes_be(&transcript.challenge()).unwrap();
 
         transcript.append(&p.a_zeta.to_bytes_be());
@@ -71,7 +71,7 @@ impl<F: IsField + IsFFTField, CS: IsCommitmentScheme<F>> Verifier<F, CS> {
     where
         F: IsPrimeField + IsFFTField,
         CS: IsCommitmentScheme<F>,
-        CS::Commitment: Serializable + IsGroup,
+        CS::Commitment: AsBytes + IsGroup,
         FieldElement<F>: ByteConversion,
     {
         // TODO: First three steps are validations: belonging to main subgroup, belonging to prime field.
@@ -409,7 +409,7 @@ mod tests {
             &verifying_key,
         );
 
-        let serialized_proof = proof.serialize();
+        let serialized_proof = proof.as_bytes();
         let deserialized_proof = Proof::deserialize(&serialized_proof).unwrap();
 
         let verifier = Verifier::new(kzg);

--- a/provers/stark/src/constraints/evaluator.rs
+++ b/provers/stark/src/constraints/evaluator.rs
@@ -6,7 +6,7 @@ use lambdaworks_math::{
         traits::{IsFFTField, IsField, IsSubFieldOf},
     },
     polynomial::Polynomial,
-    traits::Serializable,
+    traits::AsBytes,
 };
 
 #[cfg(feature = "parallel")]
@@ -43,8 +43,8 @@ impl<A: AIR> ConstraintEvaluator<A> {
         rap_challenges: &A::RAPChallenges,
     ) -> Vec<FieldElement<A::FieldExtension>>
     where
-        FieldElement<A::Field>: Serializable + Send + Sync,
-        FieldElement<A::FieldExtension>: Serializable + Send + Sync,
+        FieldElement<A::Field>: AsBytes + Send + Sync,
+        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
         A: Send + Sync,
         A::RAPChallenges: Send + Sync,
     {
@@ -263,8 +263,8 @@ fn evaluate_transition_exemptions<F: IsFFTField + IsSubFieldOf<E>, E: IsField>(
     domain: &Domain<F>,
 ) -> Vec<Vec<FieldElement<E>>>
 where
-    FieldElement<F>: Send + Sync + Serializable,
-    FieldElement<E>: Send + Sync + Serializable,
+    FieldElement<F>: Send + Sync + AsBytes,
+    FieldElement<E>: Send + Sync + AsBytes,
     Polynomial<FieldElement<F>>: Send + Sync,
 {
     #[cfg(feature = "parallel")]

--- a/provers/stark/src/examples/fibonacci_2_cols_shifted.rs
+++ b/provers/stark/src/examples/fibonacci_2_cols_shifted.rs
@@ -1,6 +1,6 @@
 use lambdaworks_math::{
     field::{element::FieldElement, traits::IsFFTField},
-    traits::Serializable,
+    traits::AsBytes,
 };
 
 use crate::{
@@ -22,14 +22,14 @@ where
     pub claimed_index: usize,
 }
 
-impl<F> Serializable for PublicInputs<F>
+impl<F> AsBytes for PublicInputs<F>
 where
     F: IsFFTField,
-    FieldElement<F>: Serializable,
+    FieldElement<F>: AsBytes,
 {
-    fn serialize(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Vec<u8> {
         let mut transcript_init_seed = self.claimed_index.to_be_bytes().to_vec();
-        transcript_init_seed.extend_from_slice(&self.claimed_value.serialize());
+        transcript_init_seed.extend_from_slice(&self.claimed_value.as_bytes());
         transcript_init_seed
     }
 }

--- a/provers/stark/src/fri/fri_commitment.rs
+++ b/provers/stark/src/fri/fri_commitment.rs
@@ -1,14 +1,14 @@
 use lambdaworks_crypto::merkle_tree::{merkle::MerkleTree, traits::IsMerkleTreeBackend};
 use lambdaworks_math::{
     field::{element::FieldElement, traits::IsField},
-    traits::Serializable,
+    traits::AsBytes,
 };
 
 #[derive(Clone)]
 pub struct FriLayer<F, B>
 where
     F: IsField,
-    FieldElement<F>: Serializable,
+    FieldElement<F>: AsBytes,
     B: IsMerkleTreeBackend,
 {
     pub evaluation: Vec<FieldElement<F>>,
@@ -20,7 +20,7 @@ where
 impl<F, B> FriLayer<F, B>
 where
     F: IsField,
-    FieldElement<F>: Serializable,
+    FieldElement<F>: AsBytes,
     B: IsMerkleTreeBackend,
 {
     pub fn new(

--- a/provers/stark/src/fri/mod.rs
+++ b/provers/stark/src/fri/mod.rs
@@ -3,7 +3,7 @@ pub mod fri_decommit;
 mod fri_functions;
 
 use lambdaworks_math::field::traits::{IsFFTField, IsField};
-use lambdaworks_math::traits::Serializable;
+use lambdaworks_math::traits::AsBytes;
 use lambdaworks_math::{
     fft::cpu::bit_reversing::in_place_bit_reverse_permute, field::traits::IsSubFieldOf,
 };
@@ -30,8 +30,8 @@ pub fn commit_phase<F: IsFFTField + IsSubFieldOf<E>, E: IsField>(
     Vec<FriLayer<E, BatchedMerkleTreeBackend<E>>>,
 )
 where
-    FieldElement<F>: Serializable + Sync + Send,
-    FieldElement<E>: Serializable + Sync + Send,
+    FieldElement<F>: AsBytes + Sync + Send,
+    FieldElement<E>: AsBytes + Sync + Send,
 {
     let mut domain_size = domain_size;
 
@@ -79,7 +79,7 @@ pub fn query_phase<F: IsField>(
     iotas: &[usize],
 ) -> Vec<FriDecommitment<F>>
 where
-    FieldElement<F>: Serializable + Sync + Send,
+    FieldElement<F>: AsBytes + Sync + Send,
 {
     if !fri_layers.is_empty() {
         let query_list = iotas
@@ -118,8 +118,8 @@ pub fn new_fri_layer<F: IsFFTField + IsSubFieldOf<E>, E: IsField>(
     domain_size: usize,
 ) -> crate::fri::fri_commitment::FriLayer<E, BatchedMerkleTreeBackend<E>>
 where
-    FieldElement<F>: Serializable + Sync + Send,
-    FieldElement<E>: Serializable + Sync + Send,
+    FieldElement<F>: AsBytes + Sync + Send,
+    FieldElement<E>: AsBytes + Sync + Send,
 {
     let mut evaluation =
         Polynomial::evaluate_offset_fft(poly, 1, Some(domain_size), coset_offset).unwrap(); // TODO: return error

--- a/provers/stark/src/proof/stark.rs
+++ b/provers/stark/src/proof/stark.rs
@@ -7,7 +7,7 @@ use lambdaworks_math::{
         fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
         traits::{IsField, IsSubFieldOf},
     },
-    traits::Serializable,
+    traits::AsBytes,
 };
 
 use crate::{
@@ -80,7 +80,7 @@ impl StoneCompatibleSerializer {
     ) -> Vec<u8>
     where
         A: AIR<Field = Stark252PrimeField, FieldExtension = Stark252PrimeField>,
-        A::PublicInputs: Serializable,
+        A::PublicInputs: AsBytes,
     {
         let mut output = Vec::new();
 
@@ -134,12 +134,12 @@ impl StoneCompatibleSerializer {
         for i in 0..proof.trace_ood_evaluations.n_cols() {
             for j in 0..proof.trace_ood_evaluations.n_rows() {
                 output
-                    .extend_from_slice(&proof.trace_ood_evaluations.get_row_main(j)[i].serialize());
+                    .extend_from_slice(&proof.trace_ood_evaluations.get_row_main(j)[i].as_bytes());
             }
         }
 
         for elem in proof.composition_poly_parts_ood_evaluation.iter() {
-            output.extend_from_slice(&elem.serialize());
+            output.extend_from_slice(&elem.as_bytes());
         }
     }
 
@@ -157,7 +157,7 @@ impl StoneCompatibleSerializer {
                 .collect::<Vec<_>>(),
         );
 
-        output.extend_from_slice(&proof.fri_last_value.serialize());
+        output.extend_from_slice(&proof.fri_last_value.as_bytes());
     }
 
     /// Appends the proof of work nonce in case there is one. There could be none if the `grinding_factor`
@@ -215,20 +215,20 @@ impl StoneCompatibleSerializer {
         // Append BT_{i_1} | BT_{i_2} | ... | BT_{i_k}
         for (opening, _) in fri_first_layer_openings.iter() {
             for elem in opening.main_trace_polys.evaluations.iter() {
-                output.extend_from_slice(&elem.serialize());
+                output.extend_from_slice(&elem.as_bytes());
             }
             if let Some(aux) = &opening.aux_trace_polys {
                 for elem in aux.evaluations.iter() {
-                    output.extend_from_slice(&elem.serialize());
+                    output.extend_from_slice(&elem.as_bytes());
                 }
             }
 
             for elem in opening.main_trace_polys.evaluations_sym.iter() {
-                output.extend_from_slice(&elem.serialize());
+                output.extend_from_slice(&elem.as_bytes());
             }
             if let Some(aux) = &opening.aux_trace_polys {
                 for elem in aux.evaluations_sym.iter() {
-                    output.extend_from_slice(&elem.serialize());
+                    output.extend_from_slice(&elem.as_bytes());
                 }
             }
         }
@@ -277,10 +277,10 @@ impl StoneCompatibleSerializer {
         // Append BH_{i_1} | BH_{i_2} | ... | B_{i_k}
         for (opening, _) in fri_first_layer_openings.iter() {
             for elem in opening.composition_poly.evaluations.iter() {
-                output.extend_from_slice(&elem.serialize());
+                output.extend_from_slice(&elem.as_bytes());
             }
             for elem in opening.composition_poly.evaluations_sym.iter() {
-                output.extend_from_slice(&elem.serialize());
+                output.extend_from_slice(&elem.as_bytes());
             }
         }
 
@@ -363,7 +363,7 @@ impl StoneCompatibleSerializer {
                 .iter()
                 .map(|(row, col)| &fri_layers_evaluations[&(i as u64, *row, *col)])
             {
-                output.extend_from_slice(&element.serialize());
+                output.extend_from_slice(&element.as_bytes());
             }
 
             indexes_previous_layer = indexes_previous_layer
@@ -450,9 +450,9 @@ impl StoneCompatibleSerializer {
     ) -> Vec<usize>
     where
         A: AIR<Field = Stark252PrimeField, FieldExtension = Stark252PrimeField>,
-        A::PublicInputs: Serializable,
+        A::PublicInputs: AsBytes,
     {
-        let mut transcript = StoneProverTranscript::new(&public_inputs.serialize());
+        let mut transcript = StoneProverTranscript::new(&public_inputs.as_bytes());
         let air = A::new(proof.trace_length, public_inputs, proof_options);
         let domain = Domain::<Stark252PrimeField>::new(&air);
         let challenges = Verifier::step_1_replay_rounds_and_recover_challenges(
@@ -467,7 +467,7 @@ impl StoneCompatibleSerializer {
 
 #[cfg(test)]
 mod tests {
-    use lambdaworks_math::{field::element::FieldElement, traits::Serializable};
+    use lambdaworks_math::{field::element::FieldElement, traits::AsBytes};
 
     use crate::{
         examples::fibonacci_2_cols_shifted::{self, Fibonacci2ColsShifted},
@@ -498,7 +498,7 @@ mod tests {
             &trace,
             &pub_inputs,
             &proof_options,
-            StoneProverTranscript::new(&pub_inputs.serialize()),
+            StoneProverTranscript::new(&pub_inputs.as_bytes()),
         )
         .unwrap();
 
@@ -576,7 +576,7 @@ mod tests {
             &trace,
             &pub_inputs,
             &proof_options,
-            StoneProverTranscript::new(&pub_inputs.serialize()),
+            StoneProverTranscript::new(&pub_inputs.as_bytes()),
         )
         .unwrap();
         let expected_bytes = [
@@ -668,7 +668,7 @@ mod tests {
             &trace,
             &pub_inputs,
             &proof_options,
-            StoneProverTranscript::new(&pub_inputs.serialize()),
+            StoneProverTranscript::new(&pub_inputs.as_bytes()),
         )
         .unwrap();
 
@@ -932,7 +932,7 @@ mod tests {
             &trace,
             &pub_inputs,
             &proof_options,
-            StoneProverTranscript::new(&pub_inputs.serialize()),
+            StoneProverTranscript::new(&pub_inputs.as_bytes()),
         )
         .unwrap();
 
@@ -1010,7 +1010,7 @@ mod tests {
             &trace,
             &pub_inputs,
             &proof_options,
-            StoneProverTranscript::new(&pub_inputs.serialize()),
+            StoneProverTranscript::new(&pub_inputs.as_bytes()),
         )
         .unwrap();
 

--- a/provers/stark/src/prover.rs
+++ b/provers/stark/src/prover.rs
@@ -6,7 +6,7 @@ use lambdaworks_math::fft::cpu::bit_reversing::{in_place_bit_reverse_permute, re
 use lambdaworks_math::fft::errors::FFTError;
 
 use lambdaworks_math::field::traits::{IsField, IsSubFieldOf};
-use lambdaworks_math::traits::Serializable;
+use lambdaworks_math::traits::AsBytes;
 use lambdaworks_math::{
     field::{element::FieldElement, traits::IsFFTField},
     polynomial::Polynomial,
@@ -50,7 +50,7 @@ pub enum ProvingError {
 pub struct Round1CommitmentData<F>
 where
     F: IsField,
-    FieldElement<F>: Serializable + Send + Sync,
+    FieldElement<F>: AsBytes + Send + Sync,
 {
     /// The result of the interpolation of the columns of the trace table.
     pub(crate) trace_polys: Vec<Polynomial<FieldElement<F>>>,
@@ -64,8 +64,8 @@ where
 pub struct Round1<A>
 where
     A: AIR,
-    FieldElement<A::FieldExtension>: Serializable + Sync + Send,
-    FieldElement<A::Field>: Serializable + Sync + Send,
+    FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+    FieldElement<A::Field>: AsBytes + Sync + Send,
 {
     /// The table of evaluations over the LDE of the main and auxiliary trace tables.
     pub(crate) lde_table: EvaluationTable<A::Field, A::FieldExtension>,
@@ -80,8 +80,8 @@ where
 impl<A> Round1<A>
 where
     A: AIR,
-    FieldElement<A::FieldExtension>: Serializable + Sync + Send,
-    FieldElement<A::Field>: Serializable + Sync + Send,
+    FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+    FieldElement<A::Field>: AsBytes + Sync + Send,
 {
     /// Returns the full list of the polynomials interpolating the trace. It includes both
     /// main and auxiliary trace polynomials. The main trace polynomials are casted to
@@ -106,7 +106,7 @@ where
 pub struct Round2<F>
 where
     F: IsField,
-    FieldElement<F>: Serializable + Sync + Send,
+    FieldElement<F>: AsBytes + Sync + Send,
 {
     /// The list of polynomials `H₀, ..., Hₙ` such that `H = ∑ᵢXⁱH(Xⁿ)`, where H is the composition polynomial.
     pub(crate) composition_poly_parts: Vec<Polynomial<FieldElement<F>>>,
@@ -171,9 +171,9 @@ pub trait IsStarkProver<A: AIR> {
     /// Returns the Merkle tree and the commitment to the vectors `vectors`.
     fn batch_commit<E>(vectors: &[Vec<FieldElement<E>>]) -> (BatchedMerkleTree<E>, Commitment)
     where
-        FieldElement<A::Field>: Serializable + Sync + Send,
-        FieldElement<A::FieldExtension>: Serializable + Sync + Send,
-        FieldElement<E>: Serializable + Sync + Send,
+        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+        FieldElement<E>: AsBytes + Sync + Send,
         E: IsSubFieldOf<A::FieldExtension>,
         A::Field: IsSubFieldOf<E>,
     {
@@ -201,9 +201,9 @@ pub trait IsStarkProver<A: AIR> {
         Commitment,
     )
     where
-        FieldElement<A::Field>: Serializable + Send + Sync,
-        FieldElement<E>: Serializable + Send + Sync,
-        FieldElement<A::FieldExtension>: Serializable + Send + Sync,
+        FieldElement<A::Field>: AsBytes + Send + Sync,
+        FieldElement<E>: AsBytes + Send + Sync,
+        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
         E: IsSubFieldOf<A::FieldExtension>,
         A::Field: IsSubFieldOf<E>,
     {
@@ -272,8 +272,8 @@ pub trait IsStarkProver<A: AIR> {
         transcript: &mut impl IsStarkTranscript<A::FieldExtension>,
     ) -> Result<Round1<A>, ProvingError>
     where
-        FieldElement<A::Field>: Serializable + Send + Sync,
-        FieldElement<A::FieldExtension>: Serializable + Send + Sync,
+        FieldElement<A::Field>: AsBytes + Send + Sync,
+        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
     {
         let (trace_polys, evaluations, main_merkle_tree, main_merkle_root) =
             Self::interpolate_and_commit::<A::Field>(main_trace, domain, transcript);
@@ -316,8 +316,8 @@ pub trait IsStarkProver<A: AIR> {
         lde_composition_poly_parts_evaluations: &[Vec<FieldElement<A::FieldExtension>>],
     ) -> (BatchedMerkleTree<A::FieldExtension>, Commitment)
     where
-        FieldElement<A::Field>: Serializable + Sync + Send,
-        FieldElement<A::FieldExtension>: Serializable + Sync + Send,
+        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
     {
         // TODO: Remove clones
         let mut lde_composition_poly_evaluations = Vec::new();
@@ -352,8 +352,8 @@ pub trait IsStarkProver<A: AIR> {
     where
         A: Send + Sync,
         A::RAPChallenges: Send + Sync,
-        FieldElement<A::Field>: Serializable + Send + Sync,
-        FieldElement<A::FieldExtension>: Serializable + Send + Sync,
+        FieldElement<A::Field>: AsBytes + Send + Sync,
+        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
     {
         // Compute the evaluations of the composition polynomial on the LDE domain.
         let evaluator = ConstraintEvaluator::new(air, &round_1_result.rap_challenges);
@@ -407,8 +407,8 @@ pub trait IsStarkProver<A: AIR> {
         z: &FieldElement<A::FieldExtension>,
     ) -> Round3<A::FieldExtension>
     where
-        FieldElement<A::Field>: Serializable + Sync + Send,
-        FieldElement<A::FieldExtension>: Serializable + Sync + Send,
+        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
     {
         let z_power = z.pow(round_2_result.composition_poly_parts.len());
 
@@ -458,8 +458,8 @@ pub trait IsStarkProver<A: AIR> {
         transcript: &mut impl IsStarkTranscript<A::FieldExtension>,
     ) -> Round4<A::Field, A::FieldExtension>
     where
-        FieldElement<A::Field>: Serializable + Send + Sync,
-        FieldElement<A::FieldExtension>: Serializable + Send + Sync,
+        FieldElement<A::Field>: AsBytes + Send + Sync,
+        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
     {
         let coset_offset_u64 = air.context().proof_options.coset_offset;
         let coset_offset = FieldElement::<A::Field>::from(coset_offset_u64);
@@ -561,8 +561,8 @@ pub trait IsStarkProver<A: AIR> {
         trace_terms_gammas: &[FieldElement<A::FieldExtension>],
     ) -> Polynomial<FieldElement<A::FieldExtension>>
     where
-        FieldElement<A::Field>: Serializable + Send + Sync,
-        FieldElement<A::FieldExtension>: Serializable + Send + Sync,
+        FieldElement<A::Field>: AsBytes + Send + Sync,
+        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
     {
         let z_power = z.pow(round_2_result.composition_poly_parts.len());
 
@@ -639,8 +639,8 @@ pub trait IsStarkProver<A: AIR> {
         (z, primitive_root): (&FieldElement<A::FieldExtension>, &FieldElement<A::Field>),
     ) -> Polynomial<FieldElement<A::FieldExtension>>
     where
-        FieldElement<A::Field>: Serializable + Send + Sync,
-        FieldElement<A::FieldExtension>: Serializable + Send + Sync,
+        FieldElement<A::Field>: AsBytes + Send + Sync,
+        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
     {
         let iter_trace_gammas = trace_terms_gammas.iter().skip(j * trace_frame_length);
         let trace_int = trace_frame_evaluations[j]
@@ -670,8 +670,8 @@ pub trait IsStarkProver<A: AIR> {
         index: usize,
     ) -> PolynomialOpenings<A::FieldExtension>
     where
-        FieldElement<A::Field>: Serializable + Sync + Send,
-        FieldElement<A::FieldExtension>: Serializable + Sync + Send,
+        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
     {
         let proof = composition_poly_merkle_tree
             .get_proof_by_pos(index)
@@ -713,8 +713,8 @@ pub trait IsStarkProver<A: AIR> {
         challenge: usize,
     ) -> PolynomialOpenings<E>
     where
-        FieldElement<A::Field>: Serializable + Sync + Send,
-        FieldElement<E>: Serializable + Sync + Send,
+        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<E>: AsBytes + Sync + Send,
         A::Field: IsSubFieldOf<E>,
         E: IsField,
     {
@@ -742,8 +742,8 @@ pub trait IsStarkProver<A: AIR> {
         indexes_to_open: &[usize],
     ) -> DeepPolynomialOpenings<A::Field, A::FieldExtension>
     where
-        FieldElement<A::Field>: Serializable + Send + Sync,
-        FieldElement<A::FieldExtension>: Serializable + Send + Sync,
+        FieldElement<A::Field>: AsBytes + Send + Sync,
+        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
     {
         let mut openings = Vec::new();
 
@@ -792,8 +792,8 @@ pub trait IsStarkProver<A: AIR> {
     where
         A: Send + Sync,
         A::RAPChallenges: Send + Sync,
-        FieldElement<A::Field>: Serializable + Send + Sync,
-        FieldElement<A::FieldExtension>: Serializable + Send + Sync,
+        FieldElement<A::Field>: AsBytes + Send + Sync,
+        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
     {
         info!("Started proof generation...");
         #[cfg(feature = "instruments")]

--- a/provers/stark/src/transcript.rs
+++ b/provers/stark/src/transcript.rs
@@ -4,7 +4,7 @@ use lambdaworks_math::{
         fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
         traits::{IsFFTField, IsField, IsSubFieldOf},
     },
-    traits::{ByteConversion, Serializable},
+    traits::{AsBytes, ByteConversion},
     unsigned_integer::element::U256,
 };
 use sha3::{Digest, Keccak256};
@@ -28,7 +28,7 @@ pub trait IsStarkTranscript<F: IsField> {
         trace_roots_of_unity: &[FieldElement<S>],
     ) -> FieldElement<F>
     where
-        FieldElement<F>: Serializable,
+        FieldElement<F>: AsBytes,
     {
         loop {
             let value: FieldElement<F> = self.sample_field_element();
@@ -173,7 +173,7 @@ pub fn batch_sample_challenges<F: IsFFTField>(
     transcript: &mut impl IsStarkTranscript<F>,
 ) -> Vec<FieldElement<F>>
 where
-    FieldElement<F>: Serializable,
+    FieldElement<F>: AsBytes,
 {
     (0..size)
         .map(|_| transcript.sample_field_element())

--- a/provers/stark/src/verifier.rs
+++ b/provers/stark/src/verifier.rs
@@ -17,7 +17,7 @@ use lambdaworks_math::{
         element::FieldElement,
         traits::{IsFFTField, IsField, IsSubFieldOf},
     },
-    traits::Serializable,
+    traits::AsBytes,
 };
 
 use super::{
@@ -87,8 +87,8 @@ pub trait IsStarkVerifier<A: AIR> {
         transcript: &mut impl IsStarkTranscript<A::FieldExtension>,
     ) -> Challenges<A::FieldExtension, A>
     where
-        FieldElement<A::Field>: Serializable,
-        FieldElement<A::FieldExtension>: Serializable,
+        FieldElement<A::Field>: AsBytes,
+        FieldElement<A::FieldExtension>: AsBytes,
     {
         // ===================================
         // ==========|   Round 1   |==========
@@ -332,8 +332,8 @@ pub trait IsStarkVerifier<A: AIR> {
         challenges: &Challenges<A::FieldExtension, A>,
     ) -> bool
     where
-        FieldElement<A::Field>: Serializable + Sync + Send,
-        FieldElement<A::FieldExtension>: Serializable + Sync + Send,
+        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
     {
         let (deep_poly_evaluations, deep_poly_evaluations_sym) =
             Self::reconstruct_deep_composition_poly_evaluations_for_all_queries(
@@ -395,8 +395,8 @@ pub trait IsStarkVerifier<A: AIR> {
         value: &[FieldElement<E>],
     ) -> bool
     where
-        FieldElement<A::Field>: Serializable + Sync + Send,
-        FieldElement<E>: Serializable + Sync + Send,
+        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<E>: AsBytes + Sync + Send,
         E: IsField,
         A::Field: IsSubFieldOf<E>,
     {
@@ -411,8 +411,8 @@ pub trait IsStarkVerifier<A: AIR> {
         iota: usize,
     ) -> bool
     where
-        FieldElement<A::Field>: Serializable + Sync + Send,
-        FieldElement<A::FieldExtension>: Serializable + Sync + Send,
+        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
     {
         let index = iota * 2;
         let index_sym = iota * 2 + 1;
@@ -465,8 +465,8 @@ pub trait IsStarkVerifier<A: AIR> {
         iota: &usize,
     ) -> bool
     where
-        FieldElement<A::Field>: Serializable + Sync + Send,
-        FieldElement<A::FieldExtension>: Serializable + Sync + Send,
+        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
     {
         let mut value = deep_poly_openings.composition_poly.evaluations.clone();
         value.extend_from_slice(&deep_poly_openings.composition_poly.evaluations_sym);
@@ -489,8 +489,8 @@ pub trait IsStarkVerifier<A: AIR> {
         challenges: &Challenges<A::FieldExtension, A>,
     ) -> bool
     where
-        FieldElement<A::Field>: Serializable + Sync + Send,
-        FieldElement<A::FieldExtension>: Serializable + Sync + Send,
+        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
     {
         challenges.iotas.iter().zip(&proof.deep_poly_openings).fold(
             true,
@@ -516,8 +516,8 @@ pub trait IsStarkVerifier<A: AIR> {
         iota: usize,
     ) -> bool
     where
-        FieldElement<A::Field>: Serializable + Sync + Send,
-        FieldElement<A::FieldExtension>: Serializable + Sync + Send,
+        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
     {
         let evaluations = if iota % 2 == 1 {
             vec![evaluation_sym.clone(), evaluation.clone()]
@@ -550,8 +550,8 @@ pub trait IsStarkVerifier<A: AIR> {
         deep_composition_evaluation_sym: &FieldElement<A::FieldExtension>,
     ) -> bool
     where
-        FieldElement<A::Field>: Serializable + Sync + Send,
-        FieldElement<A::FieldExtension>: Serializable + Sync + Send,
+        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
     {
         let fri_layers_merkle_roots = &proof.fri_layers_merkle_roots;
         let evaluation_point_vec: Vec<FieldElement<A::Field>> =
@@ -722,8 +722,8 @@ pub trait IsStarkVerifier<A: AIR> {
         mut transcript: impl IsStarkTranscript<A::FieldExtension>,
     ) -> bool
     where
-        FieldElement<A::Field>: Serializable + Sync + Send,
-        FieldElement<A::FieldExtension>: Serializable + Sync + Send,
+        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
     {
         // Verify there are enough queries
         if proof.query_list.len() < proof_options.fri_number_of_queries {


### PR DESCRIPTION
# AsBytes Refactor and Improvements

## Description

Partially Closes #744. 
 
- [x] Change the Serializable trait to AsBytes, and .serialize() to .as_bytes(). This is more consistent with how other [x] - structures in Rust works, like Strings
- [x] For all types that support .as_bytes(), support into() to create a Vec::<u8>
- [x] For all types that support .as_bytes(), support try_into() to try to convert the data into an [u8] (Derived from From implementation)

## Checklist
- [x] Linked to Github Issue