### PR TITLE
ci: split coverage upload to a different job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,6 +136,7 @@ jobs:
   coverage:
     name: Upload Coverage to Codecov
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - uses: actions/checkout@v3
       - name: Fetch coverage data

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,6 +127,24 @@ jobs:
       - name: Run tests and generate code coverage
         run: make coverage
 
+      - name: Cache coverage data
+        uses: actions/cache/save@v4
+        with:
+          path: lcov.info
+          key: coverage-${{ github.sha }}
+
+  coverage:
+    name: Upload Coverage to Codecov
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Fetch coverage data
+        uses: actions/cache/restore@v4
+        with:
+          path: lcov.info
+          key: coverage-${{ github.sha }}
+          fail-on-cache-miss: true
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
Split coverage upload to a separate job.

Motivation:
- External contributors suffer from Codecov's rate limit, meaning we need
  to retry upload several times.
- Waiting for the whole test suite to run again each retry is impractical.

This split allows us to only trigger the upload and get instant
feedback.
