### PR TITLE
perf: add an 'asm' feature to crypto to use optimized hashes

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -23,7 +23,8 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 
 [features]
-default = ["std"]
+default = ["asm", "std"]
+asm = ["sha3/asm"]
 std = ["lambdaworks-math/std", "sha2/std", "sha3/std", "serde?/std"]
 serde = ["dep:serde"]
 test_fiat_shamir = []


### PR DESCRIPTION
The `sha3` dependency allows passing an `asm` feature to use optimized implementations of hashing primitives.
This adds a feature to `lambdaworks-crypto` that forwards to `sha3`, enabled by default.
A quick check with 0.11.0-pre3 (as 0.10 doesn't implement this for ARMv8) shows a 20% improvement in `criterion_merkle` on my M1.

## Type of change

Please delete options that are not relevant.

- [x] New feature
- [ ] Bug fix
- [x] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] This change is an Optimization
  - [x] Benchmarks added/run
