### PR TITLE
fix: `from_hex` panic

### DIFF
--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -409,14 +409,14 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
         let bytes = string.as_bytes();
         let mut i = 0;
 
-        while i < (len - 1) {
-            i += 1;
+        while i < len {
             match bytes[i] {
                 b'0'..=b'9' => (),
                 b'a'..=b'f' => (),
                 b'A'..=b'F' => (),
                 _ => return false,
             }
+            i += 1;
         }
 
         true

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -437,7 +437,7 @@ impl<const NUM_LIMBS: usize> UnsignedInteger<NUM_LIMBS> {
             string = &string[2..];
         }
         if string.is_empty() {
-            return Err(CreationError::EmptyString)?;
+            return Err(CreationError::EmptyString);
         }
         if !Self::is_hex_string(string) {
             return Err(CreationError::InvalidHexString);

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -2284,6 +2284,14 @@ mod tests_u256 {
     }
 
     #[test]
+    fn construct_integer_from_invalid_check_returns_error() {
+        use crate::unsigned_integer::element::CreationError;
+        assert_eq!(U256::from_hex("0xaO"), Err(CreationError::InvalidHexString));
+        assert_eq!(U256::from_hex("0xOa"), Err(CreationError::InvalidHexString));
+        assert_eq!(U256::from_hex("0xm"), Err(CreationError::InvalidHexString));
+    }
+
+    #[test]
     fn construct_new_integer_from_dec_2() {
         let a = U256::from_dec_str("15").unwrap();
         assert_eq!(a.limbs, [0, 0, 0, 15]);

--- a/math/src/unsigned_integer/element.rs
+++ b/math/src/unsigned_integer/element.rs
@@ -2284,7 +2284,7 @@ mod tests_u256 {
     }
 
     #[test]
-    fn construct_integer_from_invalid_check_returns_error() {
+    fn construct_integer_from_invalid_hex_returns_error() {
         use crate::unsigned_integer::element::CreationError;
         assert_eq!(U256::from_hex("0xaO"), Err(CreationError::InvalidHexString));
         assert_eq!(U256::from_hex("0xOa"), Err(CreationError::InvalidHexString));


### PR DESCRIPTION
Address #886
Issue was an off-by-one in `UnsignedInteger::is_hex_string`

## Type of change

- [x] Bug fix

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
