### PR TITLE
Fix: STARK prover expression bug

### DIFF
--- a/docs/src/starks/protocol.md
+++ b/docs/src/starks/protocol.md
@@ -141,7 +141,7 @@ As we mentioned in the [protocol overview](protocol_overview.html#batch). When c
   - Compute $\text{Open}(t_j(D_{\text{LDE}}), \upsilon_s)$ and $\text{Open}(t_j(D_{\text{LDE}}), -\upsilon_s)$ for all $j=1,\dots, m$.
   - Compute $\text{Open}(H_1(D_{\text{LDE}}), \upsilon_s)$ and $\text{Open}(H_1(D_{\text{LDE}}), -\upsilon_s)$.
   - Compute $\text{Open}(H_2(D_{\text{LDE}}), \upsilon_s)$ and $\text{Open}(H_2(D_{\text{LDE}}), -\upsilon_s)$.
-  - Compute $\text{Open}(p_k(D_k), \upsilon_s^{2^k})$ and $\text{Open}(p_k(D_k), -\upsilon_s^{2^k})$ for all $k=1,\dots,n-1$.
+  - Compute $\text{Open}(p_k(D_k), -\upsilon_s^{2^k})$ for all $k=1,\dots,n-1$.
 
 #### Build proof
 
@@ -157,7 +157,6 @@ $$
 &\{\text{Open}(t_j(D_{\text{LDE}}), \upsilon_s): 0 \leq j< m, 0 \leq s < Q\}, \\
 &\{\text{Open}(H_1(D_{\text{LDE}}), \upsilon_s): 0 \leq s < Q\}, \\
 &\{\text{Open}(H_2(D_{\text{LDE}}), \upsilon_s): 0 \leq s < Q\}, \\
-&\{\text{Open}(p_k(D_k), \upsilon_s^{2^k}): 1\leq k< n, 0\leq s < Q\}, \\
 &\{\text{Open}(t_j(D_{\text{LDE}}), -\upsilon_s): 0 \leq j< m, 0 \leq s < Q\}, \\
 &\{\text{Open}(H_1(D_{\text{LDE}}), -\upsilon_s): 0 \leq s < Q\}, \\
 &\{\text{Open}(H_2(D_{\text{LDE}}), -\upsilon_s): 0 \leq s < Q\}, \\

--- a/provers/stark/src/prover.rs
+++ b/provers/stark/src/prover.rs
@@ -990,7 +990,7 @@ pub trait IsStarkProver<A: AIR> {
             fri_layers_merkle_roots: round_4_result.fri_layers_merkle_roots,
             // pₙ
             fri_last_value: round_4_result.fri_last_value,
-            // Open(p₀(D₀), 𝜐ₛ), Open(pₖ(Dₖ), −𝜐ₛ^(2ᵏ))
+            // Open(pₖ(Dₖ), −𝜐ₛ^(2ᵏ))
             query_list: round_4_result.query_list,
             // Open(H₁(D_LDE, 𝜐₀), Open(H₂(D_LDE, 𝜐₀), Open(tⱼ(D_LDE), 𝜐₀)
             // Open(H₁(D_LDE, -𝜐ᵢ), Open(H₂(D_LDE, -𝜐ᵢ), Open(tⱼ(D_LDE), -𝜐ᵢ)


### PR DESCRIPTION
# Optimizing Expressions in STARK Prover Documentation

## Description

There is no need to provide "Open(p₀(D₀), 𝜐ₛ)" and "Open(pₖ(Dₖ), 𝜐ₛ^(2ᵏ))" to the verifier, as it can derive them by itself.

## Type of change

- [x] Optimization

## Checklist
- Only modified markdown and comments, no need to test the code.
