### PR TITLE
Optimize BN254 Pairing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 repository = "https://github.com/lambdaclass/lambdaworks"
 
 [workspace.dependencies]
-iai-callgrind = "0.3.1"
+iai-callgrind = "0.13.0"
 lambdaworks-crypto = { path = "./crypto", version = "0.9.0", default-features = false }
 lambdaworks-gpu = { path = "./gpu", version = "0.9.0" }
 lambdaworks-math = { path = "./math", version = "0.9.0", default-features = false }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 ark-ff = { git = "https://github.com/arkworks-rs/algebra", rev = "ef8f758" }
 ark-test-curves = { git = "https://github.com/arkworks-rs/algebra", rev = "ef8f758" }
 ark-std = "0.4.0"
-rand = "0.8.5"
 rand_chacha = "0.3.1"
 starknet-curve = { git = "https://github.com/xJonathanLEI/starknet-rs", tag = "starknet-curve/v0.4.2" }
 starknet-ff = { git = "https://github.com/xJonathanLEI/starknet-rs", tag = "starknet-ff/v0.3.7" }

--- a/benches/benches/poseidon.rs
+++ b/benches/benches/poseidon.rs
@@ -6,6 +6,7 @@ use lambdaworks_math::field::fields::fft_friendly::stark_252_prime_field::Stark2
 use lambdaworks_math::traits::ByteConversion;
 use pathfinder_crypto::MontFelt;
 use rand::{RngCore, SeedableRng};
+use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
 fn poseidon_benchmarks(c: &mut Criterion) {

--- a/benches/benches/utils.rs
+++ b/benches/benches/utils.rs
@@ -1,4 +1,5 @@
 use ark_ff::BigInt;
+use ark_std::rand::SeedableRng;
 use ark_std::UniformRand;
 use ark_test_curves::starknet_fp::Fq;
 use lambdaworks_math::{
@@ -7,7 +8,6 @@ use lambdaworks_math::{
     },
     unsigned_integer::element::UnsignedInteger,
 };
-use rand::SeedableRng;
 
 /// Creates `amount` random elements
 pub fn generate_random_elements(amount: u64) -> Vec<Fq> {

--- a/fuzz/no_gpu_fuzz/fuzz_targets/deserialize_stark_proof.rs
+++ b/fuzz/no_gpu_fuzz/fuzz_targets/deserialize_stark_proof.rs
@@ -1,12 +1,9 @@
 #![no_main]
-use libfuzzer_sys::fuzz_target;
-use stark_platinum_prover::proof::stark::StarkProof;
 use lambdaworks_math::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
 use lambdaworks_math::traits::Deserializable;
-
+use libfuzzer_sys::fuzz_target;
+use stark_platinum_prover::proof::stark::StarkProof;
 
 fuzz_target!(|data: Vec<u8>| {
-    
     let _proof = StarkProof::<Stark252PrimeField>::deserialize(&data);
-
 });

--- a/fuzz/no_gpu_fuzz/fuzz_targets/field/stark_field_addition.rs
+++ b/fuzz/no_gpu_fuzz/fuzz_targets/field/stark_field_addition.rs
@@ -1,10 +1,9 @@
 #![no_main]
 
-use libfuzzer_sys::fuzz_target;
 use lambdaworks_math::field::{
-    element::FieldElement, 
-    fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
+    element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
 };
+use libfuzzer_sys::fuzz_target;
 
 use lambdaworks_math::traits::ByteConversion;
 
@@ -12,7 +11,7 @@ type FE = FieldElement<Stark252PrimeField>;
 
 use ibig::{modular::ModuloRing, UBig};
 
-fuzz_target!(|bytes: ([u8;32], [u8;32])| {
+fuzz_target!(|bytes: ([u8; 32], [u8; 32])| {
     let (bytes_a, bytes_b) = bytes;
     let a = FE::from_bytes_be(&bytes_a).unwrap();
     let b = FE::from_bytes_be(&bytes_b).unwrap();
@@ -23,8 +22,11 @@ fuzz_target!(|bytes: ([u8;32], [u8;32])| {
     let c = a + &b;
     let c_hex = c.representative().to_string()[2..].to_string();
 
-    let prime = 
-    UBig::from_str_radix("800000000000011000000000000000000000000000000000000000000000001", 16).unwrap();
+    let prime = UBig::from_str_radix(
+        "800000000000011000000000000000000000000000000000000000000000001",
+        16,
+    )
+    .unwrap();
     let cairo_ring = ModuloRing::new(&prime);
 
     let a_ring = cairo_ring.from(&UBig::from_str_radix(&a_hex, 16).unwrap());
@@ -34,4 +36,3 @@ fuzz_target!(|bytes: ([u8;32], [u8;32])| {
 
     assert_eq!(expected_c_hex, c_hex);
 });
-

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -98,3 +98,5 @@ name = "criterion_metal"
 harness = false
 required-features = ["metal"]
 
+[profile.bench]
+debug = true

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -28,7 +28,7 @@ cudarc = { version = "0.9.7", optional = true }
 lambdaworks-gpu = { workspace = true, optional = true }
 
 [dev-dependencies]
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.8.5", features = ["std_rng"] }
 rand_chacha = "0.3.1"
 criterion = "0.5.1"
 const-random = "0.1.15"
@@ -60,25 +60,25 @@ cuda = ["dep:cudarc", "dep:lambdaworks-gpu"]
 name = "criterion_elliptic_curve"
 harness = false
 
-[[bench]]
-name = "iai_elliptic_curve"
-harness = false
+#[[bench]]
+#name = "iai_elliptic_curve"
+#harness = false
 
 [[bench]]
 name = "criterion_polynomial"
 harness = false
 
-[[bench]]
-name = "iai_polynomial"
-harness = false
+#[[bench]]
+#name = "iai_polynomial"
+#harness = false
 
 [[bench]]
 name = "criterion_field"
 harness = false
 
-[[bench]]
-name = "iai_field"
-harness = false
+#[[bench]]
+#name = "iai_field"
+#harness = false
 
 [[bench]]
 name = "criterion_msm"
@@ -89,9 +89,9 @@ required-features = ["parallel"]
 name = "criterion_fft"
 harness = false
 
-[[bench]]
-name = "iai_fft"
-harness = false
+#[[bench]]
+#name = "iai_fft"
+#harness = false
 
 [[bench]]
 name = "criterion_metal"

--- a/math/benches/criterion_elliptic_curve.rs
+++ b/math/benches/criterion_elliptic_curve.rs
@@ -9,7 +9,7 @@ use elliptic_curves::{
 
 criterion_group!(
     name = elliptic_curve_benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    config = Criterion::default();
     targets =  bn_254_elliptic_curve_benchmarks, 
 );
 

--- a/math/benches/criterion_elliptic_curve.rs
+++ b/math/benches/criterion_elliptic_curve.rs
@@ -10,6 +10,7 @@ use elliptic_curves::{
 criterion_group!(
     name = elliptic_curve_benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets =  bn_254_elliptic_curve_benchmarks, bls12_381_elliptic_curve_benchmarks, bls12_377_elliptic_curve_benchmarks 
+    targets =  bn_254_elliptic_curve_benchmarks, 
 );
+
 criterion_main!(elliptic_curve_benches);

--- a/math/benches/criterion_elliptic_curve.rs
+++ b/math/benches/criterion_elliptic_curve.rs
@@ -4,11 +4,12 @@ use pprof::criterion::{Output, PProfProfiler};
 mod elliptic_curves;
 use elliptic_curves::{
     bls12_377::bls12_377_elliptic_curve_benchmarks, bls12_381::bls12_381_elliptic_curve_benchmarks,
+    bn_254::bn_254_elliptic_curve_benchmarks
 };
 
 criterion_group!(
     name = elliptic_curve_benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets =  bls12_381_elliptic_curve_benchmarks, bls12_377_elliptic_curve_benchmarks
+    targets =  bn_254_elliptic_curve_benchmarks, bls12_381_elliptic_curve_benchmarks, bls12_377_elliptic_curve_benchmarks 
 );
 criterion_main!(elliptic_curve_benches);

--- a/math/benches/criterion_elliptic_curve.rs
+++ b/math/benches/criterion_elliptic_curve.rs
@@ -1,16 +1,15 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use pprof::criterion::{Output, PProfProfiler};
 
 mod elliptic_curves;
 use elliptic_curves::{
     bls12_377::bls12_377_elliptic_curve_benchmarks, bls12_381::bls12_381_elliptic_curve_benchmarks,
-    bn_254::bn_254_elliptic_curve_benchmarks
+    bn_254::bn_254_elliptic_curve_benchmarks,
 };
 
 criterion_group!(
     name = elliptic_curve_benches;
     config = Criterion::default();
-    targets =  bn_254_elliptic_curve_benchmarks, 
+    targets =  bn_254_elliptic_curve_benchmarks,bls12_381_elliptic_curve_benchmarks,bls12_377_elliptic_curve_benchmarks
 );
 
 criterion_main!(elliptic_curve_benches);

--- a/math/benches/elliptic_curves/bls12_377.rs
+++ b/math/benches/elliptic_curves/bls12_377.rs
@@ -15,7 +15,7 @@ pub fn bls12_377_elliptic_curve_benchmarks(c: &mut Criterion) {
     let a = BLS12377Curve::generator().operate_with_self(a_val);
     let b = BLS12377Curve::generator().operate_with_self(b_val);
 
-    let mut group = c.benchmark_group("BLS12-381 Ops");
+    let mut group = c.benchmark_group("BLS12-377s Ops");
     group.significance_level(0.1).sample_size(10000);
     group.throughput(criterion::Throughput::Elements(1));
 

--- a/math/benches/elliptic_curves/bn_254.rs
+++ b/math/benches/elliptic_curves/bn_254.rs
@@ -106,7 +106,7 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
         group.bench_function("Subgroup Check G2", |bencher| {
             bencher.iter(|| (black_box(a_g2.is_in_subgroup())));
         });
-    */
+    
     // Ate Pairing
 
     group.bench_function("Ate Pairing", |bencher| {
@@ -122,11 +122,12 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
     group.bench_function("Miller Loop 1", |bencher| {
         bencher.iter(|| black_box(miller(black_box(&a_g1), black_box(&a_g2))))
     });
-
+*/
     // Miller Loop 2
     group.bench_function("Miller Loop 2", |bencher| {
         bencher.iter(|| black_box(miller_2(black_box(&a_g1), black_box(&a_g2))))
     });
+    /* 
     // Final Exponentiation 1
     group.bench_function("Final Exponentiation 1", |bencher| {
         bencher.iter(|| black_box(final_exponentiation(black_box(&miller_loop_output))))
@@ -142,7 +143,7 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
         bencher.iter(|| black_box(final_exponentiation_3(black_box(&miller_loop_output))))
     });
 
-/* 
+
     // Fp12 Multiplication
     group.bench_function("Fp12 Multiplication", |bencher| {
         bencher.iter(|| black_box(black_box(&f_12)*black_box(&f_12)));

--- a/math/benches/elliptic_curves/bn_254.rs
+++ b/math/benches/elliptic_curves/bn_254.rs
@@ -4,7 +4,7 @@ use lambdaworks_math::{
     elliptic_curve::{
         short_weierstrass::curves::bn_254::{
             curve::BN254Curve,
-            pairing::{final_exponentiation, miller, BN254AtePairing},
+            pairing::{final_exponentiation, miller, miller_2, BN254AtePairing},
             twist::BN254TwistCurve,
         },
         traits::{IsEllipticCurve, IsPairing},
@@ -28,74 +28,74 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("BN254 Ops");
     group.significance_level(0.1).sample_size(10000);
     group.throughput(criterion::Throughput::Elements(1));
+    /*
+        // To Affine G1
+        group.bench_function("To Affine G1", |bencher| {
+            bencher.iter(|| black_box(black_box(&a_g1).to_affine()));
+        });
 
-    // To Affine G1
-    group.bench_function("To Affine G1", |bencher| {
-        bencher.iter(|| black_box(black_box(&a_g1).to_affine()));
-    });
+        // To Affine G2
+        group.bench_function("To Affine G2", |bencher| {
+            bencher.iter(|| black_box(black_box(&a_g2).to_affine()));
+        });
 
-    // To Affine G2
-    group.bench_function("To Affine G2", |bencher| {
-        bencher.iter(|| black_box(black_box(&a_g2).to_affine()));
-    });
+        // Operate_with G1
+        group.bench_function("Operate_with_G1", |bencher| {
+            bencher.iter(|| black_box(black_box(&a_g1).operate_with(black_box(&b_g1))));
+        });
 
-    // Operate_with G1
-    group.bench_function("Operate_with_G1", |bencher| {
-        bencher.iter(|| black_box(black_box(&a_g1).operate_with(black_box(&b_g1))));
-    });
+        // Operate_with G2
+        group.bench_function("Operate_with_G2 {:?}", |bencher| {
+            bencher.iter(|| black_box(black_box(&a_g2).operate_with(black_box(&b_g2))));
+        });
 
-    // Operate_with G2
-    group.bench_function("Operate_with_G2 {:?}", |bencher| {
-        bencher.iter(|| black_box(black_box(&a_g2).operate_with(black_box(&b_g2))));
-    });
+        // Operate_with_self G1
+        group.bench_function("Operate_with_self_G1", |bencher| {
+            bencher.iter(|| black_box(black_box(&a_g1).operate_with_self(black_box(b_val))));
+        });
 
-    // Operate_with_self G1
-    group.bench_function("Operate_with_self_G1", |bencher| {
-        bencher.iter(|| black_box(black_box(&a_g1).operate_with_self(black_box(b_val))));
-    });
+        // Operate_with_self G2
+        group.bench_function("Operate_with_self_G2", |bencher| {
+            bencher.iter(|| black_box(black_box(&a_g2).operate_with_self(black_box(b_val))));
+        });
 
-    // Operate_with_self G2
-    group.bench_function("Operate_with_self_G2", |bencher| {
-        bencher.iter(|| black_box(black_box(&a_g2).operate_with_self(black_box(b_val))));
-    });
+        // Double G1
+        group.bench_function("Double G1", |bencher| {
+            bencher.iter(|| black_box(black_box(&a_g1).operate_with_self(black_box(2u64))));
+        });
 
-    // Double G1
-    group.bench_function("Double G1", |bencher| {
-        bencher.iter(|| black_box(black_box(&a_g1).operate_with_self(black_box(2u64))));
-    });
+        // Double G2
+        group.bench_function("Double G2 {:?}", |bencher| {
+            bencher.iter(|| black_box(black_box(&a_g2).double()));
+        });
 
-    // Double G2
-    group.bench_function("Double G2 {:?}", |bencher| {
-        bencher.iter(|| black_box(black_box(&a_g2).double()));
-    });
+        // Operate_with Neg G1 (Substraction)
+        group.bench_function("Operate_with Neg G1 (Substraction)", |bencher| {
+            bencher
+                .iter(|| black_box(black_box(&a_g1).operate_with(black_box(&black_box(&b_g1).neg()))));
+        });
 
-    // Operate_with Neg G1 (Substraction)
-    group.bench_function("Operate_with Neg G1 (Substraction)", |bencher| {
-        bencher
-            .iter(|| black_box(black_box(&a_g1).operate_with(black_box(&black_box(&b_g1).neg()))));
-    });
+        // Operate_with Neg G2 (Substraction)
+        group.bench_function("Operate_with Neg G2 (Substraction)", |bencher| {
+            bencher
+                .iter(|| black_box(black_box(&a_g2).operate_with(black_box(&black_box(&b_g2).neg()))));
+        });
 
-    // Operate_with Neg G2 (Substraction)
-    group.bench_function("Operate_with Neg G2 (Substraction)", |bencher| {
-        bencher
-            .iter(|| black_box(black_box(&a_g2).operate_with(black_box(&black_box(&b_g2).neg()))));
-    });
+        // Neg G1
+        group.bench_function("Neg G1", |bencher| {
+            bencher.iter(|| black_box(black_box(&a_g1).neg()));
+        });
 
-    // Neg G1
-    group.bench_function("Neg G1", |bencher| {
-        bencher.iter(|| black_box(black_box(&a_g1).neg()));
-    });
+        // Neg G2
+        group.bench_function("Neg G2", |bencher| {
+            bencher.iter(|| black_box(black_box(&a_g2).neg()));
+        });
 
-    // Neg G2
-    group.bench_function("Neg G2", |bencher| {
-        bencher.iter(|| black_box(black_box(&a_g2).neg()));
-    });
-
-    // Subgroup Check G2
-    group.bench_function("Subgroup Check G2", |bencher| {
-        bencher.iter(|| (black_box(a_g2.is_in_subgroup())));
-    });
-
+        // Subgroup Check G2
+        group.bench_function("Subgroup Check G2", |bencher| {
+            bencher.iter(|| (black_box(a_g2.is_in_subgroup())));
+        });
+    */
     // Ate Pairing
     group.bench_function("Ate Pairing", |bencher| {
         bencher.iter(|| {
@@ -108,7 +108,7 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
 
     // Miller Loop
     group.bench_function("Miller Loop", |bencher| {
-        bencher.iter(|| black_box(miller(black_box(&a_g1), black_box(&a_g2))))
+        bencher.iter(|| black_box(miller_2(black_box(&a_g1), black_box(&a_g2))))
     });
 
     // Final Exponentiation

--- a/math/benches/elliptic_curves/bn_254.rs
+++ b/math/benches/elliptic_curves/bn_254.rs
@@ -144,49 +144,41 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
 
 /* 
     // Fp12 Multiplication
-
     group.bench_function("Fp12 Multiplication", |bencher| {
         bencher.iter(|| black_box(black_box(&f_12)*black_box(&f_12)));
     });
 
     // Fp2 Multiplication
-
     group.bench_function("Fp2 Multiplication", |bencher| {
         bencher.iter(|| black_box(black_box(&f_2)*black_box(&f_2)));
     });
 
     // Fp12 Inverse
-
     group.bench_function("Fp12 Inverse", |bencher| {
         bencher.iter(|| black_box(black_box(&f_12).inv()));
     });
 
     // Cyclotomic Pow x
-
     group.bench_function("Cyclotomic Pow x", |bencher| {
         bencher.iter(|| black_box(cyclotomic_pow_x(black_box(&f_12))));
     });
 
     // Cyclotomic Pow x Version 2
-
     group.bench_function("Cyclotomic Pow x Version 2", |bencher| {
         bencher.iter(|| black_box(cyclotomic_pow_x_2(black_box(&f_12))));
     });  
 
     // Pow x function
-
     group.bench_function("Pow x function", |bencher| {
         bencher.iter(|| black_box(black_box(&f_12).pow(X)));
     });  
 
     // Cyclotomic Square
-
     group.bench_function("Cyclotomic Square", |bencher| {
         bencher.iter(|| black_box(cyclotomic_square(black_box(&f_12))));
     });
 
     // Cyclotomic Square Over Cube
-    
     group.bench_function("Cyclotomic Square Over Cube", |bencher| {
         bencher.iter(|| black_box(cyclotomic_square_quad_over_cube(black_box(&f_12))));
     }); 

--- a/math/benches/elliptic_curves/bn_254.rs
+++ b/math/benches/elliptic_curves/bn_254.rs
@@ -4,7 +4,9 @@ use lambdaworks_math::{
     elliptic_curve::{
         short_weierstrass::curves::bn_254::{
             curve::BN254Curve,
-            pairing::{final_exponentiation, miller, miller_2, BN254AtePairing},
+            pairing::{
+                final_exponentiation, final_exponentiation_2, miller, miller_2, BN254AtePairing,
+            },
             twist::BN254TwistCurve,
         },
         traits::{IsEllipticCurve, IsPairing},
@@ -107,17 +109,22 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
     });
 
     // Miller Loop 1
-    group.bench_function("Miller Loop", |bencher| {
+    group.bench_function("Miller Loop 1", |bencher| {
         bencher.iter(|| black_box(miller(black_box(&a_g1), black_box(&a_g2))))
     });
 
     // Miller Loop 2
-    group.bench_function("Miller Loop", |bencher| {
+    group.bench_function("Miller Loop 2", |bencher| {
         bencher.iter(|| black_box(miller_2(black_box(&a_g1), black_box(&a_g2))))
     });
 
-    // Final Exponentiation
-    group.bench_function("Final Exponentiation", |bencher| {
+    // Final Exponentiation 1
+    group.bench_function("Final Exponentiation 1", |bencher| {
         bencher.iter(|| black_box(final_exponentiation(black_box(&miller_loop_output))))
+    });
+
+    // Final Exponentiation 2
+    group.bench_function("Final Exponentiation 2", |bencher| {
+        bencher.iter(|| black_box(final_exponentiation_2(black_box(&miller_loop_output))))
     });
 }

--- a/math/benches/elliptic_curves/bn_254.rs
+++ b/math/benches/elliptic_curves/bn_254.rs
@@ -106,7 +106,12 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
         });
     });
 
-    // Miller Loop
+    // Miller Loop 1
+    group.bench_function("Miller Loop", |bencher| {
+        bencher.iter(|| black_box(miller(black_box(&a_g1), black_box(&a_g2))))
+    });
+
+    // Miller Loop 2
     group.bench_function("Miller Loop", |bencher| {
         bencher.iter(|| black_box(miller_2(black_box(&a_g1), black_box(&a_g2))))
     });

--- a/math/benches/elliptic_curves/bn_254.rs
+++ b/math/benches/elliptic_curves/bn_254.rs
@@ -6,8 +6,8 @@ use lambdaworks_math::{
             curve::BN254Curve, 
             field_extension::{BN254PrimeField, Degree12ExtensionField, Degree2ExtensionField}, 
             pairing::{
-                cyclotomic_pow_x, final_exponentiation, final_exponentiation_2, miller, miller_2, BN254AtePairing, X
-            }, 
+                cyclotomic_pow_x, final_exponentiation, final_exponentiation_2,final_exponentiation_3, miller, miller_2, BN254AtePairing, X,
+                cyclotomic_square_quad_over_cube, cyclotomic_square,cyclotomic_pow_x_2} ,
             twist::BN254TwistCurve
         },
         traits::{IsEllipticCurve, IsPairing},
@@ -108,7 +108,7 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
         });
     */
     // Ate Pairing
-    /* 
+
     group.bench_function("Ate Pairing", |bencher| {
         bencher.iter(|| {
             black_box(BN254AtePairing::compute_batch(&[(
@@ -137,23 +137,58 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
         bencher.iter(|| black_box(final_exponentiation_2(black_box(&miller_loop_output))))
     });
 
+    // Final Exponentiation 3
+    group.bench_function("Final Exponentiation 3", |bencher| {
+        bencher.iter(|| black_box(final_exponentiation_3(black_box(&miller_loop_output))))
+    });
+
+/* 
+    // Fp12 Multiplication
+
     group.bench_function("Fp12 Multiplication", |bencher| {
         bencher.iter(|| black_box(black_box(&f_12)*black_box(&f_12)));
     });
+
+    // Fp2 Multiplication
 
     group.bench_function("Fp2 Multiplication", |bencher| {
         bencher.iter(|| black_box(black_box(&f_2)*black_box(&f_2)));
     });
 
+    // Fp12 Inverse
+
     group.bench_function("Fp12 Inverse", |bencher| {
         bencher.iter(|| black_box(black_box(&f_12).inv()));
     });
-*/
-    group.bench_function("Cyclotomic Pow", |bencher| {
-        bencher.iter(|| black_box(black_box(cyclotomic_pow_x(&f_12))));
+
+    // Cyclotomic Pow x
+
+    group.bench_function("Cyclotomic Pow x", |bencher| {
+        bencher.iter(|| black_box(cyclotomic_pow_x(black_box(&f_12))));
     });
 
-    group.bench_function("Pow function", |bencher| {
-        bencher.iter(|| black_box(black_box(f_12.pow(X))));
+    // Cyclotomic Pow x Version 2
+
+    group.bench_function("Cyclotomic Pow x Version 2", |bencher| {
+        bencher.iter(|| black_box(cyclotomic_pow_x_2(black_box(&f_12))));
     });  
+
+    // Pow x function
+
+    group.bench_function("Pow x function", |bencher| {
+        bencher.iter(|| black_box(black_box(&f_12).pow(X)));
+    });  
+
+    // Cyclotomic Square
+
+    group.bench_function("Cyclotomic Square", |bencher| {
+        bencher.iter(|| black_box(cyclotomic_square(black_box(&f_12))));
+    });
+
+    // Cyclotomic Square Over Cube
+    
+    group.bench_function("Cyclotomic Square Over Cube", |bencher| {
+        bencher.iter(|| black_box(cyclotomic_square_quad_over_cube(black_box(&f_12))));
+    }); 
+    */
 }

--- a/math/benches/elliptic_curves/bn_254.rs
+++ b/math/benches/elliptic_curves/bn_254.rs
@@ -1,0 +1,85 @@
+use criterion::{black_box, Criterion};
+use lambdaworks_math::{
+    cyclic_group::IsGroup,
+    elliptic_curve::{
+        short_weierstrass::curves::bn_254::{
+            curve::BN254Curve,
+            pairing::BN254AtePairing,
+            twist::BN254TwistCurve,
+        },
+        traits::{IsEllipticCurve, IsPairing},
+    },
+};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+
+
+#[allow(dead_code)]
+pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let a_val: u128 = rng.gen();
+    let b_val: u128 = rng.gen();
+    let a_g1 = BN254Curve::generator().operate_with_self(a_val);
+    let b_g1 = BN254Curve::generator().operate_with_self(b_val);
+
+    let a_g2 = BN254TwistCurve::generator();
+    let b_g2 = BN254TwistCurve::generator();
+
+    let mut group = c.benchmark_group("BN254 Ops");
+    group.significance_level(0.1).sample_size(10000);
+    group.throughput(criterion::Throughput::Elements(1));
+
+    // Operate_with G1
+    group.bench_function("Operate_with_G1", |bencher| {
+        bencher.iter(|| black_box(black_box(&a_g1).operate_with(black_box(&b_g1))));
+    });
+
+    // Operate_with G2
+    group.bench_function("Operate_with_G2 {:?}", |bencher| {
+        bencher.iter(|| black_box(black_box(&a_g2).operate_with(black_box(&b_g2))));
+    });
+
+    // Operate_with_self G1
+    group.bench_function("Operate_with_self_G1", |bencher| {
+        bencher.iter(|| black_box(black_box(&a_g1).operate_with_self(black_box(b_val))));
+    });
+
+    // Operate_with_self G2
+    group.bench_function("Operate_with_self_G2", |bencher| {
+        bencher.iter(|| black_box(black_box(&a_g2).operate_with_self(black_box(b_val))));
+    });
+
+    // Double G1
+    group.bench_function("Double G1", |bencher| {
+        bencher.iter(|| black_box(black_box(&a_g1).operate_with_self(black_box(2u64))));
+    });
+
+    // Double G2
+    group.bench_function("Double G2 {:?}", |bencher| {
+        bencher.iter(|| black_box(black_box(&a_g2).double()));
+    });
+
+    // Neg G1
+    group.bench_function("Neg G1", |bencher| {
+        bencher.iter(|| black_box(black_box(&a_g1).neg()));
+    });
+
+    // Neg G2
+    group.bench_function("Neg G2", |bencher| {
+        bencher.iter(|| black_box(black_box(&a_g2).neg()));
+    });
+
+    // Subgroup Check G2
+    group.bench_function("Subgroup Check G2", |bencher| {
+        bencher.iter(|| (black_box(a_g2.is_in_subgroup())));
+    });
+
+    // Ate Pairing
+    group.bench_function("Ate Pairing", |bencher| {
+        bencher.iter(|| {
+            black_box(BN254AtePairing::compute_batch(&[(
+                black_box(&a_g1),
+                black_box(&a_g2)
+            )]))
+        });
+    });
+}

--- a/math/benches/elliptic_curves/bn_254.rs
+++ b/math/benches/elliptic_curves/bn_254.rs
@@ -4,14 +4,13 @@ use lambdaworks_math::{
     elliptic_curve::{
         short_weierstrass::curves::bn_254::{
             curve::BN254Curve,
-            pairing::{BN254AtePairing, miller, final_exponentiation},
+            pairing::{final_exponentiation, miller, BN254AtePairing},
             twist::BN254TwistCurve,
         },
         traits::{IsEllipticCurve, IsPairing},
     },
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
-
 
 #[allow(dead_code)]
 pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
@@ -29,6 +28,16 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("BN254 Ops");
     group.significance_level(0.1).sample_size(10000);
     group.throughput(criterion::Throughput::Elements(1));
+
+    // To Affine G1
+    group.bench_function("To Affine G1", |bencher| {
+        bencher.iter(|| black_box(black_box(&a_g1).to_affine()));
+    });
+
+    // To Affine G2
+    group.bench_function("To Affine G2", |bencher| {
+        bencher.iter(|| black_box(black_box(&a_g2).to_affine()));
+    });
 
     // Operate_with G1
     group.bench_function("Operate_with_G1", |bencher| {
@@ -62,12 +71,14 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
 
     // Operate_with Neg G1 (Substraction)
     group.bench_function("Operate_with Neg G1 (Substraction)", |bencher| {
-        bencher.iter(|| black_box(black_box(&a_g1).operate_with(black_box(&black_box(&b_g1).neg()))));
+        bencher
+            .iter(|| black_box(black_box(&a_g1).operate_with(black_box(&black_box(&b_g1).neg()))));
     });
 
     // Operate_with Neg G2 (Substraction)
     group.bench_function("Operate_with Neg G2 (Substraction)", |bencher| {
-        bencher.iter(|| black_box(black_box(&a_g2).operate_with(black_box(&black_box(&b_g2).neg()))));
+        bencher
+            .iter(|| black_box(black_box(&a_g2).operate_with(black_box(&black_box(&b_g2).neg()))));
     });
 
     // Neg G1
@@ -90,7 +101,7 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
         bencher.iter(|| {
             black_box(BN254AtePairing::compute_batch(&[(
                 black_box(&a_g1),
-                black_box(&a_g2)
+                black_box(&a_g2),
             )]))
         });
     });

--- a/math/benches/elliptic_curves/iai_bn_254.rs
+++ b/math/benches/elliptic_curves/iai_bn_254.rs
@@ -3,11 +3,7 @@ use lambdaworks_math::{
     cyclic_group::IsGroup,
     elliptic_curve::{
         short_weierstrass::{
-            curves::bn_254::{
-                curve::BN254Curve,
-                pairing::BN254AtePairing,
-                twist::BN254TwistCurve,
-            },
+            curves::bn_254::{curve::BN254Curve, pairing::BN254AtePairing, twist::BN254TwistCurve},
             point::ShortWeierstrassProjectivePoint,
         },
         traits::{IsEllipticCurve, IsPairing},

--- a/math/benches/elliptic_curves/iai_bn_254.rs
+++ b/math/benches/elliptic_curves/iai_bn_254.rs
@@ -1,0 +1,101 @@
+use criterion::black_box;
+use lambdaworks_math::{
+    cyclic_group::IsGroup,
+    elliptic_curve::{
+        short_weierstrass::{
+            curves::bn_254::{
+                curve::BN254Curve,
+                pairing::BN254AtePairing,
+                twist::BN254TwistCurve,
+            },
+            point::ShortWeierstrassProjectivePoint,
+        },
+        traits::{IsEllipticCurve, IsPairing},
+    },
+};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+#[allow(dead_code)]
+type G1 = ShortWeierstrassProjectivePoint<BN254Curve>;
+#[allow(dead_code)]
+type G2 = ShortWeierstrassProjectivePoint<BN254TwistCurve>;
+
+#[allow(dead_code)]
+pub fn rand_points_g1() -> (G1, G1, u128, u128) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let a_val = rng.gen();
+    let b_val = rng.gen();
+    let a = BN254Curve::generator().operate_with_self(a_val);
+    let b = BN254Curve::generator().operate_with_self(b_val);
+    (a, b, a_val, b_val)
+}
+
+#[allow(dead_code)]
+pub fn rand_points_g2() -> (G2, G2, u128, u128) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let a_val = rng.gen();
+    let b_val = rng.gen();
+    let a = BN254TwistCurve::generator().operate_with_self(a_val);
+    let b = BN254TwistCurve::generator().operate_with_self(b_val);
+    (a, b, a_val, b_val)
+}
+
+#[allow(dead_code)]
+pub fn bn_254_operate_with_g1() {
+    let (a, b, _, _) = rand_points_g1();
+    let _ = black_box(black_box(&a).operate_with(black_box(&b)));
+}
+
+#[allow(dead_code)]
+pub fn bn_254_operate_with_g2() {
+    let (a, b, _, _) = rand_points_g1();
+    let _ = black_box(black_box(&a).operate_with(black_box(&b)));
+}
+
+#[allow(dead_code)]
+pub fn bn_254_operate_with_self_g1() {
+    let (a, _, _, b_val) = rand_points_g1();
+    let _ = black_box(black_box(&a).operate_with_self(black_box(b_val)));
+}
+
+#[allow(dead_code)]
+pub fn bn_254_operate_with_self_g2() {
+    let (a, _, _, b_val) = rand_points_g2();
+    let _ = black_box(black_box(&a).operate_with_self(black_box(b_val)));
+}
+
+#[allow(dead_code)]
+pub fn bn_254_double_g1() {
+    let (a, _, _, _) = rand_points_g1();
+    let _ = black_box(black_box(&a).operate_with_self(black_box(2u64)));
+}
+
+#[allow(dead_code)]
+pub fn bn_254_double_g2() {
+    let (a, _, _, _) = rand_points_g2();
+    let _ = black_box(black_box(&a).operate_with_self(black_box(2u64)));
+}
+
+#[allow(dead_code)]
+pub fn bn_254_neg_g1() {
+    let (a, _, _, _) = rand_points_g1();
+    let _ = black_box(black_box(&a).neg());
+}
+
+#[allow(dead_code)]
+pub fn bn_254_neg_g2() {
+    let (a, _, _, _) = rand_points_g2();
+    let _ = black_box(black_box(&a).neg());
+}
+
+#[allow(dead_code)]
+pub fn bn_254_subgroup_check_g2() {
+    let (a, _, _) = rand_points_g2();
+    let _ = black_box(black_box(&a.is_in_subgroup()));
+}
+
+#[allow(dead_code)]
+pub fn bn_254_ate_pairing() {
+    let (a, _, _, _) = rand_points_g1();
+    let (_, b, _, _) = rand_points_g2();
+    let _ = black_box(BN254AtePairing::compute(black_box(&a), black_box(&b)));
+}

--- a/math/benches/elliptic_curves/mod.rs
+++ b/math/benches/elliptic_curves/mod.rs
@@ -3,4 +3,4 @@ pub mod bls12_381;
 pub mod iai_bls12_377;
 pub mod iai_bls12_381;
 pub mod bn_254;
-pub mod iai_bn_254;
+//pub mod iai_bn_254;

--- a/math/benches/elliptic_curves/mod.rs
+++ b/math/benches/elliptic_curves/mod.rs
@@ -1,6 +1,6 @@
 pub mod bls12_377;
 pub mod bls12_381;
+pub mod bn_254;
 pub mod iai_bls12_377;
 pub mod iai_bls12_381;
-pub mod bn_254;
-//pub mod iai_bn_254;
+pub mod iai_bn_254;

--- a/math/benches/elliptic_curves/mod.rs
+++ b/math/benches/elliptic_curves/mod.rs
@@ -2,3 +2,5 @@ pub mod bls12_377;
 pub mod bls12_381;
 pub mod iai_bls12_377;
 pub mod iai_bls12_381;
+pub mod bn_254;
+pub mod iai_bn_254;

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/field_extension.rs
@@ -225,7 +225,146 @@ pub fn mul_fp2_by_nonresidue(fe: &Fp2E) -> Fp2E {
     Fp2E::new([c0, c1])
 }
 
-pub type Degree6ExtensionField = CubicExtensionField<Degree2ExtensionField, LevelTwoResidue>;
+#[derive(Clone, Debug)]
+pub struct Degree12ExtensionField;
+
+/// Optimal algorithms from
+/// https://hackmd.io/@Wimet/ry7z1Xj-2#Fp12-Arithmetic
+impl IsField for Degree6ExtensionField {
+    type BaseType = [FieldElement<Degree2ExtensionField>; 3];
+
+    fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        [&a[0] + &b[0], &a[1] + &b[1], &a[2] + &b[2]]
+    }
+
+    fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        let a0 = &a[0];
+        let a1 = &a[1];
+        let a2 = &a[2];
+        let b0 = &b[0];
+        let b1 = &b[1];
+        let b2 = &b[2];
+        [((a1 + a2) * (b1 + b2) - a1 * b1 - a2 * b2) * <LevelTwoResidue as HasQuadraticNonResidue<Degree2ExtensionField>>::residue() + a0 * b0,
+        (a0 + a1) * (b0 + b1) - a0 * b0 - a1 * b1 + <LevelTwoResidue as HasQuadraticNonResidue<Degree2ExtensionField>>::residue() * a2 * b2,
+        (a0 + a2) * (b0 + b2) - a0 * b0 + a1 * b1 - a2 * b2]
+    }
+
+    fn square(a: &Self::BaseType) -> Self::BaseType {
+        let a0 = &a[0];
+        let a1 = &a[1];
+        let a2 = &a[2];
+        let a2 = &a[2];
+       
+        [ (a1 * a2 * <LevelTwoResidue as HasQuadraticNonResidue<Degree2ExtensionField>>::residue()).double() + a0.square(),
+        a2.square() * <LevelTwoResidue as HasQuadraticNonResidue<Degree2ExtensionField>>::residue() + (a0 * a1).double(),
+        (a0 * a1).double() - a2.square() + (a0 - a1 + a2).square() + (a1 * a2).double() - a0.square()
+        ]
+    }
+
+    /// INPUT: (a = a0 + a1*w),(b = b0 + b1*w) in Fp12, where ai,bi in Fp6
+    /// OUTPUT: (c0 + c1*w) = a - b in Fp12
+    /// c0 = a0 - b0
+    /// c1 = a1 - b1
+    fn sub(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType{
+        [&a[0] - &b[0], &a[1] - &b[1], &a[2] - &b[2]]
+    }
+
+    /// Returns the component wise negation of `a`
+    fn neg(a: &Self::BaseType) -> Self::BaseType {
+        [-&a[0], -&a[1]]
+    }
+
+    /// c0 = a0*(a0^2 - a1^2*v)^{-1}
+    /// c1 = -a1*(a0^2 - a1^2*v)^{-1}
+    fn inv(a: &Self::BaseType) -> Result<Self::BaseType, FieldError> {
+        let a0 = &a[0];
+        let a1 = &a[1];
+        Ok([a0 * (a0.square() - a1.square() * LevelThreeResidue::residue()).inv().unwrap(), 
+        -a1 * (a0.square() - a1.square() * LevelThreeResidue::residue()).inv().unwrap()])
+    }
+
+    /// Returns the division of `a` and `b`
+    fn div(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        <Self as IsField>::mul(a, &Self::inv(b).unwrap())
+    }
+
+    /// Returns a boolean indicating whether `a` and `b` are equal component wise.
+    fn eq(a: &Self::BaseType, b: &Self::BaseType) -> bool {
+        a[0] == b[0] && a[1] == b[1]
+    }
+
+    /// Returns the additive neutral element of the field extension.
+    fn zero() -> Self::BaseType {
+        [FieldElement::zero(), FieldElement::zero()]
+    }
+
+    /// Returns the multiplicative neutral element of the field extension.
+    fn one() -> Self::BaseType {
+        [FieldElement::one(), FieldElement::zero()]
+    }
+
+    /// Returns the element `x * 1` where 1 is the multiplicative neutral element.
+    fn from_u64(x: u64) -> Self::BaseType {
+        [FieldElement::from(x), FieldElement::zero()]
+    }
+
+    /// Takes as input an element of BaseType and returns the internal representation
+    /// of that element in the field.
+    /// Note: for this case this is simply the identity, because the components
+    /// already have correct representations.
+    fn from_base_type(x: Self::BaseType) -> Self::BaseType {
+        x
+    }
+}
+
+impl IsSubFieldOf<Degree12ExtensionField> for Degree6ExtensionField {
+
+    fn mul(
+        a: &Self::BaseType,
+        b: &<Degree12ExtensionField as IsField>::BaseType,
+    ) -> <Degree12ExtensionField as IsField>::BaseType {
+        let c0 = FieldElement::from_raw(<Self as IsField>::mul(a, b[0].value()));
+        let c1 = FieldElement::from_raw(<Self as IsField>::mul(a, b[1].value()));
+        [c0, c1]
+    }
+
+    fn add(
+        a: &Self::BaseType,
+        b: &<Degree12ExtensionField as IsField>::BaseType,
+    ) -> <Degree12ExtensionField as IsField>::BaseType {
+        let c0 = FieldElement::from_raw(<Self as IsField>::add(a, b[0].value()));
+        let c1 = FieldElement::from_raw(b[1].value().clone());
+        [c0, c1]
+    }
+
+    fn div(
+        a: &Self::BaseType,
+        b: &<Degree12ExtensionField as IsField>::BaseType,
+    ) -> <Degree12ExtensionField as IsField>::BaseType {
+        let b_inv = Degree12ExtensionField::inv(b).unwrap();
+        <Self as IsSubFieldOf<Degree12ExtensionField>>::mul(a, &b_inv)
+    }
+
+    fn sub(
+        a: &Self::BaseType,
+        b: &<Degree12ExtensionField as IsField>::BaseType,
+    ) -> <Degree12ExtensionField as IsField>::BaseType {
+        let c0 = FieldElement::from_raw(<Self as IsField>::sub(a, b[0].value()));
+        let c1 = FieldElement::from_raw(<Self as IsField>::neg(b[1].value()));
+        [c0, c1]
+    }
+
+    fn embed(a: Self::BaseType) -> <Degree12ExtensionField as IsField>::BaseType {
+        [FieldElement::from_raw(a), FieldElement::zero()]
+    }
+
+    #[cfg(feature = "alloc")]
+    fn to_subfield_vec(
+        b: <Degree12ExtensionField as IsField>::BaseType,
+    ) -> alloc::vec::Vec<Self::BaseType> {
+        b.into_iter().map(|x| x.to_raw()).collect()
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct LevelThreeResidue;

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/field_extension.rs
@@ -39,11 +39,10 @@ impl IsField for Degree2ExtensionField {
     fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         let a0b0 = &a[0] * &b[0];
         let a1b1 = &a[1] * &b[1];
-        let sum_a = &a[0] + &a[1];
-        let sum_b = &b[0] + &b[1];
-        let z = &sum_a * &sum_b;
-        [&a0b0 - &a1b1, z - &a0b0 - &a1b1]
+        let z = (&a[0] + &a[1]) * (&b[0] + &b[1]);
+        [&a0b0 - &a1b1, z - a0b0 - a1b1]
     }
+
     fn square(a: &Self::BaseType) -> Self::BaseType {
         let [a0, a1] = a;
         let v0 = a0 * a1;
@@ -67,7 +66,6 @@ impl IsField for Degree2ExtensionField {
         let inv_norm = (a[0].pow(2_u64) + a[1].pow(2_u64)).inv()?;
         Ok([&a[0] * &inv_norm, -&a[1] * inv_norm])
     }
-    
 
     /// Returns the division of `a` and `b`
     fn div(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
@@ -241,13 +239,165 @@ impl HasQuadraticNonResidue<Degree6ExtensionField> for LevelThreeResidue {
     }
 }
 
-pub type Degree12ExtensionField = QuadraticExtensionField<Degree6ExtensionField, LevelThreeResidue>;
+pub type FpE = FieldElement<BN254PrimeField>;
+pub type Fp6E = FieldElement<Degree6ExtensionField>;
+
+/* 
+// 0 + 1 * v + 0 * v^2 in Fp6
+pub const V: Fp6E = Fp6E::const_from_raw([
+    Fp2E::const_from_raw([FpE::from_hex_unchecked("0"), FpE::from_hex_unchecked("0")]), 
+    Fp2E::const_from_raw([FpE::from_hex_unchecked("0001"), FpE::from_hex_unchecked("0")]),  
+    Fp2E::const_from_raw([FpE::from_hex_unchecked("0"), FpE::from_hex_unchecked("0")])
+]);
+*/
+
+
+#[derive(Clone, Debug)]
+pub struct Degree12ExtensionField;
+
+/// Optimal algorithms from
+/// https://hackmd.io/@Wimet/ry7z1Xj-2#Fp12-Arithmetic
+impl IsField for Degree12ExtensionField {
+    type BaseType = [FieldElement<Degree6ExtensionField>; 2];
+
+    fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        [&a[0] + &b[0], &a[1] + &b[1]]
+    }
+
+    // INPUT: (a = a0 + a1 * w),(b = b0 + b1 * w) in Fp12, where ai,bi in Fp6
+    // OUTPUT: (c0 + c1 * w) = a * b in Fp12
+    // c0 = a0 * b0 + a1 * b1 * v where
+    // c1 = (a0+a1)*(b0+b1) - a0*b0 - a1*b1
+    fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        let a0 = &a[0];
+        let a1 = &a[1];
+        let b0 = &b[0];
+        let b1 = &b[1];
+        [a0 * b0 + a1 * b1 * LevelThreeResidue::residue(),
+        (a0 + a1) * (b0 + b1) - a0 * b0 - a1 * b1]
+    }
+
+    fn square(a: &Self::BaseType) -> Self::BaseType {
+        let a0 = &a[0];
+        let a1 = &a[1];
+
+        [
+            (a0 - a1) * (a0 - a1 * LevelThreeResidue::residue() ) + a0 * a1 + a0 * a1 * LevelThreeResidue::residue(),
+            a0 * a1 + a0 * a1
+        ]
+    }
+
+    /// INPUT: (a = a0 + a1*w),(b = b0 + b1*w) in Fp12, where ai,bi in Fp6
+    /// OUTPUT: (c0 + c1*w) = a - b in Fp12
+    /// c0 = a0 - b0
+    /// c1 = a1 - b1
+    fn sub(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType{
+        [&a[0] - &b[0], &a[1] - &b[1]]
+    }
+
+    /// Returns the component wise negation of `a`
+    fn neg(a: &Self::BaseType) -> Self::BaseType {
+        [-&a[0], -&a[1]]
+    }
+
+    /// c0 = a0*(a0^2 - a1^2*v)^{-1}
+    /// c1 = -a1*(a0^2 - a1^2*v)^{-1}
+    fn inv(a: &Self::BaseType) -> Result<Self::BaseType, FieldError> {
+        let a0 = &a[0];
+        let a1 = &a[1];
+        Ok([a0 * (a0.square() - a1.square() * LevelThreeResidue::residue()).inv().unwrap(), 
+        -a1 * (a0.square() - a1.square() * LevelThreeResidue::residue()).inv().unwrap()])
+    }
+
+    /// Returns the division of `a` and `b`
+    fn div(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        <Self as IsField>::mul(a, &Self::inv(b).unwrap())
+    }
+
+    /// Returns a boolean indicating whether `a` and `b` are equal component wise.
+    fn eq(a: &Self::BaseType, b: &Self::BaseType) -> bool {
+        a[0] == b[0] && a[1] == b[1]
+    }
+
+    /// Returns the additive neutral element of the field extension.
+    fn zero() -> Self::BaseType {
+        [FieldElement::zero(), FieldElement::zero()]
+    }
+
+    /// Returns the multiplicative neutral element of the field extension.
+    fn one() -> Self::BaseType {
+        [FieldElement::one(), FieldElement::zero()]
+    }
+
+    /// Returns the element `x * 1` where 1 is the multiplicative neutral element.
+    fn from_u64(x: u64) -> Self::BaseType {
+        [FieldElement::from(x), FieldElement::zero()]
+    }
+
+    /// Takes as input an element of BaseType and returns the internal representation
+    /// of that element in the field.
+    /// Note: for this case this is simply the identity, because the components
+    /// already have correct representations.
+    fn from_base_type(x: Self::BaseType) -> Self::BaseType {
+        x
+    }
+}
+
+impl IsSubFieldOf<Degree12ExtensionField> for Degree6ExtensionField {
+
+    fn mul(
+        a: &Self::BaseType,
+        b: &<Degree12ExtensionField as IsField>::BaseType,
+    ) -> <Degree12ExtensionField as IsField>::BaseType {
+        let c0 = FieldElement::from_raw(<Self as IsField>::mul(a, b[0].value()));
+        let c1 = FieldElement::from_raw(<Self as IsField>::mul(a, b[1].value()));
+        [c0, c1]
+    }
+
+    fn add(
+        a: &Self::BaseType,
+        b: &<Degree12ExtensionField as IsField>::BaseType,
+    ) -> <Degree12ExtensionField as IsField>::BaseType {
+        let c0 = FieldElement::from_raw(<Self as IsField>::add(a, b[0].value()));
+        let c1 = FieldElement::from_raw(b[1].value().clone());
+        [c0, c1]
+    }
+
+    fn div(
+        a: &Self::BaseType,
+        b: &<Degree12ExtensionField as IsField>::BaseType,
+    ) -> <Degree12ExtensionField as IsField>::BaseType {
+        let b_inv = Degree12ExtensionField::inv(b).unwrap();
+        <Self as IsSubFieldOf<Degree12ExtensionField>>::mul(a, &b_inv)
+    }
+
+    fn sub(
+        a: &Self::BaseType,
+        b: &<Degree12ExtensionField as IsField>::BaseType,
+    ) -> <Degree12ExtensionField as IsField>::BaseType {
+        let c0 = FieldElement::from_raw(<Self as IsField>::sub(a, b[0].value()));
+        let c1 = FieldElement::from_raw(<Self as IsField>::neg(b[1].value()));
+        [c0, c1]
+    }
+
+    fn embed(a: Self::BaseType) -> <Degree12ExtensionField as IsField>::BaseType {
+        [FieldElement::from_raw(a), FieldElement::zero()]
+    }
+
+    #[cfg(feature = "alloc")]
+    fn to_subfield_vec(
+        b: <Degree12ExtensionField as IsField>::BaseType,
+    ) -> alloc::vec::Vec<Self::BaseType> {
+        b.into_iter().map(|x| x.to_raw()).collect()
+    }
+}
 
 impl FieldElement<BN254PrimeField> {
     pub fn new_base(a_hex: &str) -> Self {
         Self::new(U256::from(a_hex))
     }
 }
+
 
 impl FieldElement<Degree2ExtensionField> {
     pub fn new_base(a_hex: &str) -> Self {
@@ -286,6 +436,10 @@ impl FieldElement<Degree12ExtensionField> {
             FieldElement::zero(),
         ])
     }
+    pub fn conjugate(&self) -> Self {
+        let [a, b] = self.value();
+        Self::new([a.clone(), -b])
+    }
 
     pub fn from_coefficients(coefficients: &[&str; 12]) -> Self {
         FieldElement::<Degree12ExtensionField>::new([
@@ -320,6 +474,7 @@ impl FieldElement<Degree12ExtensionField> {
         ])
     }
 }
+
 
 #[cfg(test)]
 mod tests {

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/field_extension.rs
@@ -25,8 +25,9 @@ impl IsModulus<U256> for BN254FieldModulus {
 
 pub type BN254PrimeField = MontgomeryBackendPrimeField<BN254FieldModulus, 4>;
 
-/// We define Fp2E = Fp [u] / (u^2 + 1)/// We could define it using the quadratic extension of
-/// lambdaworks, but we can optimize its operations in this way.
+/// We define Fp2E = Fp [u] / (u^2 + 1)
+/// We could define it using the quadratic extension of lambdaworks, but we can optimize its operations
+/// using these algorithms.
 #[derive(Clone, Debug)]
 pub struct Degree2ExtensionField;
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/field_extension.rs
@@ -39,10 +39,11 @@ impl IsField for Degree2ExtensionField {
     fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         let a0b0 = &a[0] * &b[0];
         let a1b1 = &a[1] * &b[1];
-        let z = (&a[0] + &a[1]) * (&b[0] + &b[1]);
-        [&a0b0 - &a1b1, z - a0b0 - a1b1]
+        let sum_a = &a[0] + &a[1];
+        let sum_b = &b[0] + &b[1];
+        let z = &sum_a * &sum_b;
+        [&a0b0 - &a1b1, z - &a0b0 - &a1b1]
     }
-
     fn square(a: &Self::BaseType) -> Self::BaseType {
         let [a0, a1] = a;
         let v0 = a0 * a1;
@@ -66,6 +67,7 @@ impl IsField for Degree2ExtensionField {
         let inv_norm = (a[0].pow(2_u64) + a[1].pow(2_u64)).inv()?;
         Ok([&a[0] * &inv_norm, -&a[1] * inv_norm])
     }
+    
 
     /// Returns the division of `a` and `b`
     fn div(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
@@ -239,166 +241,13 @@ impl HasQuadraticNonResidue<Degree6ExtensionField> for LevelThreeResidue {
     }
 }
 
-pub type FpE = FieldElement<BN254PrimeField>;
-pub type Fp6E = FieldElement<Degree6ExtensionField>;
-
-// 0 + 1 * v + 0 * v^2 in Fp6
-pub const V: Fp6E = Fp6E::const_from_raw([
-    Fp2E::const_from_raw([FpE::from_hex_unchecked("0"), FpE::from_hex_unchecked("0")]), 
-    Fp2E::const_from_raw([FpE::from_hex_unchecked("0"), FpE::from_hex_unchecked("0")]),  
-    Fp2E::const_from_raw([FpE::from_hex_unchecked("0"), FpE::from_hex_unchecked("0")])
-]);
-
-#[derive(Clone, Debug)]
-pub struct Degree12ExtensionField;
-
-/// Optimal algorithms from
-/// https://hackmd.io/@Wimet/ry7z1Xj-2#Fp12-Arithmetic
-impl IsField for Degree12ExtensionField {
-    type BaseType = [FieldElement<Degree6ExtensionField>; 2];
-
-    fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
-        [&a[0] + &b[0], &a[1] + &b[1]]
-    }
-
-    // INPUT: (a = a0 + a1 * w),(b = b0 + b1 * w) in Fp12, where ai,bi in Fp6
-    // OUTPUT: (c0 + c1 * w) = a * b in Fp12
-    // c0 = a0 * b0 + a1 * b1 * v where
-    // c1 = (a0+a1)*(b0+b1) - a0*b0 - a1*b1
-    fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
-        let a0 = &a[0];
-        let a1 = &a[1];
-        let b0 = &b[0];
-        let b1 = &b[1];
-        [a0 * b0 + a1 * b1 * V,
-        (a0 + a1) * (b0 * b1) - a0 * b0 - a1 * b1]
-    }
-
-    fn square(a: &Self::BaseType) -> Self::BaseType {
-        let a0 = &a[0];
-        let a1 = &a[1];
-        let a0_squared = a0 * a0;
-        let a1_squared = a1 * a1;
-        
-        [
-            &a0_squared + &(&a1_squared * V),
-            a0 * a1 + a0 * a1
-        ]
-    }
-
-    /// INPUT: (a = a0 + a1*w),(b = b0 + b1*w) in Fp12, where ai,bi in Fp6
-    /// OUTPUT: (c0 + c1*w) = a - b in Fp12
-    /// c0 = a0 - b0
-    /// c1 = a1 - b1
-    fn sub(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType{
-        [&a[0] - &b[0], &a[1] - &b[1]]
-    }
-
-    /// Returns the component wise negation of `a`
-    fn neg(a: &Self::BaseType) -> Self::BaseType {
-        [-&a[0], -&a[1]]
-    }
-
-    /// c0 = a0*(a0^2 - a1^2*v)^{-1}
-    /// c1 = -a1*(a0^2 - a1^2*v)^{-1}
-    fn inv(a: &Self::BaseType) -> Result<Self::BaseType, FieldError> {
-        let a0 = &a[0];
-        let a1 = &a[1];
-        Ok([a0 * (a0.square() - a1.square() * V).inv().unwrap(), -a1 * (a0.square() - a1.square()).inv().unwrap()])
-    }
-
-    /// Returns the division of `a` and `b`
-    fn div(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
-        <Self as IsField>::mul(a, &Self::inv(b).unwrap())
-    }
-
-    /// Returns a boolean indicating whether `a` and `b` are equal component wise.
-    fn eq(a: &Self::BaseType, b: &Self::BaseType) -> bool {
-        a[0] == b[0] && a[1] == b[1]
-    }
-
-    /// Returns the additive neutral element of the field extension.
-    fn zero() -> Self::BaseType {
-        [FieldElement::zero(), FieldElement::zero()]
-    }
-
-    /// Returns the multiplicative neutral element of the field extension.
-    fn one() -> Self::BaseType {
-        [FieldElement::one(), FieldElement::zero()]
-    }
-
-    /// Returns the element `x * 1` where 1 is the multiplicative neutral element.
-    fn from_u64(x: u64) -> Self::BaseType {
-        [FieldElement::from(x), FieldElement::zero()]
-    }
-
-    /// Takes as input an element of BaseType and returns the internal representation
-    /// of that element in the field.
-    /// Note: for this case this is simply the identity, because the components
-    /// already have correct representations.
-    fn from_base_type(x: Self::BaseType) -> Self::BaseType {
-        x
-    }
-}
-
-impl IsSubFieldOf<Degree12ExtensionField> for Degree6ExtensionField {
-
-    fn mul(
-        a: &Self::BaseType,
-        b: &<Degree12ExtensionField as IsField>::BaseType,
-    ) -> <Degree12ExtensionField as IsField>::BaseType {
-        let c0 = FieldElement::from_raw(<Self as IsField>::mul(a, b[0].value()));
-        let c1 = FieldElement::from_raw(<Self as IsField>::mul(a, b[1].value()));
-        [c0, c1]
-    }
-
-    fn add(
-        a: &Self::BaseType,
-        b: &<Degree12ExtensionField as IsField>::BaseType,
-    ) -> <Degree12ExtensionField as IsField>::BaseType {
-        let c0 = FieldElement::from_raw(<Self as IsField>::add(a, b[0].value()));
-        let c1 = FieldElement::from_raw(b[1].value().clone());
-        [c0, c1]
-    }
-
-    fn div(
-        a: &Self::BaseType,
-        b: &<Degree12ExtensionField as IsField>::BaseType,
-    ) -> <Degree12ExtensionField as IsField>::BaseType {
-        let b_inv = Degree12ExtensionField::inv(b).unwrap();
-        <Self as IsSubFieldOf<Degree12ExtensionField>>::mul(a, &b_inv)
-    }
-
-    fn sub(
-        a: &Self::BaseType,
-        b: &<Degree12ExtensionField as IsField>::BaseType,
-    ) -> <Degree12ExtensionField as IsField>::BaseType {
-        let c0 = FieldElement::from_raw(<Self as IsField>::sub(a, b[0].value()));
-        let c1 = FieldElement::from_raw(<Self as IsField>::neg(b[1].value()));
-        [c0, c1]
-    }
-
-    fn embed(a: Self::BaseType) -> <Degree12ExtensionField as IsField>::BaseType {
-        [FieldElement::from_raw(a), FieldElement::zero()]
-    }
-
-    #[cfg(feature = "alloc")]
-    fn to_subfield_vec(
-        b: <Degree12ExtensionField as IsField>::BaseType,
-    ) -> alloc::vec::Vec<Self::BaseType> {
-        b.into_iter().map(|x| x.to_raw()).collect()
-    }
-}
-
-
-type BaseType = [FieldElement<BN254PrimeField>; 2];
+pub type Degree12ExtensionField = QuadraticExtensionField<Degree6ExtensionField, LevelThreeResidue>;
 
 impl FieldElement<BN254PrimeField> {
     pub fn new_base(a_hex: &str) -> Self {
         Self::new(U256::from(a_hex))
     }
 }
-
 
 impl FieldElement<Degree2ExtensionField> {
     pub fn new_base(a_hex: &str) -> Self {
@@ -437,10 +286,6 @@ impl FieldElement<Degree12ExtensionField> {
             FieldElement::zero(),
         ])
     }
-    pub fn conjugate(&self) -> Self {
-        let [a, b] = self.value();
-        Self::new([a.clone(), -b])
-    }
 
     pub fn from_coefficients(coefficients: &[&str; 12]) -> Self {
         FieldElement::<Degree12ExtensionField>::new([
@@ -475,7 +320,6 @@ impl FieldElement<Degree12ExtensionField> {
         ])
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
@@ -27,6 +27,13 @@ type Fp12E = FieldElement<Degree12ExtensionField>;
 type G1Point = ShortWeierstrassProjectivePoint<BN254Curve>;
 type G2Point = ShortWeierstrassProjectivePoint<BN254TwistCurve>;
 
+/// You can find an explanation of the next implemetation in our post
+/// https://blog.lambdaclass.com/how-we-implemented-the-bn254-ate-pairing-in-lambdaworks/
+/// There you'll come across a path to understand the naive implementation of the pairing
+/// using the functions miller_naive() and final_exponentiation_naive().
+/// We then optimized the pairing using the functions miller_optimized() and final_exponentiation_optimized().
+/// You'll find both the naive and optimized versions below.
+
 ////////////////// CONSTANTS //////////////////
 
 /// x = 4965661367192848881.

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
@@ -18,6 +18,7 @@ use crate::{
     },
     field::element::FieldElement,
 };
+use std::time::{Duration, Instant};
 
 use rayon::prelude::*;
 
@@ -189,7 +190,7 @@ pub fn miller(p: &G1Point, q: &G2Point) -> Fp12E {
     f
 }
 
-fn miller_2(p: &G1Point, q: &G2Point) -> Fp12E {
+pub fn miller_2(p: &G1Point, q: &G2Point) -> Fp12E {
     let mut t = q.clone();
     let mut f = Fp12E::one();
     let q_neg = &q.neg();
@@ -724,7 +725,7 @@ fn cyclotomic_pow_x(f: Fp12E) -> Fp12E {
 
 }
 */
-
+/*
 fn cyclotomic_pow_x(f: Fp12E) -> Fp12E {
     if f == Fp12E::one() {
         Fp12E::one()
@@ -739,6 +740,31 @@ fn cyclotomic_pow_x(f: Fp12E) -> Fp12E {
             c = compressed_square(c);
             x >>= 1;
         }
+        result
+    }
+}
+*/
+
+fn cyclotomic_pow_x(f: Fp12E) -> Fp12E {
+    let start = Instant::now();
+    if f == Fp12E::one() {
+        let duration = start.elapsed(); //
+        println!("Duration for one-element case: {:?}", duration);
+        Fp12E::one()
+    } else {
+        let mut c = compress(&f);
+        let mut result = Fp12E::one();
+        let mut x = X;
+        while x > 0 {
+            if x & 1 == 1 {
+                result *= &decompress(&c);
+            }
+            c = compressed_square(c);
+            x >>= 1;
+        }
+
+        let duration = start.elapsed();
+        println!("Duration for computation: {:?}", duration);
         result
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
@@ -154,7 +154,7 @@ impl IsPairing for BN254AtePairing {
             .reduce(|acc, x| acc * x)
             .unwrap_or(Fp12E::one());
 
-        Ok(final_exponentiation(&combined))
+        Ok(final_exponentiation_2(&combined))
     }
 }
 
@@ -324,7 +324,6 @@ fn line(p: &G1Point, t: &G2Point, q: &G2Point) -> Fp12E {
     }
 }
 
-/*
 /// Computes f ^ {(p^12 - 1) / r}
 /// using that (p^12 - 1)/r = (p^6 - 1) * (p^2 + 1) * (p^4 - p^2 + 1)/r.
 /// Algorithm taken from https://hackmd.io/@Wimet/ry7z1Xj-2#Final-Exponentiation.
@@ -334,7 +333,7 @@ pub fn final_exponentiation(
     // Easy part:
     // Computes f ^ {(p^6 - 1) * (p^2 + 1)}
     let f_easy_aux = f.conjugate() * f.inv().unwrap(); // f ^ (p^6 - 1) because f^(p^6) = f.conjugate().
-    let f_easy = &frobenius_square(&f_easy_aux) * f_easy_aux; // (f^{p^6 - 1})^(p^2) * (f^{p^6 - 1}).
+    let mut f_easy = &frobenius_square(&f_easy_aux) * f_easy_aux; // (f^{p^6 - 1})^(p^2) * (f^{p^6 - 1}).
 
     /*
     // Hard part:
@@ -368,7 +367,6 @@ pub fn final_exponentiation(
         * y6.pow(36usize)
     */
 
-    /*
     // Hard part following Arkworks library.
     let mut y0 = f_easy.pow(X);
     y0 = y0.inv().unwrap();
@@ -400,8 +398,8 @@ pub fn final_exponentiation(
     y15 = frobenius_cube(&y15);
     let y16 = y15 * y14;
     y16
-    */
 
+    /*
     // Optimal hard part from the post
     // https://hackmd.io/@Wimet/ry7z1Xj-2#The-Hard-Part
     let mx = cyclotomic_pow_x(f_easy.clone());
@@ -433,11 +431,10 @@ pub fn final_exponentiation(
     let t04 = cyclotimic_square(&t03) * t14;
 
     t04
+    */
 }
 
-*/
-
-pub fn final_exponentiation(
+pub fn final_exponentiation_2(
     f: &FieldElement<Degree12ExtensionField>,
 ) -> FieldElement<Degree12ExtensionField> {
     // Easy part:
@@ -725,7 +722,7 @@ fn cyclotomic_pow_x(f: Fp12E) -> Fp12E {
 
 }
 */
-/*
+
 fn cyclotomic_pow_x(f: Fp12E) -> Fp12E {
     if f == Fp12E::one() {
         Fp12E::one()
@@ -743,8 +740,8 @@ fn cyclotomic_pow_x(f: Fp12E) -> Fp12E {
         result
     }
 }
-*/
 
+/*
 fn cyclotomic_pow_x(f: Fp12E) -> Fp12E {
     let start = Instant::now();
     if f == Fp12E::one() {
@@ -768,6 +765,7 @@ fn cyclotomic_pow_x(f: Fp12E) -> Fp12E {
         result
     }
 }
+*/
 
 /*
 fn cyclotomic_pow_x(f: Fp12E) -> Fp12E {


### PR DESCRIPTION
# BN254 optimization 

## Description

This PR improves the paring performance by using optimized operations used in key functions.
Also it incorporates benches for the BN254.

There is still room for improvement optimizng the Miller loop and the operations for Fp6 and Fp12


Optimized algorithms:

- ``Line`` 
- ``final exponentiation`` 
    - ```cyclotomic_square```
  - ``cyclotomic_pow``

- ``Fp2 operations``


## Type of change
- [ ] Optimization

## Benches
- Actual
  ```Ate pairing``` : 1.6898 ms 
  ```Miller loop``` : 540.37 µs
  ```Final exponentiation```: 771.49 µs

- New version
  ```Ate pairing``` :939.71 µs 
  ```Miller loop``` : 375.96 µs
  ```Final exponentiation```: 347.71 µs
