### PR TITLE
Typo in the Monthomery backend `mod` name

### DIFF
--- a/crypto/src/hash/hash_to_field.rs
+++ b/crypto/src/hash/hash_to_field.rs
@@ -2,7 +2,7 @@ use alloc::{string::String, vec::Vec};
 use lambdaworks_math::{
     field::{
         element::FieldElement,
-        fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+        fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
     },
     unsigned_integer::element::UnsignedInteger,
 };
@@ -72,7 +72,7 @@ mod tests {
     use lambdaworks_math::{
         field::{
             element::FieldElement,
-            fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+            fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
         },
         unsigned_integer::element::UnsignedInteger,
     };

--- a/math/benches/fields/mersenne31_montgomery.rs
+++ b/math/benches/fields/mersenne31_montgomery.rs
@@ -8,7 +8,7 @@ use lambdaworks_math::{
             fft_friendly::u64_mersenne_montgomery_field::{
                 Mersenne31MontgomeryPrimeField, MontgomeryConfigMersenne31PrimeField,
             },
-            montgomery_backed_prime_fields::IsModulus,
+            montgomery_backend_prime_fields::IsModulus,
         },
     },
     unsigned_integer::{

--- a/math/benches/fields/stark252.rs
+++ b/math/benches/fields/stark252.rs
@@ -8,7 +8,7 @@ use lambdaworks_math::{
             fft_friendly::stark_252_prime_field::{
                 MontgomeryConfigStark252PrimeField, Stark252PrimeField,
             },
-            montgomery_backed_prime_fields::IsModulus,
+            montgomery_backend_prime_fields::IsModulus,
         },
     },
     unsigned_integer::{

--- a/math/benches/fields/u64_goldilocks_montgomery.rs
+++ b/math/benches/fields/u64_goldilocks_montgomery.rs
@@ -8,7 +8,7 @@ use lambdaworks_math::{
             fft_friendly::u64_goldilocks::{
                 MontgomeryConfigU64GoldilocksPrimeField, U64GoldilocksPrimeField,
             },
-            montgomery_backed_prime_fields::IsModulus,
+            montgomery_backend_prime_fields::IsModulus,
         },
     },
     unsigned_integer::{

--- a/math/src/elliptic_curve/edwards/curves/bandersnatch/field.rs
+++ b/math/src/elliptic_curve/edwards/curves/bandersnatch/field.rs
@@ -3,7 +3,7 @@
 use crate::{
     field::{
         element::FieldElement,
-        fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+        fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
     },
     unsigned_integer::element::U256,
 };

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/field_extension.rs
@@ -1,6 +1,6 @@
 use crate::field::{
     element::FieldElement,
-    fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+    fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
 };
 use crate::unsigned_integer::element::U384;
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/default_types.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/default_types.rs
@@ -1,7 +1,7 @@
 use crate::{
     field::{
         element::FieldElement,
-        fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+        fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
         traits::IsFFTField,
     },
     unsigned_integer::element::{UnsignedInteger, U256},

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -5,7 +5,7 @@ use crate::field::{
         cubic::{CubicExtensionField, HasCubicNonResidue},
         quadratic::{HasQuadraticNonResidue, QuadraticExtensionField},
     },
-    fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+    fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
     traits::{IsField, IsSubFieldOf},
 };
 use crate::traits::ByteConversion;

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/default_types.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/default_types.rs
@@ -1,7 +1,7 @@
 use crate::{
     field::{
         element::FieldElement,
-        fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+        fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
     },
     unsigned_integer::element::U256,
 };

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/field_extension.rs
@@ -4,7 +4,7 @@ use crate::field::{
         cubic::{CubicExtensionField, HasCubicNonResidue},
         quadratic::{HasQuadraticNonResidue, QuadraticExtensionField},
     },
-    fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+    fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
 };
 use crate::unsigned_integer::element::U256;
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
@@ -1,6 +1,6 @@
 use crate::elliptic_curve::short_weierstrass::point::ShortWeierstrassProjectivePoint;
 use crate::elliptic_curve::traits::IsEllipticCurve;
-use crate::field::fields::montgomery_backed_prime_fields::{
+use crate::field::fields::montgomery_backend_prime_fields::{
     IsModulus, MontgomeryBackendPrimeField,
 };
 use crate::unsigned_integer::element::U384;

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -31,7 +31,7 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 ))]
 use serde::Deserialize;
 
-use super::fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField};
+use super::fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField};
 use super::traits::{IsPrimeField, IsSubFieldOf, LegendreSymbol};
 
 /// A field element with operations algorithms defined in `F`

--- a/math/src/field/fields/fft_friendly/babybear.rs
+++ b/math/src/field/fields/fft_friendly/babybear.rs
@@ -1,7 +1,7 @@
 use crate::{
     field::{
         element::FieldElement,
-        fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+        fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
         traits::IsFFTField,
     },
     unsigned_integer::element::{UnsignedInteger, U64},
@@ -17,13 +17,13 @@ impl IsModulus<U64> for MontgomeryConfigBabybear31PrimeField {
 }
 
 pub type Babybear31PrimeField =
-    U64MontgomeryBackendPrimeField<MontgomeryConfigBabybear31PrimeField>;
+U64MontgomeryBackendPrimeField<MontgomeryConfigBabybear31PrimeField>;
 
 //a two-adic primitive root of unity is 21^(2^24)
-// 21^(2^24)=1 mod 2013265921
-// 2^27(2^4-1)+1 where n=27 (two-adicity) and k=2^4+1
+// 21^(2^24) = 1 mod 2013265921
+// 2^27 * (2^4-1) + 1 where n=27 (two-adicity) and k=2^4+1
 
-//In the future we should allow this with metal and cuda feature, and just dispatch it to the CPU until the implementation is done
+// In the future we should allow this with metal and cuda feature, and just dispatch it to the CPU until the implementation is done
 #[cfg(any(not(feature = "metal"), not(feature = "cuda")))]
 impl IsFFTField for Babybear31PrimeField {
     const TWO_ADICITY: u64 = 24;

--- a/math/src/field/fields/fft_friendly/stark_252_prime_field.rs
+++ b/math/src/field/fields/fft_friendly/stark_252_prime_field.rs
@@ -1,7 +1,7 @@
 use crate::{
     field::{
         element::FieldElement,
-        fields::montgomery_backed_prime_fields::{IsModulus, U256PrimeField},
+        fields::montgomery_backend_prime_fields::{IsModulus, U256PrimeField},
         traits::IsFFTField,
     },
     unsigned_integer::element::{UnsignedInteger, U256},

--- a/math/src/field/fields/fft_friendly/u64_goldilocks.rs
+++ b/math/src/field/fields/fft_friendly/u64_goldilocks.rs
@@ -1,7 +1,7 @@
 use crate::{
     field::{
         element::FieldElement,
-        fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+        fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
     },
     unsigned_integer::element::U64,
 };

--- a/math/src/field/fields/fft_friendly/u64_mersenne_montgomery_field.rs
+++ b/math/src/field/fields/fft_friendly/u64_mersenne_montgomery_field.rs
@@ -1,7 +1,7 @@
 use crate::{
     field::{
         element::FieldElement,
-        fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+        fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
     },
     unsigned_integer::element::U64,
 };

--- a/math/src/field/fields/mod.rs
+++ b/math/src/field/fields/mod.rs
@@ -2,7 +2,7 @@
 pub mod fft_friendly;
 /// Implementation of the 32-bit Mersenne Prime field (p = 2^31 - 1)
 pub mod mersenne31;
-pub mod montgomery_backed_prime_fields;
+pub mod montgomery_backend_prime_fields;
 /// Implementation of the Goldilocks Prime field (p = 2^448 - 2^224 - 1)
 pub mod p448_goldilocks_prime_field;
 /// Implemenation of Pallas field

--- a/math/src/field/fields/montgomery_backend_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backend_prime_fields.rs
@@ -387,7 +387,7 @@ mod tests_u384_prime_fields {
     use crate::field::element::FieldElement;
     use crate::field::errors::FieldError;
     use crate::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
-    use crate::field::fields::montgomery_backed_prime_fields::{
+    use crate::field::fields::montgomery_backend_prime_fields::{
         IsModulus, U256PrimeField, U384PrimeField,
     };
     use crate::field::traits::IsField;
@@ -776,7 +776,7 @@ mod tests_u384_prime_fields {
 mod tests_u256_prime_fields {
     use crate::field::element::FieldElement;
     use crate::field::errors::FieldError;
-    use crate::field::fields::montgomery_backed_prime_fields::{IsModulus, U256PrimeField};
+    use crate::field::fields::montgomery_backend_prime_fields::{IsModulus, U256PrimeField};
     use crate::field::traits::IsField;
     use crate::field::traits::IsPrimeField;
     #[cfg(feature = "alloc")]

--- a/math/src/field/fields/pallas_field.rs
+++ b/math/src/field/fields/pallas_field.rs
@@ -1,5 +1,5 @@
 use crate::{
-    field::fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+    field::fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
     unsigned_integer::element::U256,
 };
 

--- a/math/src/field/fields/vesta_field.rs
+++ b/math/src/field/fields/vesta_field.rs
@@ -1,5 +1,5 @@
 use crate::{
-    field::fields::montgomery_backed_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
+    field::fields::montgomery_backend_prime_fields::{IsModulus, MontgomeryBackendPrimeField},
     unsigned_integer::element::U256,
 };
 

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -60,13 +60,13 @@ where
     }
 }
 
-/// Trait to define necessary parameters for FFT-friendly Fields.
-/// Two-Adic fields are ones whose order is of the form  $2^n k + 1$.
+/// Trait to define necessary parameters for FFT-friendly fields.
+/// Two-Adic fields are ones whose order is of the form  $2^{n}k + 1$.
 /// Here $n$ is usually called the *two-adicity* of the field. The
 /// reason we care about it is that in an $n$-adic field there are $2^j$-roots
-/// of unity for every `j` between 1 and n, which is needed to do Fast Fourier.
-/// A two-adic primitive root of unity is a number w that satisfies w^(2^n) = 1
-/// and w^(j) != 1 for every j below 2^n. With this primitive root we can generate
+/// of unity for every $j$ between $1$ and $n$, which is needed to do Fast Fourier.
+/// A two-adic primitive root of unity is a number $w$ that satisfies $w^{2^n} = 1$
+/// and $w^j$ != 1 for every $j$ below $2^n$. With this primitive root we can generate
 /// any other root of unity we need to perform FFT.
 pub trait IsFFTField: IsField {
     const TWO_ADICITY: u64;

--- a/math/src/unsigned_integer/mod.rs
+++ b/math/src/unsigned_integer/mod.rs
@@ -4,3 +4,5 @@
 pub mod element;
 pub mod montgomery;
 pub mod traits;
+
+pub mod babybear;

--- a/math/src/unsigned_integer/mod.rs
+++ b/math/src/unsigned_integer/mod.rs
@@ -4,5 +4,3 @@
 pub mod element;
 pub mod montgomery;
 pub mod traits;
-
-pub mod babybear;


### PR DESCRIPTION
Plus some minor editing of docs/comments for readability.