### PR TITLE
perf: avoid unnecessary clone when building Merkle trees

### DIFF
--- a/crypto/src/merkle_tree/merkle.rs
+++ b/crypto/src/merkle_tree/merkle.rs
@@ -32,10 +32,10 @@ where
     B: IsMerkleTreeBackend,
 {
     pub fn build(unhashed_leaves: &[B::Data]) -> Self {
-        let mut hashed_leaves: Vec<B::Node> = B::hash_leaves(unhashed_leaves);
+        let hashed_leaves: Vec<B::Node> = B::hash_leaves(unhashed_leaves);
 
         //The leaf must be a power of 2 set
-        hashed_leaves = complete_until_power_of_two(&mut hashed_leaves);
+        let hashed_leaves = complete_until_power_of_two(hashed_leaves);
         let leaves_len = hashed_leaves.len();
 
         //The length of leaves minus one inner node in the merkle tree

--- a/crypto/src/merkle_tree/utils.rs
+++ b/crypto/src/merkle_tree/utils.rs
@@ -115,8 +115,8 @@ mod tests {
     #[test]
     // expected |2|2|
     fn complete_the_length_of_one_field_element_to_be_a_power_of_two() {
-        let mut values: Vec<FE> = vec![FE::new(2)];
-        let hashed_leaves = complete_until_power_of_two(&mut values);
+        let values: Vec<FE> = vec![FE::new(2)];
+        let hashed_leaves = complete_until_power_of_two(values);
 
         let mut expected_leaves = vec![FE::new(2)];
         expected_leaves.extend([FE::new(2)]);

--- a/crypto/src/merkle_tree/utils.rs
+++ b/crypto/src/merkle_tree/utils.rs
@@ -21,11 +21,11 @@ pub fn parent_index(node_index: usize) -> usize {
 }
 
 // The list of values is completed repeating the last value to a power of two length
-pub fn complete_until_power_of_two<T: Clone>(values: &mut Vec<T>) -> Vec<T> {
+pub fn complete_until_power_of_two<T: Clone>(mut values: Vec<T>) -> Vec<T> {
     while !is_power_of_two(values.len()) {
         values.push(values[values.len() - 1].clone())
     }
-    values.to_vec()
+    values
 }
 
 pub fn is_power_of_two(x: usize) -> bool {
@@ -95,8 +95,8 @@ mod tests {
     #[test]
     // expected |1|2|3|4|5|5|5|5|
     fn complete_the_length_of_a_list_of_fields_elements_to_be_a_power_of_two() {
-        let mut values: Vec<FE> = (1..6).map(FE::new).collect();
-        let hashed_leaves = complete_until_power_of_two(&mut values);
+        let values: Vec<FE> = (1..6).map(FE::new).collect();
+        let hashed_leaves = complete_until_power_of_two(values);
 
         let mut expected_leaves = (1..6).map(FE::new).collect::<Vec<FE>>();
         expected_leaves.extend([FE::new(5); 3]);


### PR DESCRIPTION
The function `complete_until_power_of_two` takes a mutable reference, modifies the `Vec<_>` in-place, only to clone it and return it. Instead, just take ownership of the argument and return it again, without cloning.

Note while the change is marked as an optimization the impact isn't that high (<2%), but it's almost free and "feels" a little bit more correct this way.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [x] Optimization

## Results

Ran on M1 MBP 2020 14" 16GiB:
```
Merkle Tree/build       time:   [724.84 ms 734.25 ms 748.73 ms]                                                        
                        change: [-3.1234% -1.9869% -0.6644%] (p = 0.01 < 0.05)                                         
                        Change within noise threshold.
```

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] This change is an Optimization
  - [x] Benchmarks added/run
