### PR TITLE
fix: typos in documentation files

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,6 +1,6 @@
 # Fuzzing
 There are three types of fuzzers distributed on different workspaces depending on the features (metal/cuda) they need. So you should make sure you cded into the right folder before running any of the commands.
-This directory contains three types of fuzzers distributed onto three different workspaces. `no_gpu_fuzz` and `metal_fuzz` both use `cargo-fuzz` and must be run with nightly, also the latter only runs on mac. `cuda_fuzz` runs on machines with nvida GPUs and uses `honggfuzz` which runs on most linux distros.
+This directory contains three types of fuzzers distributed onto three different workspaces. `no_gpu_fuzz` and `metal_fuzz` both use `cargo-fuzz` and must be run with nightly, also the latter only runs on mac. `cuda_fuzz` runs on machines with nvidia GPUs and uses `honggfuzz` which runs on most linux distros.
 
 ## Setup
 Run the following commands to get ready. 

--- a/provers/plonk/README.md
+++ b/provers/plonk/README.md
@@ -14,7 +14,7 @@ let y = system.new_public_input();
 let e = system.new_variable();
 
 let z = system.mul(&x, &e);    
-system.assert_eq(&y, &z);;
+system.assert_eq(&y, &z);
 ```
 
 By placing this logic under one function, one can create "gadgets" to abstract functionality.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `nvida` to `nvidia`.
Corrected `system.assert_eq(&y, &z);;` to `system.assert_eq(&y, &z);` (the extra semicolon has been removed). 

Please review the changes and let me know if any additional changes are needed.

