### PR TITLE
Fix: os2ip not compatible with RFC specification

### DIFF
--- a/crypto/src/hash/hash_to_field.rs
+++ b/crypto/src/hash/hash_to_field.rs
@@ -40,15 +40,15 @@ fn os2ip<M: IsModulus<UnsignedInteger<N>> + Clone, const N: usize>(
     let mut aux_x = x.to_vec();
     aux_x.reverse();
     let two_to_the_nth = build_two_to_the_nth();
-    let mut j = 0_u32;
+    let mut i = 0_u32;
     let mut item_hex = String::with_capacity(N * 16);
     let mut result = FieldElement::zero();
-    for item_u8 in aux_x.iter() {
-        item_hex += &format!("{:x}", item_u8);
-        if item_hex.len() == item_hex.capacity() {
-            result += FieldElement::from_hex_unchecked(&item_hex) * two_to_the_nth.pow(j);
+    for (j, item_u8) in aux_x.iter().enumerate() {
+        item_hex += &format!("{:02x}", item_u8);
+        if item_hex.len() == item_hex.capacity() || j == aux_x.len() - 1 {
+            result += FieldElement::from_hex_unchecked(&item_hex) * two_to_the_nth.pow(i);
             item_hex.clear();
-            j += 1;
+            i += 1;
         }
     }
     result


### PR DESCRIPTION
## Description

The current implementation of `hash_to_field`, specifically `os2ip`, is not compatible with the official [RFC specification](https://www.rfc-editor.org/rfc/pdfrfc/rfc8017.txt.pdf) (4.2, p. 12). This pull request updates the implementation of `os2ip` to be in line with the specification.

## Type of change

There are two issues in the current implementation.

1. The input bytes are being converted to dynamic length hex coding, preventing the result-update logic from being called in cases where there is an uneven number of byte values < 16. As a result, the returned field element will be 0 with probability 1/2.

https://github.com/lambdaclass/lambdaworks/blob/f6dda1c526c49a33809684c44a948e20dadf5a78/crypto/src/hash/hash_to_field.rs#L47

The updated version adds leading zeros to the encoding to guarantee a length of 2 chars per byte.

https://github.com/LucasAschenbach/lambdaworks/blob/41a570ea09b59ef40cd328436d5e1db4b78b315c/crypto/src/hash/hash_to_field.rs#L47

2. The current implementation assumes the number of bytes to be divisible by N * 16 which is generally not the case. The remainder is being discarded.

https://github.com/lambdaclass/lambdaworks/blob/f6dda1c526c49a33809684c44a948e20dadf5a78/crypto/src/hash/hash_to_field.rs#L48

To include the remainder bytes, the result-update logic is now called one more time when the last byte has been processed.

https://github.com/LucasAschenbach/lambdaworks/blob/41a570ea09b59ef40cd328436d5e1db4b78b315c/crypto/src/hash/hash_to_field.rs#L48

- [ ] New feature
- [x] Bug fix
- [ ] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
