### PR TITLE
Simplify bit operations for big int by reusing assign impl

### DIFF
--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -322,14 +322,12 @@ impl<const NUM_LIMBS: usize> ShrAssign<usize> for UnsignedInteger<NUM_LIMBS> {
 
 impl<const NUM_LIMBS: usize> BitAnd for UnsignedInteger<NUM_LIMBS> {
     type Output = Self;
+
     #[inline(always)]
     fn bitand(self, rhs: Self) -> Self::Output {
-        let Self { mut limbs } = self;
-
-        for (a_i, b_i) in limbs.iter_mut().zip(rhs.limbs.iter()) {
-            *a_i &= b_i;
-        }
-        Self { limbs }
+        let mut result = self;
+        result &= rhs;
+        result
     }
 }
 
@@ -345,14 +343,12 @@ impl<const NUM_LIMBS: usize> BitAndAssign for UnsignedInteger<NUM_LIMBS> {
 
 impl<const NUM_LIMBS: usize> BitOr for UnsignedInteger<NUM_LIMBS> {
     type Output = Self;
+
     #[inline(always)]
     fn bitor(self, rhs: Self) -> Self::Output {
-        let Self { mut limbs } = self;
-
-        for (a_i, b_i) in limbs.iter_mut().zip(rhs.limbs.iter()) {
-            *a_i |= b_i;
-        }
-        Self { limbs }
+        let mut result = self;
+        result |= rhs;
+        result
     }
 }
 
@@ -369,14 +365,12 @@ impl<const NUM_LIMBS: usize> BitOrAssign for UnsignedInteger<NUM_LIMBS> {
 
 impl<const NUM_LIMBS: usize> BitXor for UnsignedInteger<NUM_LIMBS> {
     type Output = Self;
+
     #[inline(always)]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        let Self { mut limbs } = self;
-
-        for (a_i, b_i) in limbs.iter_mut().zip(rhs.limbs.iter()) {
-            *a_i ^= b_i;
-        }
-        Self { limbs }
+        let mut result = self;
+        result ^= rhs;
+        result
     }
 }
 


### PR DESCRIPTION
# Simplify bit operations for big int by reusing assign impl

## Description

This pull request simplifies the bit operations (`bitxor`, `bitor`, `bitand`) for big integers by reusing the assignment implementation (`bitxor_assign`, `bitor_assign`, `bitand_assign`). By doing so, we can reduce code duplication and improve maintainability.

## Type of change

Please delete options that are not relevant.

- [X] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [X] This change is an Optimization
  - [ ] Benchmarks added/run
