### PR TITLE
chore: add poseidon benches comparing other implementations

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -12,7 +12,6 @@ rand_chacha = "0.3.1"
 starknet-curve = { git = "https://github.com/xJonathanLEI/starknet-rs" }
 starknet-ff = { git = "https://github.com/xJonathanLEI/starknet-rs" }
 starknet-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs" }
-p3-poseidon = { git = "https://github.com/Plonky3/Plonky3" }
 pathfinder-crypto = { git = "https://github.com/eqlabs/pathfinder.git" }
 
 [dependencies.lambdaworks-math]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,9 +11,15 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 starknet-curve = { git = "https://github.com/xJonathanLEI/starknet-rs" }
 starknet-ff = { git = "https://github.com/xJonathanLEI/starknet-rs" }
+starknet-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs" }
+p3-poseidon = { git = "https://github.com/Plonky3/Plonky3" }
+pathfinder-crypto = { git = "https://github.com/eqlabs/pathfinder.git" }
 
 [dependencies.lambdaworks-math]
 path = "../math"
+
+[dependencies.lambdaworks-crypto]
+path = "../crypto"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false }
@@ -45,4 +51,8 @@ harness = false
 
 [[bench]]
 name = "point"
+harness = false
+
+[[bench]]
+name = "poseidon"
 harness = false

--- a/benches/benches/poseidon.rs
+++ b/benches/benches/poseidon.rs
@@ -4,7 +4,7 @@ use lambdaworks_crypto::hash::poseidon::Poseidon;
 use lambdaworks_math::field::element::FieldElement;
 use lambdaworks_math::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
 use lambdaworks_math::traits::ByteConversion;
-use pathfinder_crypto::MontFelt;
+use pathfinder_crypto::{Felt, MontFelt};
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
@@ -24,9 +24,13 @@ fn poseidon_benchmarks(c: &mut Criterion) {
     });
 
     let mut mont_x = lw_x.value().limbs;
-    mont_x.reverse();
     let mut mont_y = lw_y.value().limbs;
+
+    // In order use the same field elements for starknet-rs and pathfinder, we have to reverse
+    // the limbs order respect to the lambdaworks implementation.
+    mont_x.reverse();
     mont_y.reverse();
+
     let sn_ff_x = starknet_ff::FieldElement::from_mont(mont_x);
     let sn_ff_y = starknet_ff::FieldElement::from_mont(mont_y);
     group.bench_function("starknet-rs", |bench| {

--- a/benches/benches/poseidon.rs
+++ b/benches/benches/poseidon.rs
@@ -7,7 +7,6 @@ use lambdaworks_math::traits::ByteConversion;
 use pathfinder_crypto::MontFelt;
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
-use starknet_crypto::poseidon_hash;
 
 fn poseidon_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("poseidon");
@@ -31,7 +30,7 @@ fn poseidon_benchmarks(c: &mut Criterion) {
     let sn_ff_x = starknet_ff::FieldElement::from_mont(mont_x);
     let sn_ff_y = starknet_ff::FieldElement::from_mont(mont_y);
     group.bench_function("starknet-rs", |bench| {
-        bench.iter(|| black_box(poseidon_hash(sn_ff_x, sn_ff_y)))
+        bench.iter(|| black_box(starknet_crypto::poseidon_hash(sn_ff_x, sn_ff_y)))
     });
 
     let pf_x = MontFelt(mont_x);

--- a/benches/benches/poseidon.rs
+++ b/benches/benches/poseidon.rs
@@ -4,7 +4,7 @@ use lambdaworks_crypto::hash::poseidon::Poseidon;
 use lambdaworks_math::field::element::FieldElement;
 use lambdaworks_math::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
 use lambdaworks_math::traits::ByteConversion;
-use pathfinder_crypto::{Felt, MontFelt};
+use pathfinder_crypto::MontFelt;
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 

--- a/benches/benches/poseidon.rs
+++ b/benches/benches/poseidon.rs
@@ -1,0 +1,44 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use lambdaworks_crypto::hash::poseidon::starknet::PoseidonCairoStark252;
+use lambdaworks_crypto::hash::poseidon::Poseidon;
+use lambdaworks_math::field::element::FieldElement;
+use lambdaworks_math::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
+use lambdaworks_math::traits::ByteConversion;
+use pathfinder_crypto::MontFelt;
+use rand::{RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use starknet_crypto::poseidon_hash;
+
+fn poseidon_benchmarks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("poseidon");
+
+    let mut rng = ChaCha8Rng::seed_from_u64(2);
+    let mut felt1: [u8; 32] = Default::default();
+    rng.fill_bytes(&mut felt1);
+    let mut felt2: [u8; 32] = Default::default();
+    rng.fill_bytes(&mut felt2);
+
+    let lw_x = FieldElement::<Stark252PrimeField>::from_bytes_be(&felt1).unwrap();
+    let lw_y = FieldElement::<Stark252PrimeField>::from_bytes_be(&felt2).unwrap();
+    group.bench_function("lambdaworks", |bench| {
+        bench.iter(|| black_box(PoseidonCairoStark252::hash(&lw_x, &lw_y)))
+    });
+
+    let mut mont_x = lw_x.value().limbs;
+    mont_x.reverse();
+    let mut mont_y = lw_y.value().limbs;
+    mont_y.reverse();
+    let sn_ff_x = starknet_ff::FieldElement::from_mont(mont_x);
+    let sn_ff_y = starknet_ff::FieldElement::from_mont(mont_y);
+    group.bench_function("starknet-rs", |bench| {
+        bench.iter(|| black_box(poseidon_hash(sn_ff_x, sn_ff_y)))
+    });
+
+    let pf_x = MontFelt(mont_x);
+    let pf_y = MontFelt(mont_y);
+    group.bench_function("pathfinder", |bench| {
+        bench.iter(|| black_box(pathfinder_crypto::hash::poseidon_hash(pf_x, pf_y)))
+    });
+}
+criterion_group!(poseidon, poseidon_benchmarks);
+criterion_main!(poseidon);

--- a/crypto/benches/criterion_poseidon.rs
+++ b/crypto/benches/criterion_poseidon.rs
@@ -3,10 +3,19 @@ use lambdaworks_crypto::hash::poseidon::starknet::PoseidonCairoStark252;
 use lambdaworks_crypto::hash::poseidon::Poseidon;
 use lambdaworks_math::field::element::FieldElement;
 use lambdaworks_math::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
+use lambdaworks_math::traits::ByteConversion;
+use rand::{RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
 
 fn poseidon_benchmarks(c: &mut Criterion) {
-    let x = FieldElement::<Stark252PrimeField>::from_hex("0x123456").unwrap();
-    let y = FieldElement::<Stark252PrimeField>::from_hex("0x789101").unwrap();
+    let mut rng = ChaCha8Rng::seed_from_u64(2);
+    let mut felt1: [u8; 32] = Default::default();
+    rng.fill_bytes(&mut felt1);
+    let mut felt2: [u8; 32] = Default::default();
+    rng.fill_bytes(&mut felt2);
+
+    let x = FieldElement::<Stark252PrimeField>::from_bytes_be(&felt1).unwrap();
+    let y = FieldElement::<Stark252PrimeField>::from_bytes_be(&felt2).unwrap();
     let mut group = c.benchmark_group("Poseidon Benchmark");
 
     // Benchmark with black_box is 0.41% faster

--- a/crypto/benches/criterion_poseidon.rs
+++ b/crypto/benches/criterion_poseidon.rs
@@ -18,7 +18,6 @@ fn poseidon_benchmarks(c: &mut Criterion) {
     let y = FieldElement::<Stark252PrimeField>::from_bytes_be(&felt2).unwrap();
     let mut group = c.benchmark_group("Poseidon Benchmark");
 
-    // Benchmark with black_box is 0.41% faster
     group.bench_function("Hashing with black_box", |bench| {
         bench.iter(|| black_box(PoseidonCairoStark252::hash(&x, &y)))
     });


### PR DESCRIPTION
This PR adds poseidon benches comparing with the `starknet-rs` and `pathfinder` poseidon implementations.
