### PR TITLE
feat(merkle): Pad single tree leaves to next power of two

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -9,10 +9,9 @@ ark-test-curves = { git = "https://github.com/arkworks-rs/algebra", rev = "ef8f7
 ark-std = "0.4.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-starknet-curve = { git = "https://github.com/xJonathanLEI/starknet-rs" }
-#starknet-ff = { git = "https://github.com/xJonathanLEI/starknet-rs" }
-starknet-types-core = { version = "0.1.3", default-features = false, features = ["curve"] }
-starknet-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs" }
+starknet-curve = { git = "https://github.com/xJonathanLEI/starknet-rs", tag = "starknet-curve/v0.4.2" }
+starknet-ff = { git = "https://github.com/xJonathanLEI/starknet-rs", tag = "starknet-ff/v0.3.7" }
+starknet-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs", tag = "starknet-crypto/v0.6.2" }
 pathfinder-crypto = { git = "https://github.com/eqlabs/pathfinder.git" }
 
 [dependencies.lambdaworks-math]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -10,7 +10,8 @@ ark-std = "0.4.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 starknet-curve = { git = "https://github.com/xJonathanLEI/starknet-rs" }
-starknet-ff = { git = "https://github.com/xJonathanLEI/starknet-rs" }
+#starknet-ff = { git = "https://github.com/xJonathanLEI/starknet-rs" }
+starknet-types-core = { version = "0.1.3", default-features = false, features = ["curve"] }
 starknet-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs" }
 pathfinder-crypto = { git = "https://github.com/eqlabs/pathfinder.git" }
 

--- a/benches/benches/poseidon.rs
+++ b/benches/benches/poseidon.rs
@@ -31,8 +31,8 @@ fn poseidon_benchmarks(c: &mut Criterion) {
     mont_x.reverse();
     mont_y.reverse();
 
-    let sn_ff_x = starknet_ff::FieldElement::from_mont(mont_x);
-    let sn_ff_y = starknet_ff::FieldElement::from_mont(mont_y);
+    let sn_ff_x = starknet_crypto::FieldElement::from_mont(mont_x);
+    let sn_ff_y = starknet_crypto::FieldElement::from_mont(mont_y);
     group.bench_function("starknet-rs", |bench| {
         bench.iter(|| black_box(starknet_crypto::poseidon_hash(sn_ff_x, sn_ff_y)))
     });

--- a/crypto/src/merkle_tree/merkle.rs
+++ b/crypto/src/merkle_tree/merkle.rs
@@ -33,11 +33,6 @@ where
     pub fn build(unhashed_leaves: &[B::Data]) -> Self {
         let mut hashed_leaves: Vec<B::Node> = B::hash_leaves(unhashed_leaves);
 
-        // If there is only one node, handle it specially
-        if hashed_leaves.len() == 1 {
-            hashed_leaves.push(hashed_leaves[0].clone());
-        }
-
         //The leaf must be a power of 2 set
         hashed_leaves = complete_until_power_of_two(&mut hashed_leaves);
         let leaves_len = hashed_leaves.len();

--- a/crypto/src/merkle_tree/utils.rs
+++ b/crypto/src/merkle_tree/utils.rs
@@ -28,14 +28,12 @@ pub fn complete_until_power_of_two<T: Clone>(values: &mut Vec<T>) -> Vec<T> {
     values.to_vec()
 }
 
-/*
-    ! NOTE !
-    - We in this function we  say 2^0 = 1 is not a power of two when it is infact true. We 
-    need this to maintain that the smallest tree at two leaves counts and we could not find 
-    a name that wasn't overly verbose. In the case of a single value being present in a leaf node 
-    this indicates we pad to next power of two (i.e. 2). The function is private and is only used 
-    to ensure the tree has a power of 2 number of leaves.
-*/
+// ! NOTE !
+// We in this function we  say 2^0 = 1 is not a power of two when it is infact true. We
+// need this to maintain that the smallest tree at two leaves counts and we could not find
+// a name that wasn't overly verbose. In the case of a single value being present in a leaf node
+// this indicates we pad to next power of two (i.e. 2). The function is private and is only used
+// to ensure the tree has a power of 2 number of leaves.
 fn is_power_of_two(x: usize) -> bool {
     (x > 1) && ((x & (x - 1)) == 0)
 }

--- a/crypto/src/merkle_tree/utils.rs
+++ b/crypto/src/merkle_tree/utils.rs
@@ -22,9 +22,6 @@ pub fn parent_index(node_index: usize) -> usize {
 
 // The list of values is completed repeating the last value to a power of two length
 pub fn complete_until_power_of_two<T: Clone>(values: &mut Vec<T>) -> Vec<T> {
-    if values.len() == 1 {
-        return values.clone(); // Return immediately if there is only one element.
-    }
     while !is_power_of_two(values.len()) {
         values.push(values[values.len() - 1].clone());
     }
@@ -32,7 +29,11 @@ pub fn complete_until_power_of_two<T: Clone>(values: &mut Vec<T>) -> Vec<T> {
 }
 
 pub fn is_power_of_two(x: usize) -> bool {
-    (x != 0) && ((x & (x - 1)) == 0)
+    if x == 1 {
+        false
+    } else {
+        (x != 0) && ((x & (x - 1)) == 0)
+    }
 }
 
 // ! CAUTION !
@@ -107,6 +108,19 @@ mod tests {
         for (leaf, expected_leaves) in hashed_leaves.iter().zip(expected_leaves) {
             assert_eq!(*leaf, expected_leaves);
         }
+    }
+
+    #[test]
+    // expected |2|2|
+    fn complete_the_length_of_one_field_element_to_be_a_power_of_two() {
+        let mut values: Vec<FE> = vec![FE::new(2)];
+        let hashed_leaves = complete_until_power_of_two(&mut values);
+
+        let mut expected_leaves = vec![FE::new(2)];
+        expected_leaves.extend([FE::new(2)]);
+        assert_eq!(hashed_leaves.len(), 2);
+        assert_eq!(hashed_leaves[0], expected_leaves[0]);
+        assert_eq!(hashed_leaves[1], expected_leaves[1]);
     }
 
     const ROOT: usize = 0;

--- a/crypto/src/merkle_tree/utils.rs
+++ b/crypto/src/merkle_tree/utils.rs
@@ -28,12 +28,16 @@ pub fn complete_until_power_of_two<T: Clone>(values: &mut Vec<T>) -> Vec<T> {
     values.to_vec()
 }
 
-pub fn is_power_of_two(x: usize) -> bool {
-    if x == 1 {
-        false
-    } else {
-        (x != 0) && ((x & (x - 1)) == 0)
-    }
+/*
+    ! NOTE !
+    - We in this function we  say 2^0 = 1 is not a power of two when it is infact true. We 
+    need this to maintain that the smallest tree at two leaves counts and we could not find 
+    a name that wasn't overly verbose. In the case of a single value being present in a leaf node 
+    this indicates we pad to next power of two (i.e. 2). The function is private and is only used 
+    to ensure the tree has a power of 2 number of leaves.
+*/
+fn is_power_of_two(x: usize) -> bool {
+    (x > 1) && ((x & (x - 1)) == 0)
 }
 
 // ! CAUTION !


### PR DESCRIPTION
# Pad Single Tree leaves to next power of two

## Description

For merkle trees with a single leaf, pads the number of leaves to the next power of two by appending the last element.

## Type of change

Please delete options that are not relevant.

- [x] New feature

## Checklist
- [x] Unit tests added
