### PR TITLE
Add error to UnsInt from_hex when hex too big

### DIFF
--- a/math/src/errors.rs
+++ b/math/src/errors.rs
@@ -11,6 +11,7 @@ pub enum ByteConversionError {
 pub enum CreationError {
     InvalidHexString,
     InvalidDecString,
+    HexStringIsTooBig,
     EmptyString,
 }
 

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -509,7 +509,7 @@ impl<F: IsPrimeField> FieldElement<F> {
     /// Creates a `FieldElement` from a hexstring. It can contain `0x` or not.
     /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring.
     /// Returns a `CreationError::EmptyString` if the input string is empty.
-    /// Returns a `CreationError::HexStringIsTooBig` if the the imput hex string is bigger
+    /// Returns a `CreationError::HexStringIsTooBig` if the the input hex string is bigger
     /// than the maximum amount of characters for this element.
     pub fn from_hex(hex_string: &str) -> Result<Self, CreationError> {
         if hex_string.is_empty() {

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -511,12 +511,10 @@ impl<F: IsPrimeField> FieldElement<F> {
     /// Returns a `CreationError::EmptyString` if the input string is empty.
     pub fn from_hex(hex_string: &str) -> Result<Self, CreationError> {
         if hex_string.is_empty() {
-            return Err(CreationError::EmptyString)?;
+            return Err(CreationError::EmptyString);
         }
-
-        Ok(Self {
-            value: F::from_hex(hex_string)?,
-        })
+        let value = F::from_hex(hex_string)?;
+        Ok(Self { value })
     }
 
     #[cfg(feature = "std")]

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -509,6 +509,8 @@ impl<F: IsPrimeField> FieldElement<F> {
     /// Creates a `FieldElement` from a hexstring. It can contain `0x` or not.
     /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring.
     /// Returns a `CreationError::EmptyString` if the input string is empty.
+    /// Returns a `CreationError::HexStringIsTooBig` if the the imput hex string is bigger
+    /// than the maximum amount of characters for this element.
     pub fn from_hex(hex_string: &str) -> Result<Self, CreationError> {
         if hex_string.is_empty() {
             return Err(CreationError::EmptyString);

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -1150,6 +1150,19 @@ mod tests_u256_prime_fields {
     }
 
     #[test]
+    fn creating_a_field_element_from_hex_too_big_errors() {
+        let a = U256FP1Element::from_hex(&"f".repeat(65));
+        assert!(a.is_err());
+        assert_eq!(a.unwrap_err(), crate::errors::CreationError::HexStringIsTooBig)
+    }
+
+    #[test]
+    fn creating_a_field_element_from_hex_works_on_the_size_limit() {
+        let a = U256FP1Element::from_hex(&"f".repeat(64));
+        assert!(a.is_ok());
+    }
+
+    #[test]
     fn creating_a_field_element_from_hex_works_2() {
         let a = U256F29Element::from_hex_unchecked("aa");
         let b = U256F29Element::from(25);

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -1153,7 +1153,10 @@ mod tests_u256_prime_fields {
     fn creating_a_field_element_from_hex_too_big_errors() {
         let a = U256FP1Element::from_hex(&"f".repeat(65));
         assert!(a.is_err());
-        assert_eq!(a.unwrap_err(), crate::errors::CreationError::HexStringIsTooBig)
+        assert_eq!(
+            a.unwrap_err(),
+            crate::errors::CreationError::HexStringIsTooBig
+        )
     }
 
     #[test]

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -425,7 +425,8 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
     /// Creates an `UnsignedInteger` from a hexstring. It can contain `0x` or not.
     /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring.
     /// Returns a `CreationError::EmptyString` if the input string is empty.
-    /// Returns a `CreationError::HexStringIsTooBig` if the the imput hex string is bigger than the maximum amount of characters for this element.
+    /// Returns a `CreationError::HexStringIsTooBig` if the the imput hex string is bigger
+    /// than the maximum amount of characters for this element.
     pub fn from_hex(value: &str) -> Result<Self, CreationError> {
         let mut string = value;
         let mut char_iterator = value.chars();

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -425,6 +425,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
     /// Creates an `UnsignedInteger` from a hexstring. It can contain `0x` or not.
     /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring.
     /// Returns a `CreationError::EmptyString` if the input string is empty.
+    /// Returns a `CreationError::HexStringIsTooBig` if the the imput hex string is bigger than the maximum amount of characters for this element.
     pub fn from_hex(value: &str) -> Result<Self, CreationError> {
         let mut string = value;
         let mut char_iterator = value.chars();
@@ -447,7 +448,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         if string.len() > max_amount_of_hex_chars {
             return Err(CreationError::HexStringIsTooBig);
         }
-        
+
         Ok(Self::from_hex_unchecked(string))
     }
 
@@ -1258,12 +1259,15 @@ mod tests_u384 {
     fn from_hex_with_overflowing_hexstring_should_error() {
         let u256_from_big_string = U256::from_hex(&"f".repeat(65));
         assert!(u256_from_big_string.is_err());
-        assert!(u256_from_big_string == Err(crate::unsigned_integer::element::CreationError::HexStringIsTooBig));
+        assert!(
+            u256_from_big_string
+                == Err(crate::unsigned_integer::element::CreationError::HexStringIsTooBig)
+        );
     }
 
     #[test]
     fn from_hex_with_non_overflowing_hexstring_should_work() {
-        assert_eq!(U256::from_hex(&"0".repeat(64)).unwrap().limbs, [0,0,0,0])
+        assert_eq!(U256::from_hex(&"0".repeat(64)).unwrap().limbs, [0, 0, 0, 0])
     }
 
     #[test]

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -425,7 +425,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
     /// Creates an `UnsignedInteger` from a hexstring. It can contain `0x` or not.
     /// Returns an `CreationError::InvalidHexString`if the value is not a hexstring.
     /// Returns a `CreationError::EmptyString` if the input string is empty.
-    /// Returns a `CreationError::HexStringIsTooBig` if the the imput hex string is bigger
+    /// Returns a `CreationError::HexStringIsTooBig` if the the input hex string is bigger
     /// than the maximum amount of characters for this element.
     pub fn from_hex(value: &str) -> Result<Self, CreationError> {
         let mut string = value;

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -440,6 +440,14 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         if !Self::is_hex_string(string) {
             return Err(CreationError::InvalidHexString);
         }
+
+        // Limbs are of 64 bits - 8 bytes
+        // We have 16 nibbles per bytes
+        let max_amount_of_hex_chars = NUM_LIMBS * 16;
+        if string.len() > max_amount_of_hex_chars {
+            return Err(CreationError::HexStringIsTooBig);
+        }
+        
         Ok(Self::from_hex_unchecked(string))
     }
 
@@ -1001,7 +1009,7 @@ impl<const NUM_LIMBS: usize> Arbitrary for UnsignedInteger<NUM_LIMBS> {
 #[cfg(test)]
 mod tests_u384 {
     use crate::traits::ByteConversion;
-    use crate::unsigned_integer::element::{UnsignedInteger, U384};
+    use crate::unsigned_integer::element::{UnsignedInteger, U256, U384};
     #[cfg(feature = "proptest")]
     use proptest::prelude::*;
     #[cfg(feature = "proptest")]
@@ -1244,6 +1252,18 @@ mod tests_u384 {
                 6872850209053821716
             ]
         );
+    }
+
+    #[test]
+    fn from_hex_with_overflowing_hexstring_should_error() {
+        let u256_from_big_string = U256::from_hex(&"f".repeat(65));
+        assert!(u256_from_big_string.is_err());
+        assert!(u256_from_big_string == Err(crate::unsigned_integer::element::CreationError::HexStringIsTooBig));
+    }
+
+    #[test]
+    fn from_hex_with_non_overflowing_hexstring_should_work() {
+        assert_eq!(U256::from_hex(&"0".repeat(64)).unwrap().limbs, [0,0,0,0])
     }
 
     #[test]


### PR DESCRIPTION
# Fix panic on from_hex with big strings

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist
- [ ] Linked to Github Issue
