### PR TITLE
Refactor STARK for small fields

### DIFF
--- a/provers/stark/src/constraints/evaluator.rs
+++ b/provers/stark/src/constraints/evaluator.rs
@@ -3,7 +3,7 @@ use super::boundary::BoundaryConstraints;
 use crate::debug::check_boundary_polys_divisibility;
 use crate::domain::Domain;
 use crate::trace::LDETraceTable;
-use crate::traits::AIR;
+use crate::traits::{TransitionEvaluationContext, AIR};
 use crate::{frame::Frame, prover::evaluate_polynomial_on_lde_domain};
 use itertools::Itertools;
 #[cfg(not(feature = "parallel"))]
@@ -14,6 +14,7 @@ use rayon::{
     iter::IndexedParallelIterator,
     prelude::{IntoParallelIterator, ParallelIterator},
 };
+
 #[cfg(feature = "instruments")]
 use std::time::Instant;
 
@@ -184,7 +185,11 @@ impl<A: AIR> ConstraintEvaluator<A> {
 
                 // Compute all the transition constraints at this point of the LDE domain.
                 let evaluations_transition =
-                    air.compute_transition_prover(&frame, &periodic_values, rap_challenges);
+                    air.compute_transition(&TransitionEvaluationContext::Prover {
+                        frame: &frame,
+                        periodic_values: &periodic_values,
+                        rap_challenges,
+                    });
 
                 #[cfg(all(debug_assertions, not(feature = "parallel")))]
                 transition_evaluations.push(evaluations_transition.clone());

--- a/provers/stark/src/constraints/evaluator.rs
+++ b/provers/stark/src/constraints/evaluator.rs
@@ -184,12 +184,12 @@ impl<A: AIR> ConstraintEvaluator<A> {
                     .collect();
 
                 // Compute all the transition constraints at this point of the LDE domain.
-                let evaluations_transition =
-                    air.compute_transition(&TransitionEvaluationContext::Prover {
-                        frame: &frame,
-                        periodic_values: &periodic_values,
-                        rap_challenges,
-                    });
+                let transition_evaluation_context = TransitionEvaluationContext::new_prover(
+                    &frame,
+                    &periodic_values,
+                    rap_challenges,
+                );
+                let evaluations_transition = air.compute_transition(&transition_evaluation_context);
 
                 #[cfg(all(debug_assertions, not(feature = "parallel")))]
                 transition_evaluations.push(evaluations_transition.clone());

--- a/provers/stark/src/constraints/transition.rs
+++ b/provers/stark/src/constraints/transition.rs
@@ -3,6 +3,7 @@ use std::ops::Div;
 use crate::domain::Domain;
 use crate::frame::Frame;
 use crate::prover::evaluate_polynomial_on_lde_domain;
+use crate::traits::TransitionEvaluationContext;
 use itertools::Itertools;
 use lambdaworks_math::field::element::FieldElement;
 use lambdaworks_math::field::traits::{IsFFTField, IsField, IsSubFieldOf};
@@ -33,10 +34,8 @@ where
     /// vector, in the index corresponding to the constraint as given by `constraint_idx()`.
     fn evaluate(
         &self,
-        frame: &Frame<F, E>,
+        evaluation_context: &TransitionEvaluationContext<F, E>,
         transition_evaluations: &mut [FieldElement<E>],
-        periodic_values: &[FieldElement<F>],
-        rap_challenges: &[FieldElement<E>],
     );
 
     /// The periodicity the constraint is applied over the trace.

--- a/provers/stark/src/constraints/transition.rs
+++ b/provers/stark/src/constraints/transition.rs
@@ -1,7 +1,6 @@
 use std::ops::Div;
 
 use crate::domain::Domain;
-use crate::frame::Frame;
 use crate::prover::evaluate_polynomial_on_lde_domain;
 use crate::traits::TransitionEvaluationContext;
 use itertools::Itertools;

--- a/provers/stark/src/debug.rs
+++ b/provers/stark/src/debug.rs
@@ -93,11 +93,9 @@ pub fn validate_trace<A: AIR>(
             .iter()
             .map(|col| col[step].clone())
             .collect();
-        let evaluations = air.compute_transition(&TransitionEvaluationContext::Prover {
-            frame: &frame,
-            periodic_values: &periodic_values,
-            rap_challenges,
-        });
+        let transition_evaluation_context =
+            TransitionEvaluationContext::new_prover(&frame, &periodic_values, rap_challenges);
+        let evaluations = air.compute_transition(&transition_evaluation_context);
 
         // Iterate over each transition evaluation. When the evaluated step is not from
         // the exemption steps corresponding to the transition, it should have zero as a

--- a/provers/stark/src/debug.rs
+++ b/provers/stark/src/debug.rs
@@ -1,5 +1,5 @@
 use super::domain::Domain;
-use super::traits::AIR;
+use super::traits::{TransitionEvaluationContext, AIR};
 use crate::{frame::Frame, trace::LDETraceTable};
 use lambdaworks_math::{
     field::{
@@ -93,7 +93,11 @@ pub fn validate_trace<A: AIR>(
             .iter()
             .map(|col| col[step].clone())
             .collect();
-        let evaluations = air.compute_transition_prover(&frame, &periodic_values, rap_challenges);
+        let evaluations = air.compute_transition(&TransitionEvaluationContext::Prover {
+            frame: &frame,
+            periodic_values: &periodic_values,
+            rap_challenges,
+        });
 
         // Iterate over each transition evaluation. When the evaluated step is not from
         // the exemption steps corresponding to the transition, it should have zero as a

--- a/provers/stark/src/examples/dummy_air.rs
+++ b/provers/stark/src/examples/dummy_air.rs
@@ -6,10 +6,9 @@ use crate::{
         transition::TransitionConstraint,
     },
     context::AirContext,
-    frame::Frame,
     proof::options::ProofOptions,
     trace::TraceTable,
-    traits::AIR,
+    traits::{TransitionEvaluationContext, AIR},
 };
 use lambdaworks_math::field::{
     element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
@@ -48,11 +47,22 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        _periodic_values: &[FieldElement<F>],
-        _rap_challenges: &[FieldElement<F>],
     ) {
+        let (frame, _periodic_values, _rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_step = frame.get_evaluation_step(0);
         let second_step = frame.get_evaluation_step(1);
         let third_step = frame.get_evaluation_step(2);
@@ -97,11 +107,22 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        _periodic_values: &[FieldElement<F>],
-        _rap_challenges: &[FieldElement<F>],
     ) {
+        let (frame, _periodic_values, _rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_step = frame.get_evaluation_step(0);
 
         let bit = first_step.get_main_evaluation_element(0, 0);
@@ -185,15 +206,6 @@ impl AIR for DummyAIR {
 
     fn pub_inputs(&self) -> &Self::PublicInputs {
         &()
-    }
-
-    fn compute_transition_verifier(
-        &self,
-        frame: &Frame<Self::FieldExtension, Self::FieldExtension>,
-        periodic_values: &[FieldElement<Self::FieldExtension>],
-        rap_challenges: &[FieldElement<Self::FieldExtension>],
-    ) -> Vec<FieldElement<Self::Field>> {
-        self.compute_transition_prover(frame, periodic_values, rap_challenges)
     }
 }
 

--- a/provers/stark/src/examples/fibonacci_2_cols_shifted.rs
+++ b/provers/stark/src/examples/fibonacci_2_cols_shifted.rs
@@ -4,10 +4,9 @@ use crate::{
         transition::TransitionConstraint,
     },
     context::AirContext,
-    frame::Frame,
     proof::options::ProofOptions,
     trace::TraceTable,
-    traits::AIR,
+    traits::{TransitionEvaluationContext, AIR},
 };
 use lambdaworks_math::{
     field::{element::FieldElement, traits::IsFFTField},
@@ -46,11 +45,22 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        _periodic_values: &[FieldElement<F>],
-        _rap_challenges: &[FieldElement<F>],
     ) {
+        let (frame, _periodic_values, _rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_row = frame.get_evaluation_step(0);
         let second_row = frame.get_evaluation_step(1);
 
@@ -94,11 +104,22 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        _periodic_values: &[FieldElement<F>],
-        _rap_challenges: &[FieldElement<F>],
     ) {
+        let (frame, _periodic_values, _rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_row = frame.get_evaluation_step(0);
         let second_row = frame.get_evaluation_step(1);
 
@@ -222,15 +243,6 @@ where
 
     fn pub_inputs(&self) -> &Self::PublicInputs {
         &self.pub_inputs
-    }
-
-    fn compute_transition_verifier(
-        &self,
-        frame: &Frame<Self::FieldExtension, Self::FieldExtension>,
-        periodic_values: &[FieldElement<Self::FieldExtension>],
-        rap_challenges: &[FieldElement<Self::FieldExtension>],
-    ) -> Vec<FieldElement<Self::Field>> {
-        self.compute_transition_prover(frame, periodic_values, rap_challenges)
     }
 }
 

--- a/provers/stark/src/examples/fibonacci_2_columns.rs
+++ b/provers/stark/src/examples/fibonacci_2_columns.rs
@@ -7,10 +7,9 @@ use crate::{
         transition::TransitionConstraint,
     },
     context::AirContext,
-    frame::Frame,
     proof::options::ProofOptions,
     trace::TraceTable,
-    traits::AIR,
+    traits::{TransitionEvaluationContext, AIR},
 };
 use lambdaworks_math::field::{element::FieldElement, traits::IsFFTField};
 
@@ -45,11 +44,22 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        _periodic_values: &[FieldElement<F>],
-        _rap_challenges: &[FieldElement<F>],
     ) {
+        let (frame, _periodic_values, _rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_step = frame.get_evaluation_step(0);
         let second_step = frame.get_evaluation_step(1);
 
@@ -95,11 +105,22 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        _periodic_values: &[FieldElement<F>],
-        _rap_challenges: &[FieldElement<F>],
     ) {
+        let (frame, _periodic_values, _rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_step = frame.get_evaluation_step(0);
         let second_step = frame.get_evaluation_step(1);
 
@@ -193,15 +214,6 @@ where
 
     fn pub_inputs(&self) -> &Self::PublicInputs {
         &self.pub_inputs
-    }
-
-    fn compute_transition_verifier(
-        &self,
-        frame: &Frame<Self::FieldExtension, Self::FieldExtension>,
-        periodic_values: &[FieldElement<Self::FieldExtension>],
-        rap_challenges: &[FieldElement<Self::FieldExtension>],
-    ) -> Vec<FieldElement<Self::Field>> {
-        self.compute_transition_prover(frame, periodic_values, rap_challenges)
     }
 }
 

--- a/provers/stark/src/examples/fibonacci_rap.rs
+++ b/provers/stark/src/examples/fibonacci_rap.rs
@@ -6,10 +6,9 @@ use crate::{
         transition::TransitionConstraint,
     },
     context::AirContext,
-    frame::Frame,
     proof::options::ProofOptions,
     trace::TraceTable,
-    traits::AIR,
+    traits::{TransitionEvaluationContext, AIR},
 };
 use lambdaworks_crypto::fiat_shamir::is_transcript::IsTranscript;
 use lambdaworks_math::{
@@ -51,11 +50,22 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        _periodic_values: &[FieldElement<F>],
-        _rap_challenges: &[FieldElement<F>],
     ) {
+        let (frame, _periodic_values, _rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_step = frame.get_evaluation_step(0);
         let second_step = frame.get_evaluation_step(1);
         let third_step = frame.get_evaluation_step(2);
@@ -101,11 +111,22 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        _periodic_values: &[FieldElement<F>],
-        rap_challenges: &[FieldElement<F>],
     ) {
+        let (frame, _periodic_values, rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_step = frame.get_evaluation_step(0);
         let second_step = frame.get_evaluation_step(1);
 
@@ -258,15 +279,6 @@ where
 
     fn pub_inputs(&self) -> &Self::PublicInputs {
         &self.pub_inputs
-    }
-
-    fn compute_transition_verifier(
-        &self,
-        frame: &Frame<Self::FieldExtension, Self::FieldExtension>,
-        periodic_values: &[FieldElement<Self::FieldExtension>],
-        rap_challenges: &[FieldElement<Self::FieldExtension>],
-    ) -> Vec<FieldElement<Self::Field>> {
-        self.compute_transition_prover(frame, periodic_values, rap_challenges)
     }
 }
 

--- a/provers/stark/src/examples/quadratic_air.rs
+++ b/provers/stark/src/examples/quadratic_air.rs
@@ -6,10 +6,9 @@ use crate::{
         transition::TransitionConstraint,
     },
     context::AirContext,
-    frame::Frame,
     proof::options::ProofOptions,
     trace::TraceTable,
-    traits::AIR,
+    traits::{TransitionEvaluationContext, AIR},
 };
 use lambdaworks_math::field::{element::FieldElement, traits::IsFFTField};
 
@@ -44,11 +43,22 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        _periodic_values: &[FieldElement<F>],
-        _rap_challenges: &[FieldElement<F>],
     ) {
+        let (frame, _periodic_values, _rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_step = frame.get_evaluation_step(0);
         let second_step = frame.get_evaluation_step(1);
 
@@ -145,15 +155,6 @@ where
 
     fn pub_inputs(&self) -> &Self::PublicInputs {
         &self.pub_inputs
-    }
-
-    fn compute_transition_verifier(
-        &self,
-        frame: &Frame<Self::FieldExtension, Self::FieldExtension>,
-        periodic_values: &[FieldElement<Self::FieldExtension>],
-        rap_challenges: &[FieldElement<Self::FieldExtension>],
-    ) -> Vec<FieldElement<Self::Field>> {
-        self.compute_transition_prover(frame, periodic_values, rap_challenges)
     }
 }
 

--- a/provers/stark/src/examples/read_only_memory.rs
+++ b/provers/stark/src/examples/read_only_memory.rs
@@ -6,10 +6,9 @@ use crate::{
         transition::TransitionConstraint,
     },
     context::AirContext,
-    frame::Frame,
     proof::options::ProofOptions,
     trace::TraceTable,
-    traits::AIR,
+    traits::{TransitionEvaluationContext, AIR},
 };
 use lambdaworks_crypto::fiat_shamir::is_transcript::IsTranscript;
 use lambdaworks_math::field::traits::IsPrimeField;
@@ -52,11 +51,22 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        _periodic_values: &[FieldElement<F>],
-        _rap_challenges: &[FieldElement<F>],
     ) {
+        let (frame, _periodic_values, _rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_step = frame.get_evaluation_step(0);
         let second_step = frame.get_evaluation_step(1);
 
@@ -105,11 +115,22 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        _periodic_values: &[FieldElement<F>],
-        _rap_challenges: &[FieldElement<F>],
     ) {
+        let (frame, _periodic_values, _rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_step = frame.get_evaluation_step(0);
         let second_step = frame.get_evaluation_step(1);
 
@@ -159,11 +180,22 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        _periodic_values: &[FieldElement<F>],
-        rap_challenges: &[FieldElement<F>],
     ) {
+        let (frame, _periodic_values, rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_step = frame.get_evaluation_step(0);
         let second_step = frame.get_evaluation_step(1);
 
@@ -343,15 +375,6 @@ where
 
     fn pub_inputs(&self) -> &Self::PublicInputs {
         &self.pub_inputs
-    }
-
-    fn compute_transition_verifier(
-        &self,
-        frame: &Frame<Self::FieldExtension, Self::FieldExtension>,
-        periodic_values: &[FieldElement<Self::FieldExtension>],
-        rap_challenges: &[FieldElement<Self::FieldExtension>],
-    ) -> Vec<FieldElement<Self::Field>> {
-        self.compute_transition_prover(frame, periodic_values, rap_challenges)
     }
 }
 

--- a/provers/stark/src/examples/simple_fibonacci.rs
+++ b/provers/stark/src/examples/simple_fibonacci.rs
@@ -7,7 +7,7 @@ use crate::{
     frame::Frame,
     proof::options::ProofOptions,
     trace::TraceTable,
-    traits::AIR,
+    traits::{TransitionEvaluationContext, AIR},
 };
 use lambdaworks_math::field::{element::FieldElement, traits::IsFFTField};
 use std::marker::PhantomData;
@@ -43,10 +43,8 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        _periodic_values: &[FieldElement<F>],
-        _rap_challenges: &[FieldElement<F>],
     ) {
         let first_step = frame.get_evaluation_step(0);
         let second_step = frame.get_evaluation_step(1);
@@ -146,15 +144,6 @@ where
 
     fn pub_inputs(&self) -> &Self::PublicInputs {
         &self.pub_inputs
-    }
-
-    fn compute_transition_verifier(
-        &self,
-        frame: &Frame<Self::FieldExtension, Self::FieldExtension>,
-        periodic_values: &[FieldElement<Self::FieldExtension>],
-        rap_challenges: &[FieldElement<Self::FieldExtension>],
-    ) -> Vec<FieldElement<Self::Field>> {
-        self.compute_transition_prover(frame, periodic_values, rap_challenges)
     }
 }
 

--- a/provers/stark/src/examples/simple_fibonacci.rs
+++ b/provers/stark/src/examples/simple_fibonacci.rs
@@ -4,7 +4,6 @@ use crate::{
         transition::TransitionConstraint,
     },
     context::AirContext,
-    frame::Frame,
     proof::options::ProofOptions,
     trace::TraceTable,
     traits::{TransitionEvaluationContext, AIR},
@@ -46,6 +45,19 @@ where
         evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
     ) {
+        let (frame, _periodic_values, _rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_step = frame.get_evaluation_step(0);
         let second_step = frame.get_evaluation_step(1);
         let third_step = frame.get_evaluation_step(2);

--- a/provers/stark/src/examples/simple_periodic_cols.rs
+++ b/provers/stark/src/examples/simple_periodic_cols.rs
@@ -6,10 +6,9 @@ use crate::{
         transition::TransitionConstraint,
     },
     context::AirContext,
-    frame::Frame,
     proof::options::ProofOptions,
     trace::TraceTable,
-    traits::AIR,
+    traits::{TransitionEvaluationContext, AIR},
 };
 use lambdaworks_math::field::{element::FieldElement, traits::IsFFTField};
 
@@ -47,11 +46,22 @@ where
 
     fn evaluate(
         &self,
-        frame: &Frame<F, F>,
+        evaluation_context: &TransitionEvaluationContext<F, F>,
         transition_evaluations: &mut [FieldElement<F>],
-        periodic_values: &[FieldElement<F>],
-        _rap_challenges: &[FieldElement<F>],
     ) {
+        let (frame, periodic_values, _rap_challenges) = match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values,
+                rap_challenges,
+            }
+            | TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values,
+                rap_challenges,
+            } => (frame, periodic_values, rap_challenges),
+        };
+
         let first_step = frame.get_evaluation_step(0);
         let second_step = frame.get_evaluation_step(1);
         let third_step = frame.get_evaluation_step(2);
@@ -174,15 +184,6 @@ where
 
     fn pub_inputs(&self) -> &Self::PublicInputs {
         &self.pub_inputs
-    }
-
-    fn compute_transition_verifier(
-        &self,
-        frame: &Frame<Self::FieldExtension, Self::FieldExtension>,
-        periodic_values: &[FieldElement<Self::FieldExtension>],
-        rap_challenges: &[FieldElement<Self::FieldExtension>],
-    ) -> Vec<FieldElement<Self::Field>> {
-        self.compute_transition_prover(frame, periodic_values, rap_challenges)
     }
 }
 

--- a/provers/stark/src/traits.rs
+++ b/provers/stark/src/traits.rs
@@ -41,6 +41,36 @@ where
     },
 }
 
+impl<'a, F, E> TransitionEvaluationContext<'a, F, E>
+where
+    F: IsSubFieldOf<E>,
+    E: IsField,
+{
+    pub fn new_prover(
+        frame: &'a Frame<'a, F, E>,
+        periodic_values: &'a [FieldElement<F>],
+        rap_challenges: &'a [FieldElement<E>],
+    ) -> Self {
+        Self::Prover {
+            frame,
+            periodic_values,
+            rap_challenges,
+        }
+    }
+
+    pub fn new_verifier(
+        frame: &'a Frame<'a, E, E>,
+        periodic_values: &'a [FieldElement<E>],
+        rap_challenges: &'a [FieldElement<E>],
+    ) -> Self {
+        Self::Verifier {
+            frame,
+            periodic_values,
+            rap_challenges,
+        }
+    }
+}
+
 /// AIR is a representation of the Constraints
 pub trait AIR {
     type Field: IsFFTField + IsSubFieldOf<Self::FieldExtension> + Send + Sync;

--- a/provers/stark/src/verifier.rs
+++ b/provers/stark/src/verifier.rs
@@ -274,12 +274,13 @@ pub trait IsStarkVerifier<A: AIR> {
 
         let ood_frame =
             (proof.trace_ood_evaluations).into_frame(num_main_trace_columns, A::STEP_SIZE);
+        let transition_evaluation_context = TransitionEvaluationContext::new_verifier(
+            &ood_frame,
+            &periodic_values,
+            &challenges.rap_challenges,
+        );
         let transition_ood_frame_evaluations =
-            air.compute_transition(&TransitionEvaluationContext::Verifier {
-                frame: &ood_frame,
-                periodic_values: &periodic_values,
-                rap_challenges: &challenges.rap_challenges,
-            });
+            air.compute_transition(&transition_evaluation_context);
 
         let mut denominators =
             vec![FieldElement::<A::FieldExtension>::zero(); air.num_transition_constraints()];

--- a/provers/stark/src/verifier.rs
+++ b/provers/stark/src/verifier.rs
@@ -4,7 +4,7 @@ use super::{
     fri::fri_decommit::FriDecommitment,
     grinding,
     proof::{options::ProofOptions, stark::StarkProof},
-    traits::AIR,
+    traits::{TransitionEvaluationContext, AIR},
 };
 use crate::{config::Commitment, proof::stark::DeepPolynomialOpening};
 use lambdaworks_crypto::{fiat_shamir::is_transcript::IsTranscript, merkle_tree::proof::Proof};
@@ -274,11 +274,12 @@ pub trait IsStarkVerifier<A: AIR> {
 
         let ood_frame =
             (proof.trace_ood_evaluations).into_frame(num_main_trace_columns, A::STEP_SIZE);
-        let transition_ood_frame_evaluations = air.compute_transition_verifier(
-            &ood_frame,
-            &periodic_values,
-            &challenges.rap_challenges,
-        );
+        let transition_ood_frame_evaluations =
+            air.compute_transition(&TransitionEvaluationContext::Verifier {
+                frame: &ood_frame,
+                periodic_values: &periodic_values,
+                rap_challenges: &challenges.rap_challenges,
+            });
 
         let mut denominators =
             vec![FieldElement::<A::FieldExtension>::zero(); air.num_transition_constraints()];


### PR DESCRIPTION
# Refactor STARK for small fields

This PR refactors the `Air` and `TransitionConstraints` traits to make the STARKs protocol compatible with small fields and their extensions.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Optimization
