### PR TITLE
Compression for BLS12381

### DIFF
--- a/math/benches/elliptic_curves/bls12_381.rs
+++ b/math/benches/elliptic_curves/bls12_381.rs
@@ -2,16 +2,19 @@ use criterion::{black_box, Criterion};
 use lambdaworks_math::{
     cyclic_group::IsGroup,
     elliptic_curve::{
-        short_weierstrass::curves::bls12_381::{
-            compression::{compress_g1_point, decompress_g1_point},
-            curve::BLS12381Curve,
-            pairing::BLS12381AtePairing,
-            twist::BLS12381TwistCurve,
+        short_weierstrass::{
+            curves::bls12_381::{
+                curve::BLS12381Curve, pairing::BLS12381AtePairing, twist::BLS12381TwistCurve,
+            },
+            point::ShortWeierstrassProjectivePoint,
+            traits::Compress,
         },
         traits::{IsEllipticCurve, IsPairing},
     },
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
+
+pub type G1Point = ShortWeierstrassProjectivePoint<BLS12381Curve>;
 
 #[allow(dead_code)]
 pub fn bls12_381_elliptic_curve_benchmarks(c: &mut Criterion) {
@@ -70,13 +73,13 @@ pub fn bls12_381_elliptic_curve_benchmarks(c: &mut Criterion) {
 
     // Compress_G1_point
     group.bench_function("Compress G1 point", |bencher| {
-        bencher.iter(|| black_box(compress_g1_point(black_box(&a_g1))));
+        bencher.iter(|| black_box(G1Point::compress_g1_point(black_box(&a_g1))));
     });
 
     // Decompress_G1_point
     group.bench_function("Decompress G1 Point", |bencher| {
-        let a: [u8; 48] = compress_g1_point(&a_g1).try_into().unwrap();
-        bencher.iter(|| black_box(decompress_g1_point(&mut black_box(a))).unwrap());
+        let a: [u8; 48] = G1Point::compress_g1_point(&a_g1).try_into().unwrap();
+        bencher.iter(|| black_box(G1Point::decompress_g1_point(&mut black_box(a))).unwrap());
     });
 
     // Subgroup Check G1

--- a/math/benches/elliptic_curves/iai_bls12_381.rs
+++ b/math/benches/elliptic_curves/iai_bls12_381.rs
@@ -4,16 +4,17 @@ use lambdaworks_math::{
     elliptic_curve::{
         short_weierstrass::{
             curves::bls12_381::{
-                compression::{compress_g1_point, decompress_g1_point},
-                curve::BLS12381Curve,
-                pairing::BLS12381AtePairing,
-                twist::BLS12381TwistCurve,
+                curve::BLS12381Curve, pairing::BLS12381AtePairing, twist::BLS12381TwistCurve,
             },
             point::ShortWeierstrassProjectivePoint,
+            traits::Compress,
         },
         traits::{IsEllipticCurve, IsPairing},
     },
 };
+
+pub type G1Point = ShortWeierstrassProjectivePoint<BLS12381Curve>;
+
 use rand::{rngs::StdRng, Rng, SeedableRng};
 #[allow(dead_code)]
 type G1 = ShortWeierstrassProjectivePoint<BLS12381Curve>;
@@ -91,14 +92,14 @@ pub fn bls12_381_neg_g2() {
 #[allow(dead_code)]
 pub fn bls12_381_compress_g1() {
     let (a, _, _, _) = rand_points_g1();
-    let _ = black_box(compress_g1_point(black_box(&a)));
+    let _ = black_box(G1Point::compress_g1_point(black_box(&a)));
 }
 
 #[allow(dead_code)]
 pub fn bls12_381_decompress_g1() {
     let (a, _, _, _) = rand_points_g1();
-    let a: [u8; 48] = compress_g1_point(&a).try_into().unwrap();
-    let _ = black_box(decompress_g1_point(&mut black_box(a))).unwrap();
+    let a: [u8; 48] = G1Point::compress_g1_point(&a).try_into().unwrap();
+    let _ = black_box(G1Point::decompress_g1_point(&mut black_box(a))).unwrap();
 }
 
 #[allow(dead_code)]

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
@@ -19,8 +19,8 @@ use crate::{
     traits::ByteConversion,
 };
 
-pub type G1Point = ShortWeierstrassProjectivePoint<BLS12381Curve>;
-pub type BLS12381FieldElement = FieldElement<BLS12381PrimeField>;
+type G1Point = ShortWeierstrassProjectivePoint<BLS12381Curve>;
+type BLS12381FieldElement = FieldElement<BLS12381PrimeField>;
 
 impl Compress for G1Point {
     type G1Point = G1Point;

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
@@ -1,7 +1,11 @@
-use super::field_extension::BLS12381PrimeField;
+use super::{field_extension::BLS12381PrimeField, twist::BLS12381TwistCurve};
 use crate::{
-    elliptic_curve::short_weierstrass::{
-        curves::bls12_381::curve::BLS12381Curve, point::ShortWeierstrassProjectivePoint,
+    elliptic_curve::{
+        short_weierstrass::{
+            curves::bls12_381::curve::BLS12381Curve, point::ShortWeierstrassProjectivePoint,
+            traits::Compress,
+        },
+        traits::IsEllipticCurve,
     },
     field::element::FieldElement,
 };
@@ -15,80 +19,93 @@ use crate::{
 pub type G1Point = ShortWeierstrassProjectivePoint<BLS12381Curve>;
 pub type BLS12381FieldElement = FieldElement<BLS12381PrimeField>;
 
-pub fn decompress_g1_point(input_bytes: &mut [u8; 48]) -> Result<G1Point, ByteConversionError> {
-    let first_byte = input_bytes.first().unwrap();
-    // We get the 3 most significant bits
-    let prefix_bits = first_byte >> 5;
-    let first_bit = (prefix_bits & 4_u8) >> 2;
-    // If first bit is not 1, then the value is not compressed.
-    if first_bit != 1 {
-        return Err(ByteConversionError::ValueNotCompressed);
-    }
-    let second_bit = (prefix_bits & 2_u8) >> 1;
-    // If the second bit is 1, then the compressed point is the
-    // point at infinity and we return it directly.
-    if second_bit == 1 {
-        return Ok(G1Point::neutral_element());
-    }
-    let third_bit = prefix_bits & 1_u8;
+impl Compress for G1Point {
+    type G1Point = G1Point;
 
-    let first_byte_without_control_bits = (first_byte << 3) >> 3;
-    input_bytes[0] = first_byte_without_control_bits;
+    type G2Point = <BLS12381TwistCurve as IsEllipticCurve>::PointRepresentation;
 
-    let x = BLS12381FieldElement::from_bytes_be(input_bytes)?;
+    type Error = ByteConversionError;
 
-    // We apply the elliptic curve formula to know the y^2 value.
-    let y_squared = x.pow(3_u16) + BLS12381FieldElement::from(4);
+    #[cfg(feature = "alloc")]
+    fn compress_g1_point(point: &Self::G1Point) -> alloc::vec::Vec<u8> {
+        if *point == G1Point::neutral_element() {
+            // point is at infinity
+            let mut x_bytes = alloc::vec![0_u8; 48];
+            x_bytes[0] |= 1 << 7;
+            x_bytes[0] |= 1 << 6;
+            x_bytes
+        } else {
+            // point is not at infinity
+            let point_affine = point.to_affine();
+            let x = point_affine.x();
+            let y = point_affine.y();
 
-    let (y_sqrt_1, y_sqrt_2) = &y_squared.sqrt().ok_or(ByteConversionError::InvalidValue)?;
+            let mut x_bytes = x.to_bytes_be();
 
-    // we call "negative" to the greate root,
-    // if the third bit is 1, we take this grater value.
-    // Otherwise, we take the second one.
-    let y = match (
-        y_sqrt_1.representative().cmp(&y_sqrt_2.representative()),
-        third_bit,
-    ) {
-        (Ordering::Greater, 0) => y_sqrt_2,
-        (Ordering::Greater, _) => y_sqrt_1,
-        (Ordering::Less, 0) => y_sqrt_1,
-        (Ordering::Less, _) => y_sqrt_2,
-        (Ordering::Equal, _) => y_sqrt_1,
-    };
+            // Set first bit to to 1 indicate this is compressed element.
+            x_bytes[0] |= 1 << 7;
 
-    let point =
-        G1Point::from_affine(x, y.clone()).map_err(|_| ByteConversionError::InvalidValue)?;
-
-    point
-        .is_in_subgroup()
-        .then_some(point)
-        .ok_or(ByteConversionError::PointNotInSubgroup)
-}
-
-#[cfg(feature = "alloc")]
-pub fn compress_g1_point(point: &G1Point) -> alloc::vec::Vec<u8> {
-    if *point == G1Point::neutral_element() {
-        // point is at infinity
-        let mut x_bytes = alloc::vec![0_u8; 48];
-        x_bytes[0] |= 1 << 7;
-        x_bytes[0] |= 1 << 6;
-        x_bytes
-    } else {
-        // point is not at infinity
-        let point_affine = point.to_affine();
-        let x = point_affine.x();
-        let y = point_affine.y();
-
-        let mut x_bytes = x.to_bytes_be();
-
-        // Set first bit to to 1 indicate this is compressed element.
-        x_bytes[0] |= 1 << 7;
-
-        let y_neg = core::ops::Neg::neg(y);
-        if y_neg.representative() < y.representative() {
-            x_bytes[0] |= 1 << 5;
+            let y_neg = core::ops::Neg::neg(y);
+            if y_neg.representative() < y.representative() {
+                x_bytes[0] |= 1 << 5;
+            }
+            x_bytes
         }
-        x_bytes
+    }
+
+    fn decompress_g1_point(input_bytes: &mut [u8; 48]) -> Result<Self::G1Point, Self::Error> {
+        let first_byte = input_bytes.first().unwrap();
+        // We get the 3 most significant bits
+        let prefix_bits = first_byte >> 5;
+        let first_bit = (prefix_bits & 4_u8) >> 2;
+        // If first bit is not 1, then the value is not compressed.
+        if first_bit != 1 {
+            return Err(ByteConversionError::ValueNotCompressed);
+        }
+        let second_bit = (prefix_bits & 2_u8) >> 1;
+        // If the second bit is 1, then the compressed point is the
+        // point at infinity and we return it directly.
+        if second_bit == 1 {
+            return Ok(G1Point::neutral_element());
+        }
+        let third_bit = prefix_bits & 1_u8;
+
+        let first_byte_without_control_bits = (first_byte << 3) >> 3;
+        input_bytes[0] = first_byte_without_control_bits;
+
+        let x = BLS12381FieldElement::from_bytes_be(input_bytes)?;
+
+        // We apply the elliptic curve formula to know the y^2 value.
+        let y_squared = x.pow(3_u16) + BLS12381FieldElement::from(4);
+
+        let (y_sqrt_1, y_sqrt_2) = &y_squared.sqrt().ok_or(ByteConversionError::InvalidValue)?;
+
+        // we call "negative" to the greate root,
+        // if the third bit is 1, we take this grater value.
+        // Otherwise, we take the second one.
+        let y = match (
+            y_sqrt_1.representative().cmp(&y_sqrt_2.representative()),
+            third_bit,
+        ) {
+            (Ordering::Greater, 0) => y_sqrt_2,
+            (Ordering::Greater, _) => y_sqrt_1,
+            (Ordering::Less, 0) => y_sqrt_1,
+            (Ordering::Less, _) => y_sqrt_2,
+            (Ordering::Equal, _) => y_sqrt_1,
+        };
+
+        let point =
+            G1Point::from_affine(x, y.clone()).map_err(|_| ByteConversionError::InvalidValue)?;
+
+        point
+            .is_in_subgroup()
+            .then_some(point)
+            .ok_or(ByteConversionError::PointNotInSubgroup)
+    }
+
+    #[allow(unused)]
+    fn decompress_g2_point(input_bytes: &mut [u8; 96]) -> Result<Self::G2Point, Self::Error> {
+        todo!()
     }
 }
 
@@ -96,11 +113,10 @@ pub fn compress_g1_point(point: &G1Point) -> alloc::vec::Vec<u8> {
 mod tests {
     use super::{BLS12381FieldElement, G1Point};
     use crate::elliptic_curve::short_weierstrass::curves::bls12_381::curve::BLS12381Curve;
+    use crate::elliptic_curve::short_weierstrass::traits::Compress;
     use crate::elliptic_curve::traits::{FromAffine, IsEllipticCurve};
 
     #[cfg(feature = "alloc")]
-    use super::compress_g1_point;
-    use super::decompress_g1_point;
     use crate::{
         cyclic_group::IsGroup, traits::ByteConversion, unsigned_integer::element::UnsignedInteger,
     };
@@ -121,8 +137,10 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn test_g1_compress_generator() {
+        use crate::elliptic_curve::short_weierstrass::traits::Compress;
+
         let g = BLS12381Curve::generator();
-        let mut compressed_g = compress_g1_point(&g);
+        let mut compressed_g = G1Point::compress_g1_point(&g);
         let first_byte = compressed_g.first().unwrap();
 
         let first_byte_without_control_bits = (first_byte << 3) >> 3;
@@ -137,8 +155,10 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn test_g1_compress_point_at_inf() {
+        use crate::elliptic_curve::short_weierstrass::traits::Compress;
+
         let inf = G1Point::neutral_element();
-        let compressed_inf = compress_g1_point(&inf);
+        let compressed_inf = G1Point::compress_g1_point(&inf);
         let first_byte = compressed_inf.first().unwrap();
 
         assert_eq!(*first_byte >> 6, 3_u8);
@@ -147,11 +167,13 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn test_compress_decompress_generator() {
+        use crate::elliptic_curve::short_weierstrass::traits::Compress;
+
         let g = BLS12381Curve::generator();
-        let compressed_g = compress_g1_point(&g);
+        let compressed_g = G1Point::compress_g1_point(&g);
         let mut compressed_g_slice: [u8; 48] = compressed_g.try_into().unwrap();
 
-        let decompressed_g = decompress_g1_point(&mut compressed_g_slice).unwrap();
+        let decompressed_g = G1Point::decompress_g1_point(&mut compressed_g_slice).unwrap();
 
         assert_eq!(g, decompressed_g);
     }
@@ -163,10 +185,10 @@ mod tests {
         // calculate g point operate with itself
         let g_2 = g.operate_with_self(UnsignedInteger::<4>::from("2"));
 
-        let compressed_g2 = compress_g1_point(&g_2);
+        let compressed_g2 = G1Point::compress_g1_point(&g_2);
         let mut compressed_g2_slice: [u8; 48] = compressed_g2.try_into().unwrap();
 
-        let decompressed_g2 = decompress_g1_point(&mut compressed_g2_slice).unwrap();
+        let decompressed_g2 = G1Point::decompress_g1_point(&mut compressed_g2_slice).unwrap();
 
         assert_eq!(g_2, decompressed_g2);
     }

--- a/math/src/elliptic_curve/short_weierstrass/traits.rs
+++ b/math/src/elliptic_curve/short_weierstrass/traits.rs
@@ -1,3 +1,4 @@
+use crate::cyclic_group::IsGroup;
 use crate::elliptic_curve::traits::IsEllipticCurve;
 use crate::field::element::FieldElement;
 use core::fmt::Debug;
@@ -17,4 +18,16 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
     ) -> FieldElement<Self::BaseField> {
         y.pow(2_u16) - x.pow(3_u16) - Self::a() * x - Self::b()
     }
+}
+
+pub trait Compress {
+    type G1Point: IsGroup;
+    type G2Point: IsGroup;
+    type Error;
+
+    fn compress_g1_point(point: &Self::G1Point) -> Vec<u8>;
+
+    fn decompress_g1_point(input_bytes: &mut [u8; 48]) -> Result<Self::G1Point, Self::Error>;
+
+    fn decompress_g2_point(input_bytes: &mut [u8; 96]) -> Result<Self::G2Point, Self::Error>;
 }

--- a/math/src/elliptic_curve/short_weierstrass/traits.rs
+++ b/math/src/elliptic_curve/short_weierstrass/traits.rs
@@ -25,7 +25,7 @@ pub trait Compress {
     type G2Point: IsGroup;
     type Error;
 
-    fn compress_g1_point(point: &Self::G1Point) -> Vec<u8>;
+    fn compress_g1_point(point: &Self::G1Point) -> alloc::vec::Vec<u8>;
 
     fn decompress_g1_point(input_bytes: &mut [u8; 48]) -> Result<Self::G1Point, Self::Error>;
 

--- a/math/src/elliptic_curve/short_weierstrass/traits.rs
+++ b/math/src/elliptic_curve/short_weierstrass/traits.rs
@@ -25,6 +25,7 @@ pub trait Compress {
     type G2Point: IsGroup;
     type Error;
 
+    #[cfg(feature = "alloc")]
     fn compress_g1_point(point: &Self::G1Point) -> alloc::vec::Vec<u8>;
 
     fn decompress_g1_point(input_bytes: &mut [u8; 48]) -> Result<Self::G1Point, Self::Error>;


### PR DESCRIPTION
# Port compression for BLS12381

## Description

Port compression for Short Weierstrass from [lambdaworks_kzg](https://github.com/lambdaclass/lambdaworks_kzg/tree/main).

The motivation for this PR is to introduce missing compression functionality for `ShortWeierstrassProjectivePoint<BLS12381Curve>`, specifically, decompression for G1 and G2 points.

The changes included are:

- Introduce the `Compress` trait, which defines compression and decompression for G1, and decompression for G2.
- Implement the `Compress` trait for `ShortWeierstrassProjectivePoint<BLS12381Curve>`.
- Adapt tests that used the previous implementation for G1 compression.

## Type of change

- [x] New feature
- [x] Refactor

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
