### PR TITLE
Polynomial: differentiate & print methods. 

### DIFF
--- a/math/src/polynomial/mod.rs
+++ b/math/src/polynomial/mod.rs
@@ -140,6 +140,19 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
         self.coefficients().len()
     }
 
+    /// Returns the derivative of the polynomial with respect to x.
+    pub fn differentiate(&self) -> Self {
+        let degree = self.degree();
+        if degree == 0 {
+            return Polynomial::zero();
+        }
+        let mut derivative = Vec::with_capacity(self.degree());
+        for (i, coeff) in self.coefficients().iter().enumerate().skip(1) {
+            derivative.push(FieldElement::<F>::from(i as u64) * coeff);
+        }
+        Polynomial::new(&derivative)
+    }
+
     /// Computes quotient with `x - b` in place.
     pub fn ruffini_division_inplace(&mut self, b: &FieldElement<F>) {
         let mut c = FieldElement::zero();
@@ -1176,5 +1189,20 @@ mod tests {
         assert_eq!(b, Polynomial::zero());
         assert_eq!(lhs, g);
         assert_eq!(g, p3);
+    }
+
+    #[test]
+    fn test_differentiate() {
+        // 3x^2 + 2x + 42
+        let px = Polynomial::new(&[FE::new(42), FE::new(2), FE::new(3)]);
+        // 6x + 2
+        let dpdx = px.differentiate();
+        assert_eq!(dpdx, Polynomial::new(&[FE::new(2), FE::new(6)]));
+
+        // 128
+        let px = Polynomial::new(&[FE::new(128)]);
+        // 0
+        let dpdx = px.differentiate();
+        assert_eq!(dpdx, Polynomial::new(&[FE::new(0)]));
     }
 }

--- a/math/src/polynomial/mod.rs
+++ b/math/src/polynomial/mod.rs
@@ -1,5 +1,5 @@
 use super::field::element::FieldElement;
-use crate::field::traits::{IsField, IsSubFieldOf};
+use crate::field::traits::{IsField, IsPrimeField, IsSubFieldOf};
 use alloc::{borrow::ToOwned, vec, vec::Vec};
 use core::{fmt::Display, ops};
 
@@ -312,6 +312,44 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
                 .map(|x| x.to_extension::<L>())
                 .collect(),
         }
+    }
+}
+
+impl<F: IsPrimeField> Polynomial<FieldElement<F>> {
+    // Print the polynomial as a string ready to be used in SageMath, or just for pretty printing.
+    pub fn print_as_sage_poly(&self, var_name: Option<char>) -> String {
+        let var_name = var_name.unwrap_or('x');
+        if self.coefficients.is_empty()
+            || self.coefficients.len() == 1 && self.coefficients[0] == FieldElement::zero()
+        {
+            return String::new();
+        }
+
+        let mut string = String::new();
+        let zero = FieldElement::<F>::zero();
+
+        for (i, coeff) in self.coefficients.iter().rev().enumerate() {
+            if *coeff == zero {
+                continue;
+            }
+
+            let coeff_str = coeff.representative().to_string();
+
+            if i == self.coefficients.len() - 1 {
+                string.push_str(&coeff_str);
+            } else if i == self.coefficients.len() - 2 {
+                string.push_str(&format!("{}*{} + ", coeff_str, var_name));
+            } else {
+                string.push_str(&format!(
+                    "{}*{}^{} + ",
+                    coeff_str,
+                    var_name,
+                    self.coefficients.len() - 1 - i
+                ));
+            }
+        }
+
+        string
     }
 }
 
@@ -1204,5 +1242,11 @@ mod tests {
         // 0
         let dpdx = px.differentiate();
         assert_eq!(dpdx, Polynomial::new(&[FE::new(0)]));
+    }
+
+    #[test]
+    fn test_print_as_sage_poly() {
+        let p = Polynomial::new(&[FE::new(1), FE::new(2), FE::new(3)]);
+        assert_eq!(p.print_as_sage_poly(None), "3*x^2 + 2*x + 1");
     }
 }

--- a/math/src/polynomial/mod.rs
+++ b/math/src/polynomial/mod.rs
@@ -146,7 +146,7 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
         if degree == 0 {
             return Polynomial::zero();
         }
-        let mut derivative = Vec::with_capacity(self.degree());
+        let mut derivative = Vec::with_capacity(degree);
         for (i, coeff) in self.coefficients().iter().enumerate().skip(1) {
             derivative.push(FieldElement::<F>::from(i as u64) * coeff);
         }

--- a/math/src/polynomial/mod.rs
+++ b/math/src/polynomial/mod.rs
@@ -1,8 +1,8 @@
 use super::field::element::FieldElement;
 use crate::field::traits::{IsField, IsPrimeField, IsSubFieldOf};
-use alloc::{borrow::ToOwned, vec, vec::Vec};
+use alloc::string::{String, ToString};
+use alloc::{borrow::ToOwned, format, vec, vec::Vec};
 use core::{fmt::Display, ops};
-
 pub mod dense_multilinear_poly;
 mod error;
 pub mod sparse_multilinear_poly;


### PR DESCRIPTION
Rationale : 

- differentiate can be useful
- printing nicely the poly as well 

- Will enable drop-in replacement in Garaga for the Polynomial struct. 

Thank you! :)