### PR TITLE
Adjust imports to target Rust nightly

### DIFF
--- a/crypto/src/commitments/kzg.rs
+++ b/crypto/src/commitments/kzg.rs
@@ -1,5 +1,5 @@
 use super::traits::IsCommitmentScheme;
-use alloc::{borrow::ToOwned, vec::Vec};
+use alloc::{borrow::*, vec::*};
 use core::{marker::PhantomData, mem};
 use lambdaworks_math::{
     cyclic_group::IsGroup,
@@ -252,7 +252,7 @@ impl<const N: usize, F: IsPrimeField<RepresentativeType = UnsignedInteger<N>>, P
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
+    use alloc::vec::*;
     use lambdaworks_math::{
         cyclic_group::IsGroup,
         elliptic_curve::{

--- a/crypto/src/fiat_shamir/default_transcript.rs
+++ b/crypto/src/fiat_shamir/default_transcript.rs
@@ -1,5 +1,5 @@
 use super::is_transcript::IsTranscript;
-use crate::alloc::borrow::ToOwned;
+use crate::alloc::borrow::*;
 use core::marker::PhantomData;
 use lambdaworks_math::{
     field::{element::FieldElement, traits::IsField},
@@ -76,7 +76,7 @@ mod tests {
     use super::*;
 
     extern crate alloc;
-    use alloc::vec::Vec;
+    use alloc::vec::*;
     use lambdaworks_math::elliptic_curve::short_weierstrass::curves::bls12_381::default_types::FrField;
 
     #[test]

--- a/crypto/src/hash/hash_to_field.rs
+++ b/crypto/src/hash/hash_to_field.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, vec::Vec};
+use alloc::{string::*, vec::*};
 use lambdaworks_math::{
     field::{
         element::FieldElement,
@@ -68,7 +68,7 @@ fn build_two_to_the_nth<M: IsModulus<UnsignedInteger<N>> + Clone, const N: usize
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
+    use alloc::vec::*;
     use lambdaworks_math::{
         field::{
             element::FieldElement,

--- a/crypto/src/hash/monolith/mod.rs
+++ b/crypto/src/hash/monolith/mod.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::vec::*;
 use lambdaworks_math::field::{
     fields::mersenne31::field::MERSENNE_31_PRIME_FIELD_ORDER, traits::IsField,
 };

--- a/crypto/src/hash/monolith/utils.rs
+++ b/crypto/src/hash/monolith/utils.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::vec::*;
 use lambdaworks_math::field::{
     fields::mersenne31::field::{Mersenne31Field, MERSENNE_31_PRIME_FIELD_ORDER},
     traits::IsField,

--- a/crypto/src/hash/poseidon/mod.rs
+++ b/crypto/src/hash/poseidon/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{borrow::ToOwned, vec::Vec};
+use alloc::{borrow::*, vec::*};
 use lambdaworks_math::field::element::FieldElement as FE;
 
 pub mod parameters;

--- a/crypto/src/hash/sha3/mod.rs
+++ b/crypto/src/hash/sha3/mod.rs
@@ -1,7 +1,4 @@
-use alloc::{
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{string::*, vec::*};
 use sha3::{Digest, Sha3_256};
 
 pub struct Sha3Hasher;

--- a/crypto/src/merkle_tree/backends/field_element.rs
+++ b/crypto/src/merkle_tree/backends/field_element.rs
@@ -77,7 +77,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
+    use alloc::vec::*;
     use lambdaworks_math::field::{
         element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
     };

--- a/crypto/src/merkle_tree/backends/field_element_vector.rs
+++ b/crypto/src/merkle_tree/backends/field_element_vector.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 
 use crate::hash::poseidon::Poseidon;
 use crate::merkle_tree::traits::IsMerkleTreeBackend;
-use alloc::vec::Vec;
+use alloc::vec::*;
 use lambdaworks_math::{
     field::{element::FieldElement, traits::IsField},
     traits::AsBytes,

--- a/crypto/src/merkle_tree/merkle.rs
+++ b/crypto/src/merkle_tree/merkle.rs
@@ -1,6 +1,6 @@
 use core::fmt::Display;
 
-use alloc::vec::Vec;
+use alloc::vec::*;
 
 use super::{proof::Proof, traits::IsMerkleTreeBackend, utils::*};
 

--- a/crypto/src/merkle_tree/proof.rs
+++ b/crypto/src/merkle_tree/proof.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::vec::*;
 #[cfg(feature = "alloc")]
 use lambdaworks_math::traits::Serializable;
 use lambdaworks_math::{errors::DeserializationError, traits::Deserializable};
@@ -71,7 +71,7 @@ mod tests {
 
     #[cfg(feature = "alloc")]
     use super::Proof;
-    use alloc::vec::Vec;
+    use alloc::vec::*;
     use lambdaworks_math::field::{element::FieldElement, fields::u64_prime_field::U64PrimeField};
     #[cfg(feature = "alloc")]
     use lambdaworks_math::traits::{Deserializable, Serializable};

--- a/crypto/src/merkle_tree/traits.rs
+++ b/crypto/src/merkle_tree/traits.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::vec::*;
 #[cfg(feature = "parallel")]
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 

--- a/crypto/src/merkle_tree/utils.rs
+++ b/crypto/src/merkle_tree/utils.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::vec::*;
 
 use super::traits::IsMerkleTreeBackend;
 
@@ -61,7 +61,7 @@ pub fn right_child_index(parent_index: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
+    use alloc::vec::*;
     use lambdaworks_math::field::{element::FieldElement, fields::u64_prime_field::U64PrimeField};
 
     use crate::merkle_tree::{test_merkle::TestBackend, traits::IsMerkleTreeBackend};

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -14,7 +14,7 @@ use super::traits::IsShortWeierstrass;
 #[cfg(feature = "alloc")]
 use crate::traits::AsBytes;
 #[cfg(feature = "alloc")]
-use alloc::vec::Vec;
+use alloc::vec::*;
 
 #[derive(Clone, Debug)]
 pub struct ShortWeierstrassProjectivePoint<E: IsEllipticCurve>(pub ProjectivePoint<E>);

--- a/math/src/fft/cpu/bit_reversing.rs
+++ b/math/src/fft/cpu/bit_reversing.rs
@@ -20,7 +20,7 @@ pub fn reverse_index(i: usize, size: u64) -> usize {
 #[cfg(all(test, feature = "alloc"))]
 mod test {
     use super::*;
-    use alloc::vec::Vec;
+    use alloc::vec::*;
 
     // TODO: proptest would be better.
     #[test]

--- a/math/src/fft/cpu/roots_of_unity.rs
+++ b/math/src/fft/cpu/roots_of_unity.rs
@@ -2,7 +2,7 @@ use crate::field::{
     element::FieldElement,
     traits::{IsFFTField, RootsConfig},
 };
-use alloc::vec::Vec;
+use alloc::vec::*;
 
 use crate::fft::errors::FFTError;
 

--- a/math/src/fft/polynomial.rs
+++ b/math/src/fft/polynomial.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     polynomial::Polynomial,
 };
-use alloc::{vec, vec::Vec};
+use alloc::{vec, vec::*};
 
 #[cfg(feature = "cuda")]
 use crate::fft::gpu::cuda::polynomial::{evaluate_fft_cuda, interpolate_fft_cuda};

--- a/math/src/fft/test_helpers.rs
+++ b/math/src/fft/test_helpers.rs
@@ -5,7 +5,7 @@ use crate::{
         traits::{IsFFTField, RootsConfig},
     },
 };
-use alloc::vec::Vec;
+use alloc::vec::*;
 
 /// Calculates the (non-unitary) Discrete Fourier Transform of `input` via the DFT matrix.
 pub fn naive_matrix_dft_test<F: IsFFTField>(input: &[FieldElement<F>]) -> Vec<FieldElement<F>> {

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -721,7 +721,7 @@ mod tests {
     #[cfg(feature = "alloc")]
     use crate::unsigned_integer::element::UnsignedInteger;
     #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
+    use alloc::vec::*;
     #[cfg(feature = "alloc")]
     use proptest::collection;
     use proptest::{prelude::*, prop_compose, proptest, strategy::Strategy};

--- a/math/src/polynomial/dense_multilinear_poly.rs
+++ b/math/src/polynomial/dense_multilinear_poly.rs
@@ -2,7 +2,7 @@ use crate::{
     field::{element::FieldElement, traits::IsField},
     polynomial::error::MultilinearError,
 };
-use alloc::{vec, vec::Vec};
+use alloc::{vec, vec::*};
 use core::ops::{Add, Index, Mul};
 #[cfg(feature = "parallel")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};

--- a/math/src/polynomial/mod.rs
+++ b/math/src/polynomial/mod.rs
@@ -1,6 +1,6 @@
 use super::field::element::FieldElement;
 use crate::field::traits::{IsField, IsSubFieldOf};
-use alloc::{borrow::ToOwned, vec, vec::Vec};
+use alloc::{borrow::*, vec, vec::*};
 use core::{fmt::Display, ops};
 
 pub mod dense_multilinear_poly;

--- a/math/src/polynomial/sparse_multilinear_poly.rs
+++ b/math/src/polynomial/sparse_multilinear_poly.rs
@@ -3,7 +3,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::field::{element::FieldElement, traits::IsField};
 use crate::polynomial::error::MultilinearError;
-use alloc::vec::Vec;
+use alloc::vec::*;
 
 pub struct SparseMultilinearPolynomial<F: IsField>
 where

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -1,5 +1,5 @@
 use core::cmp::Ordering;
-use core::convert::From;
+use core::convert::*;
 use core::ops::{
     Add, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Mul, Shl, Shr, ShrAssign,
     Sub,

--- a/provers/winterfell_adapter/src/examples/fibonacci_rap.rs
+++ b/provers/winterfell_adapter/src/examples/fibonacci_rap.rs
@@ -8,7 +8,7 @@ use winter_air::{
 };
 use winter_math::{ExtensionOf, FieldElement as IsWinterfellFieldElement, StarkField};
 use winter_prover::{ColMatrix, Trace, TraceTable};
-use winter_utils::{collections::Vec, uninit_vector};
+use winter_utils::{collections::*, uninit_vector};
 
 #[derive(Clone)]
 pub struct RapTraceTable<B: StarkField> {


### PR DESCRIPTION
# Adjust imports to target Rust nightly

## Description


New components such as `Vec` or `ToString` have recently been added to the standard library prelude (`std`). As Lambdaworks is predominantly `no_std`, importing `::vec::Vec` explicitly leads to Rust interpreting it as an import overlay, considering that `Vec` already exists in the `std` prelude. However, without the `no_std` flag, Rust fails to recognize `Vec` due to its inability to access the `std` prelude. Consequently, to avoid warnings and ensure compatibility, imports have been modified to use `vec::*`.

## Type of change

Please delete options that are not relevant.

- [X] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [X] This change is an Optimization
  - [ ] Benchmarks added/run
