### PR TITLE
Fix minor grammatical errors in documentation

### DIFF
--- a/docs/src/fft/benchmarks.md
+++ b/docs/src/fft/benchmarks.md
@@ -10,7 +10,7 @@ Three methods of polynomial interpolation were benchmarked, with different input
 
 these were run with criterion-rs in a MacBook Pro M1 (18.3), statistically measuring the total run time of one iteration. The field used was a 256 bit STARK-friendly prime field.
 
-All values of time are in milliseconds. Those cases which were greater than 30 seconds were marked respectively as they're too slow and weren't worth to be benchmarked. The input size refers to *d + 1* where *d* is the polynomial's degree (so size is amount of coefficients).
+All values of time are in milliseconds. Those cases which were greater than 30 seconds were marked respectively as they're too slow and weren't worth benchmarking. The input size refers to *d + 1* where *d* is the polynomial's degree (so size is amount of coefficients).
 
 | Input size | CPU Lagrange | CPU FFT   | GPU FFT (Metal) |
 |------------|--------------|-----------|-----------------|

--- a/docs/src/plonk/implementation.md
+++ b/docs/src/plonk/implementation.md
@@ -51,7 +51,7 @@ assert!(verifier.verify(
 ));
 ```
 
-Let's brake it down. The helper function `test_common_preprocessed_input_2()` returns an instance of the following struct for the particular test circuit:
+Let's break it down. The helper function `test_common_preprocessed_input_2()` returns an instance of the following struct for the particular test circuit:
 ```rust
 pub struct CommonPreprocessedInput<F: IsField> {
     pub n: usize,


### PR DESCRIPTION
# Fix minor grammatical errors in documentation

## Description

Two minor grammatical issues in the documentation files `docs/src/fft/benchmarks.md` and `docs/src/plonk/implementation.md`. These errors could cause confusion for readers and reduce the professionalism of the documentation.

1. In `docs/src/fft/benchmarks.md`, the sentence:
   > "Those cases which were greater than 30 seconds were marked respectively as they're too slow and weren't worth to be benchmarked."
   was corrected to:
   > "Those cases which were greater than 30 seconds were marked respectively as they're too slow and weren't worth benchmarking."
   **Explanation**: The phrase "weren't worth to be benchmarked" is grammatically incorrect. The correct phrase is "weren't worth benchmarking," which improves the readability and clarity of the sentence.

2. In `docs/src/plonk/implementation.md`, the sentence:
   > "Let's brake it down."
   was corrected to:
   > "Let's break it down."
   **Explanation**: The word "brake" was mistakenly used instead of "break." "Brake" refers to a stopping mechanism, while "break" is the correct word in this context, meaning to divide or analyze something in parts.

These changes improve the clarity and professionalism of the documentation. 

## Type of change

Please delete options that are not relevant.

- [x] Optimization

## Checklist

- [x] Documentation has been added/updated.

