### PR TITLE
Delayed reduction for M31 summations - from Plonky3

### DIFF
--- a/crypto/src/hash/monolith/utils.rs
+++ b/crypto/src/hash/monolith/utils.rs
@@ -24,11 +24,7 @@ fn random_field_element(shake: &mut Shake128Reader) -> u32 {
 }
 
 pub fn dot_product(u: &[u32], v: &[u32]) -> u32 {
-    u.iter()
-        .zip(v)
-        .map(|(x, y)| F::mul(x, y))
-        .reduce(|a, b| F::add(&a, &b))
-        .unwrap()
+    Mersenne31Field::sum(u.iter().zip(v).map(|(x, y)| F::mul(x, y)))
 }
 
 pub fn get_random_y_i(

--- a/math/src/field/fields/mersenne31/field.rs
+++ b/math/src/field/fields/mersenne31/field.rs
@@ -36,12 +36,7 @@ impl Mersenne31Field {
     }
 
     #[inline]
-    fn from_u32(x: u32) -> u32 {
-        Self::weak_reduce(x)
-    }
-
-    #[inline]
-    fn sum<I: Iterator<Item = <Self as IsField>::BaseType>>(
+    pub fn sum<I: Iterator<Item = <Self as IsField>::BaseType>>(
         iter: I,
     ) -> <Self as IsField>::BaseType {
         // Delayed reduction
@@ -221,7 +216,7 @@ mod tests {
         let up_to = u32::pow(2, 23);
         let pow = u64::pow(2, 60);
 
-        let iter = (0..up_to).map(F::from_u32).map(|e| F::pow(&e, pow));
+        let iter = (0..up_to).map(F::weak_reduce).map(|e| F::pow(&e, pow));
 
         assert_eq!(F::from_u64(1314320703), F::sum(iter));
     }

--- a/math/src/field/fields/mersenne31/field.rs
+++ b/math/src/field/fields/mersenne31/field.rs
@@ -34,6 +34,19 @@ impl Mersenne31Field {
             *n
         }
     }
+
+    #[inline]
+    fn from_u32(x: u32) -> u32 {
+        Self::weak_reduce(x)
+    }
+
+    #[inline]
+    fn sum<I: Iterator<Item = <Self as IsField>::BaseType>>(
+        iter: I,
+    ) -> <Self as IsField>::BaseType {
+        // Delayed reduction
+        Self::from_u64(iter.map(|x| (x as u64)).sum::<u64>())
+    }
 }
 
 pub const MERSENNE_31_PRIME_FIELD_ORDER: u32 = (1 << 31) - 1;
@@ -63,12 +76,7 @@ impl IsField for Mersenne31Field {
     /// Returns the multiplication of `a` and `b`.
     // Note: for powers of 2 we can perform bit shifting this would involve overriding the trait implementation
     fn mul(a: &u32, b: &u32) -> u32 {
-        let prod = u64::from(*a) * u64::from(*b);
-        let prod_lo = (prod as u32) & ((1 << 31) - 1);
-        let prod_hi = (prod >> 31) as u32;
-        //assert prod_hi and prod_lo 31 bit clear
-        debug_assert!((prod_lo >> 31) == 0 && (prod_hi >> 31) == 0);
-        Self::add(&prod_lo, &prod_hi)
+        Self::from_u64(u64::from(*a) * u64::from(*b))
     }
 
     fn sub(a: &u32, b: &u32) -> u32 {
@@ -201,12 +209,21 @@ impl Display for FieldElement<Mersenne31Field> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     type F = Mersenne31Field;
 
     #[test]
     fn from_hex_for_b_is_11() {
         assert_eq!(F::from_hex("B").unwrap(), 11);
+    }
+
+    #[test]
+    fn sum_delayed_reduction() {
+        let up_to = u32::pow(2, 23);
+        let pow = u64::pow(2, 60);
+
+        let iter = (0..up_to).map(F::from_u32).map(|e| F::pow(&e, pow));
+
+        assert_eq!(F::from_u64(1314320703), F::sum(iter));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Closes #806 

Adds a .sum function for Mersenne31, following the [delayed reduction strategy](https://github.com/Plonky3/Plonky3/pull/260/files#diff-9dc0207247b1fca1df5dedb2b3cd1103663c2a0a455cae61826d2a43c15cb5f9R296). 

There was no summation interface so not labeling this as an optimization, although it is. 
Here's a simple setup to test the performance:

```
let iter = (u32::pow(2, 23)..u64::pow(2, 60)).map(F::weak_reduce).map(|e| F::pow(&e, pow));
let now = Instant::now();
{ F::sum(iter); }
let elapsed = now.elapsed();

// Summation with iter.reduce(|x, y| Self::add(&x, &y)).unwrap_or(Self::zero())
Elapsed: 9.19s
Elapsed: 9.20s
Elapsed: 9.01s
Elapsed: 8.86s
// Summation with Self::from_u64(iter.map(|x| (x as u64)).sum::<u64>())
Elapsed: 8.79s
Elapsed: 8.76s
Elapsed: 8.81s
Elapsed: 8.77s
```



- [X] Linked to Github Issue
