### PR TITLE
Add Montgomery u32 backend for BabyBear

### DIFF
--- a/fuzz/no_gpu_fuzz/Cargo.toml
+++ b/fuzz/no_gpu_fuzz/Cargo.toml
@@ -16,6 +16,8 @@ num-traits = "0.2"
 ibig = "0.3.6"
 p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3", rev = "41cd843" }
 p3-mersenne-31 = { git = "https://github.com/Plonky3/Plonky3", rev = "41cd843" }
+p3-field = { git = "https://github.com/Plonky3/Plonky3" }
+p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3" }
 
 [[bin]]
 name = "curve_bls12_381"
@@ -54,6 +56,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "babybear"
+path = "fuzz_targets/field/babybear.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "mini_goldilocks"
 path = "fuzz_targets/field/mini_goldilocks.rs"
 test = false
@@ -83,5 +91,3 @@ name = "deserialize_stark_proof"
 path = "fuzz_targets/deserialize_stark_proof.rs"
 test = false
 doc = false
-
-

--- a/fuzz/no_gpu_fuzz/fuzz_targets/field/babybear.rs
+++ b/fuzz/no_gpu_fuzz/fuzz_targets/field/babybear.rs
@@ -13,11 +13,9 @@ pub type F = FieldElement<U32Babybear31PrimeField>;
 
 fuzz_target!(|values: (u32, u32)| {
     // Note: we filter values outside of order as it triggers an assert within plonky3 disallowing values n >= Self::Order
-
     let (value_u32_a, value_u32_b) = values;
 
     if value_u32_a >= 2013265921 || value_u32_b >= 2013265921 {
-        // Ignorar casos fuera del rango del campo
         return;
     }
     let a = F::from(value_u32_a as u64);

--- a/fuzz/no_gpu_fuzz/fuzz_targets/field/babybear.rs
+++ b/fuzz/no_gpu_fuzz/fuzz_targets/field/babybear.rs
@@ -1,0 +1,81 @@
+#![no_main]
+
+use lambdaworks_math::field::{
+    element::FieldElement,
+    fields::u32_montgomery_backend_prime_field::U32MontgomeryBackendPrimeField,
+};
+use libfuzzer_sys::fuzz_target;
+use p3_baby_bear::BabyBear;
+use p3_field::{Field, FieldAlgebra, PrimeField32};
+
+pub type U32Babybear31PrimeField = U32MontgomeryBackendPrimeField<2013265921>;
+pub type F = FieldElement<U32Babybear31PrimeField>;
+
+fuzz_target!(|values: (u32, u32)| {
+    // Note: we filter values outside of order as it triggers an assert within plonky3 disallowing values n >= Self::Order
+
+    let (value_u32_a, value_u32_b) = values;
+
+    if value_u32_a >= 2013265921 || value_u32_b >= 2013265921 {
+        // Ignorar casos fuera del rango del campo
+        return;
+    }
+    let a = F::from(value_u32_a as u64);
+    let b = F::from(value_u32_b as u64);
+
+    // Note: if we parse using from_canonical_u32 fails due to check that n < Self::Order
+    let a_expected = BabyBear::from_canonical_u32(value_u32_a);
+    let b_expected = BabyBear::from_canonical_u32(value_u32_b);
+
+    let add_u32 = &a + &b;
+    let addition = a_expected + b_expected;
+    assert_eq!(add_u32.representative(), addition.as_canonical_u32());
+
+    let sub_u32 = &a - &b;
+    let substraction = a_expected - b_expected;
+    assert_eq!(sub_u32.representative(), substraction.as_canonical_u32());
+
+    let mul_u32 = &a * &b;
+    let multiplication = a_expected * b_expected;
+    assert_eq!(mul_u32.representative(), multiplication.as_canonical_u32());
+
+    // Axioms soundness
+    let one = F::one();
+    let zero = F::zero();
+
+    assert_eq!(&a + &zero, a, "Neutral add element a failed");
+    assert_eq!(&b + &zero, b, "Neutral mul element b failed");
+    assert_eq!(&a * &one, a, "Neutral add element a failed");
+    assert_eq!(&b * &one, b, "Neutral mul element b failed");
+
+    assert_eq!(&a + &b, &b + &a, "Commutative add property failed");
+    assert_eq!(&a * &b, &b * &a, "Commutative mul property failed");
+
+    let c = &a * &b;
+    assert_eq!(
+        (&a + &b) + &c,
+        &a + (&b + &c),
+        "Associative add property failed"
+    );
+    assert_eq!(
+        (&a * &b) * &c,
+        &a * (&b * &c),
+        "Associative mul property failed"
+    );
+
+    assert_eq!(
+        &a * (&b + &c),
+        &a * &b + &a * &c,
+        "Distributive property failed"
+    );
+
+    assert_eq!(&a - &a, zero, "Inverse add a failed");
+    assert_eq!(&b - &b, zero, "Inverse add b failed");
+
+    if a != zero {
+        assert_eq!(&a * a.inv().unwrap(), one, "Inverse mul a failed");
+    }
+    if b != zero {
+        assert_eq!(&b * b.inv().unwrap(), one, "Inverse mul b failed");
+    }
+});

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -39,7 +39,8 @@ const-random = "0.1.15"
 iai-callgrind.workspace = true
 proptest = "1.1.0"
 pprof = { version = "0.13.0", features = ["criterion", "flamegraph"] }
-
+p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3" }
+p3-field = { git = "https://github.com/Plonky3/Plonky3" }
 [features]
 default = ["parallel", "std"]
 std = ["alloc", "serde?/std", "serde_json?/std"]

--- a/math/benches/criterion_field.rs
+++ b/math/benches/criterion_field.rs
@@ -5,13 +5,15 @@ mod fields;
 use fields::mersenne31::{mersenne31_extension_ops_benchmarks, mersenne31_ops_benchmarks};
 use fields::mersenne31_montgomery::mersenne31_mont_ops_benchmarks;
 use fields::{
-    stark252::starkfield_ops_benchmarks, u64_goldilocks::u64_goldilocks_ops_benchmarks,
+    baby_bear::{babybear_ops_benchmarks, babybear_ops_benchmarks_f64, babybear_p3_ops_benchmarks},
+    stark252::starkfield_ops_benchmarks,
+    u64_goldilocks::u64_goldilocks_ops_benchmarks,
     u64_goldilocks_montgomery::u64_goldilocks_montgomery_ops_benchmarks,
 };
 
 criterion_group!(
     name = field_benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = mersenne31_ops_benchmarks, mersenne31_extension_ops_benchmarks, mersenne31_mont_ops_benchmarks, starkfield_ops_benchmarks, u64_goldilocks_ops_benchmarks, u64_goldilocks_montgomery_ops_benchmarks
+    targets =babybear_ops_benchmarks,babybear_ops_benchmarks_f64, babybear_p3_ops_benchmarks
 );
 criterion_main!(field_benches);

--- a/math/benches/criterion_field.rs
+++ b/math/benches/criterion_field.rs
@@ -14,6 +14,7 @@ use fields::{
 criterion_group!(
     name = field_benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets =babybear_ops_benchmarks,babybear_ops_benchmarks_f64, babybear_p3_ops_benchmarks
+    targets =babybear_ops_benchmarks,babybear_ops_benchmarks_f64, babybear_p3_ops_benchmarks,mersenne31_extension_ops_benchmarks,mersenne31_ops_benchmarks,
+    starkfield_ops_benchmarks,u64_goldilocks_ops_benchmarks,u64_goldilocks_montgomery_ops_benchmarks,mersenne31_mont_ops_benchmarks
 );
 criterion_main!(field_benches);

--- a/math/benches/fields/baby_bear.rs
+++ b/math/benches/fields/baby_bear.rs
@@ -1,0 +1,217 @@
+use criterion::Criterion;
+use std::hint::black_box;
+
+use lambdaworks_math::field::{
+    element::FieldElement,
+    fields::{
+        fft_friendly::babybear::Babybear31PrimeField,
+        u32_montgomery_backend_prime_field::U32MontgomeryBackendPrimeField,
+    },
+};
+
+use p3_baby_bear::BabyBear;
+use p3_field::extension::BinomialExtensionField;
+use p3_field::{Field, FieldAlgebra};
+
+use rand::random;
+use rand::Rng;
+
+pub type U32Babybear31PrimeField = U32MontgomeryBackendPrimeField<2013265921>;
+pub type F = FieldElement<U32Babybear31PrimeField>;
+pub type F64 = FieldElement<Babybear31PrimeField>;
+
+pub fn rand_field_elements(num: usize) -> Vec<(F, F)> {
+    let mut result = Vec::with_capacity(num);
+    for _ in 0..result.capacity() {
+        result.push((F::from(random::<u64>()), F::from(random::<u64>())));
+    }
+    result
+}
+
+fn rand_babybear_elements_p3(num: usize) -> Vec<(BabyBear, BabyBear)> {
+    let mut rng = rand::thread_rng();
+    (0..num)
+        .map(|_| (rng.gen::<BabyBear>(), rng.gen::<BabyBear>()))
+        .collect()
+}
+
+pub fn babybear_ops_benchmarks(c: &mut Criterion) {
+    let input: Vec<Vec<(F, F)>> = [1000000]
+        .into_iter()
+        .map(rand_field_elements)
+        .collect::<Vec<_>>();
+    let mut group = c.benchmark_group("BabyBear operations using Lambdaworks u32");
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Addition {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, y) in i {
+                    black_box(black_box(x) + black_box(y));
+                }
+            });
+        });
+    }
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Multiplication {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, y) in i {
+                    black_box(black_box(x) * black_box(y));
+                }
+            });
+        });
+    }
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Square {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, _) in i {
+                    black_box(black_box(x).square());
+                }
+            });
+        });
+    }
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Inverse {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, _) in i {
+                    black_box(black_box(x).inv().unwrap());
+                }
+            });
+        });
+    }
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Division {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, y) in i {
+                    black_box(black_box(x) / black_box(y));
+                }
+            });
+        });
+    }
+}
+
+pub fn rand_field_elements_u64(num: usize) -> Vec<(F64, F64)> {
+    let mut result = Vec::with_capacity(num);
+    for _ in 0..result.capacity() {
+        result.push((F64::from(random::<u64>()), F64::from(random::<u64>())));
+    }
+    result
+}
+pub fn babybear_ops_benchmarks_f64(c: &mut Criterion) {
+    let input: Vec<Vec<(F64, F64)>> = [1000000]
+        .into_iter()
+        .map(rand_field_elements_u64)
+        .collect::<Vec<_>>();
+    let mut group = c.benchmark_group("BabyBear operations using Lambdaworks u64");
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Addition {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, y) in i {
+                    black_box(black_box(x) + black_box(y));
+                }
+            });
+        });
+    }
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Multiplication {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, y) in i {
+                    black_box(black_box(x) * black_box(y));
+                }
+            });
+        });
+    }
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Square {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, _) in i {
+                    black_box(black_box(x).square());
+                }
+            });
+        });
+    }
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Inverse {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, _) in i {
+                    black_box(black_box(x).inv().unwrap());
+                }
+            });
+        });
+    }
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Division {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, y) in i {
+                    black_box(black_box(x) / black_box(y));
+                }
+            });
+        });
+    }
+}
+
+pub fn babybear_p3_ops_benchmarks(c: &mut Criterion) {
+    let input: Vec<Vec<(BabyBear, BabyBear)>> = [1000000]
+        .into_iter()
+        .map(rand_babybear_elements_p3)
+        .collect::<Vec<_>>();
+
+    let mut group = c.benchmark_group("BabyBear operations using Plonky3");
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Addition {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, y) in i {
+                    black_box(black_box(*x) + black_box(*y));
+                }
+            });
+        });
+    }
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Multiplication {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, y) in i {
+                    black_box(black_box(*x) * black_box(*y));
+                }
+            });
+        });
+    }
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Square {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, _) in i {
+                    black_box(black_box(x).square());
+                }
+            });
+        });
+    }
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Inverse {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, _) in i {
+                    black_box(black_box(x).inverse());
+                }
+            });
+        });
+    }
+
+    for i in input.clone().into_iter() {
+        group.bench_with_input(format!("Division {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, y) in i {
+                    black_box(black_box(*x) / black_box(*y));
+                }
+            });
+        });
+    }
+}

--- a/math/benches/fields/baby_bear.rs
+++ b/math/benches/fields/baby_bear.rs
@@ -10,7 +10,6 @@ use lambdaworks_math::field::{
 };
 
 use p3_baby_bear::BabyBear;
-use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, FieldAlgebra};
 
 use rand::random;

--- a/math/benches/fields/mod.rs
+++ b/math/benches/fields/mod.rs
@@ -1,3 +1,4 @@
+pub mod baby_bear;
 pub mod mersenne31;
 pub mod mersenne31_montgomery;
 pub mod stark252;

--- a/math/src/field/fields/fft_friendly/babybear_u32.rs
+++ b/math/src/field/fields/fft_friendly/babybear_u32.rs
@@ -1,0 +1,283 @@
+use crate::{
+    field::{
+        element::FieldElement,
+        fields::u32_montgomery_backend_prime_field::U32MontgomeryBackendPrimeField,
+        traits::IsFFTField,
+    },
+    unsigned_integer::element::{UnsignedInteger, U64},
+};
+
+pub type Babybear31PrimeField = U32MontgomeryBackendPrimeField<2013265921>;
+
+//a two-adic primitive root of unity is 21^(2^24)
+// 21^(2^24)=1 mod 2013265921
+// 2^27(2^4-1)+1 where n=27 (two-adicity) and k=2^4+1
+//In the future we should allow this with metal and cuda feature, and just dispatch it to the CPU until the implementation is done
+#[cfg(any(not(feature = "metal"), not(feature = "cuda")))]
+impl IsFFTField for Babybear31PrimeField {
+    const TWO_ADICITY: u64 = 24;
+
+    const TWO_ADIC_PRIMITVE_ROOT_OF_UNITY: Self::BaseType = 21;
+
+    fn field_name() -> &'static str {
+        "babybear31"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod test_babybear_31_bytes_ops {
+        use super::*;
+        use crate::{field::element::FieldElement, traits::ByteConversion};
+
+        #[test]
+        fn two_plus_one_is_three() {
+            let a = FieldElement::<Babybear31PrimeField>::from(2);
+            let b = FieldElement::<Babybear31PrimeField>::one();
+            let res = FieldElement::<Babybear31PrimeField>::from(3);
+
+            assert_eq!(a + b, res)
+        }
+
+        #[test]
+        fn one_minus_two_is_minus_one() {
+            let a = FieldElement::<Babybear31PrimeField>::from(2);
+            let b = FieldElement::<Babybear31PrimeField>::one();
+            let res = FieldElement::<Babybear31PrimeField>::from(2013265921);
+            let zero = FieldElement::<Babybear31PrimeField>::zero();
+
+            println!("Zero: {:?}", zero);
+            println!("Zero representative: {:?}", zero.representative());
+            println!("Mod: {:?}", res);
+            println!("Mod representative: {:?}", res.representative());
+            println!("-B:  {:?}", (-b).representative());
+            println!("A: {:?}", a);
+            println!("A representative: {:?}", a.representative());
+            println!("MOD plus 1: {:?}", (res + b).representative());
+            assert_eq!(b - a, res)
+        }
+
+        #[test]
+        fn mul_by_zero_is_zero() {
+            let a = FieldElement::<Babybear31PrimeField>::from(2);
+            let b = FieldElement::<Babybear31PrimeField>::zero();
+            assert_eq!(a * b, b)
+        }
+
+        #[test]
+        fn neg_zero_is_zero() {
+            let zero = FieldElement::<Babybear31PrimeField>::from(0);
+
+            assert_eq!(-&zero, zero);
+        }
+
+        #[test]
+        #[cfg(feature = "alloc")]
+        fn byte_serialization_for_a_number_matches_with_byte_conversion_implementation_le() {
+            let element =
+                FieldElement::<Babybear31PrimeField>::from_hex("0x0123456701234567").unwrap();
+            let bytes = element.to_bytes_le();
+            let expected_bytes: [u8; 8] = ByteConversion::to_bytes_le(&element).try_into().unwrap();
+            assert_eq!(bytes, expected_bytes);
+        }
+
+        #[test]
+        #[cfg(feature = "alloc")]
+        fn byte_serialization_for_a_number_matches_with_byte_conversion_implementation_be() {
+            let element =
+                FieldElement::<Babybear31PrimeField>::from_hex("0123456701234567").unwrap();
+            let bytes = element.to_bytes_be();
+            let expected_bytes: [u8; 8] = ByteConversion::to_bytes_be(&element).try_into().unwrap();
+            assert_eq!(bytes, expected_bytes);
+        }
+
+        #[test]
+        fn byte_serialization_and_deserialization_works_le() {
+            let element =
+                FieldElement::<Babybear31PrimeField>::from_hex("0x7654321076543210").unwrap();
+            let bytes = element.to_bytes_le();
+            let from_bytes = FieldElement::<Babybear31PrimeField>::from_bytes_le(&bytes).unwrap();
+            assert_eq!(element, from_bytes);
+        }
+
+        #[test]
+        fn byte_serialization_and_deserialization_works_be() {
+            let element =
+                FieldElement::<Babybear31PrimeField>::from_hex("7654321076543210").unwrap();
+            let bytes = element.to_bytes_be();
+            let from_bytes = FieldElement::<Babybear31PrimeField>::from_bytes_be(&bytes).unwrap();
+            assert_eq!(element, from_bytes);
+        }
+    }
+
+    #[cfg(all(feature = "std", not(feature = "instruments")))]
+    mod test_babybear_31_fft {
+        use super::*;
+        #[cfg(not(any(feature = "metal", feature = "cuda")))]
+        use crate::fft::cpu::roots_of_unity::{
+            get_powers_of_primitive_root, get_powers_of_primitive_root_coset,
+        };
+        #[cfg(not(any(feature = "metal", feature = "cuda")))]
+        use crate::field::element::FieldElement;
+        #[cfg(not(any(feature = "metal", feature = "cuda")))]
+        use crate::field::traits::{IsFFTField, RootsConfig};
+        use crate::polynomial::Polynomial;
+        use proptest::{collection, prelude::*, std_facade::Vec};
+
+        #[cfg(not(any(feature = "metal", feature = "cuda")))]
+        fn gen_fft_and_naive_evaluation<F: IsFFTField>(
+            poly: Polynomial<FieldElement<F>>,
+        ) -> (Vec<FieldElement<F>>, Vec<FieldElement<F>>) {
+            let len = poly.coeff_len().next_power_of_two();
+            let order = len.trailing_zeros();
+            let twiddles =
+                get_powers_of_primitive_root(order.into(), len, RootsConfig::Natural).unwrap();
+
+            let fft_eval = Polynomial::evaluate_fft::<F>(&poly, 1, None).unwrap();
+            let naive_eval = poly.evaluate_slice(&twiddles);
+
+            (fft_eval, naive_eval)
+        }
+
+        #[cfg(not(any(feature = "metal", feature = "cuda")))]
+        fn gen_fft_coset_and_naive_evaluation<F: IsFFTField>(
+            poly: Polynomial<FieldElement<F>>,
+            offset: FieldElement<F>,
+            blowup_factor: usize,
+        ) -> (Vec<FieldElement<F>>, Vec<FieldElement<F>>) {
+            let len = poly.coeff_len().next_power_of_two();
+            let order = (len * blowup_factor).trailing_zeros();
+            let twiddles =
+                get_powers_of_primitive_root_coset(order.into(), len * blowup_factor, &offset)
+                    .unwrap();
+
+            let fft_eval =
+                Polynomial::evaluate_offset_fft::<F>(&poly, blowup_factor, None, &offset).unwrap();
+            let naive_eval = poly.evaluate_slice(&twiddles);
+
+            (fft_eval, naive_eval)
+        }
+
+        #[cfg(not(any(feature = "metal", feature = "cuda")))]
+        fn gen_fft_and_naive_interpolate<F: IsFFTField>(
+            fft_evals: &[FieldElement<F>],
+        ) -> (Polynomial<FieldElement<F>>, Polynomial<FieldElement<F>>) {
+            let order = fft_evals.len().trailing_zeros() as u64;
+            let twiddles =
+                get_powers_of_primitive_root(order, 1 << order, RootsConfig::Natural).unwrap();
+
+            let naive_poly = Polynomial::interpolate(&twiddles, fft_evals).unwrap();
+            let fft_poly = Polynomial::interpolate_fft::<F>(fft_evals).unwrap();
+
+            (fft_poly, naive_poly)
+        }
+
+        #[cfg(not(any(feature = "metal", feature = "cuda")))]
+        fn gen_fft_and_naive_coset_interpolate<F: IsFFTField>(
+            fft_evals: &[FieldElement<F>],
+            offset: &FieldElement<F>,
+        ) -> (Polynomial<FieldElement<F>>, Polynomial<FieldElement<F>>) {
+            let order = fft_evals.len().trailing_zeros() as u64;
+            let twiddles = get_powers_of_primitive_root_coset(order, 1 << order, offset).unwrap();
+
+            let naive_poly = Polynomial::interpolate(&twiddles, fft_evals).unwrap();
+            let fft_poly = Polynomial::interpolate_offset_fft(fft_evals, offset).unwrap();
+
+            (fft_poly, naive_poly)
+        }
+
+        #[cfg(not(any(feature = "metal", feature = "cuda")))]
+        fn gen_fft_interpolate_and_evaluate<F: IsFFTField>(
+            poly: Polynomial<FieldElement<F>>,
+        ) -> (Polynomial<FieldElement<F>>, Polynomial<FieldElement<F>>) {
+            let eval = Polynomial::evaluate_fft::<F>(&poly, 1, None).unwrap();
+            let new_poly = Polynomial::interpolate_fft::<F>(&eval).unwrap();
+
+            (poly, new_poly)
+        }
+
+        prop_compose! {
+            fn powers_of_two(max_exp: u8)(exp in 1..max_exp) -> usize { 1 << exp }
+            // max_exp cannot be multiple of the bits that represent a usize, generally 64 or 32.
+            // also it can't exceed the test field's two-adicity.
+        }
+        prop_compose! {
+            fn field_element()(num in any::<u64>().prop_filter("Avoid null coefficients", |x| x != &0)) -> FieldElement<Babybear31PrimeField> {
+                FieldElement::<Babybear31PrimeField>::from(num)
+            }
+        }
+        prop_compose! {
+            fn offset()(num in any::<u64>(), factor in any::<u64>()) -> FieldElement<Babybear31PrimeField> { FieldElement::<Babybear31PrimeField>::from(num).pow(factor) }
+        }
+        prop_compose! {
+            fn field_vec(max_exp: u8)(vec in collection::vec(field_element(), 0..1 << max_exp)) -> Vec<FieldElement<Babybear31PrimeField>> {
+                vec
+            }
+        }
+        prop_compose! {
+            fn non_power_of_two_sized_field_vec(max_exp: u8)(vec in collection::vec(field_element(), 2..1<<max_exp).prop_filter("Avoid polynomials of size power of two", |vec| !vec.len().is_power_of_two())) -> Vec<FieldElement<Babybear31PrimeField>> {
+                vec
+            }
+        }
+        prop_compose! {
+            fn poly(max_exp: u8)(coeffs in field_vec(max_exp)) -> Polynomial<FieldElement<Babybear31PrimeField>> {
+                Polynomial::new(&coeffs)
+            }
+        }
+        prop_compose! {
+            fn poly_with_non_power_of_two_coeffs(max_exp: u8)(coeffs in non_power_of_two_sized_field_vec(max_exp)) -> Polynomial<FieldElement<Babybear31PrimeField>> {
+                Polynomial::new(&coeffs)
+            }
+        }
+
+        proptest! {
+            // Property-based test that ensures FFT eval. gives same result as a naive polynomial evaluation.
+            #[test]
+            #[cfg(not(any(feature = "metal",feature = "cuda")))]
+            fn test_fft_matches_naive_evaluation(poly in poly(8)) {
+                let (fft_eval, naive_eval) = gen_fft_and_naive_evaluation(poly);
+                prop_assert_eq!(fft_eval, naive_eval);
+            }
+
+            // Property-based test that ensures FFT eval. with coset gives same result as a naive polynomial evaluation.
+            #[test]
+            #[cfg(not(any(feature = "metal",feature = "cuda")))]
+            fn test_fft_coset_matches_naive_evaluation(poly in poly(4), offset in offset(), blowup_factor in powers_of_two(4)) {
+                let (fft_eval, naive_eval) = gen_fft_coset_and_naive_evaluation(poly, offset, blowup_factor);
+                prop_assert_eq!(fft_eval, naive_eval);
+            }
+
+            // #[cfg(not(any(feature = "metal"),not(feature = "cuda")))]
+            // Property-based test that ensures FFT interpolation is the same as naive..
+            #[test]
+            #[cfg(not(any(feature = "metal",feature = "cuda")))]
+            fn test_fft_interpolate_matches_naive(fft_evals in field_vec(4)
+                                                           .prop_filter("Avoid polynomials of size not power of two",
+                                                                        |evals| evals.len().is_power_of_two())) {
+                let (fft_poly, naive_poly) = gen_fft_and_naive_interpolate(&fft_evals);
+                prop_assert_eq!(fft_poly, naive_poly);
+            }
+
+            // Property-based test that ensures FFT interpolation with an offset is the same as naive.
+            #[test]
+            #[cfg(not(any(feature = "metal",feature = "cuda")))]
+            fn test_fft_interpolate_coset_matches_naive(offset in offset(), fft_evals in field_vec(4)
+                                                           .prop_filter("Avoid polynomials of size not power of two",
+                                                                        |evals| evals.len().is_power_of_two())) {
+                let (fft_poly, naive_poly) = gen_fft_and_naive_coset_interpolate(&fft_evals, &offset);
+                prop_assert_eq!(fft_poly, naive_poly);
+            }
+
+            // Property-based test that ensures interpolation is the inverse operation of evaluation.
+            #[test]
+            #[cfg(not(any(feature = "metal",feature = "cuda")))]
+            fn test_fft_interpolate_is_inverse_of_evaluate(
+                poly in poly(4).prop_filter("Avoid non pows of two", |poly| poly.coeff_len().is_power_of_two())) {
+                let (poly, new_poly) = gen_fft_interpolate_and_evaluate(poly);
+                prop_assert_eq!(poly, new_poly);
+            }
+        }
+    }
+}

--- a/math/src/field/fields/fft_friendly/babybear_u32.rs
+++ b/math/src/field/fields/fft_friendly/babybear_u32.rs
@@ -1,10 +1,5 @@
-use crate::{
-    field::{
-        element::FieldElement,
-        fields::u32_montgomery_backend_prime_field::U32MontgomeryBackendPrimeField,
-        traits::IsFFTField,
-    },
-    unsigned_integer::element::{UnsignedInteger, U64},
+use crate::field::{
+    fields::u32_montgomery_backend_prime_field::U32MontgomeryBackendPrimeField, traits::IsFFTField,
 };
 
 pub type Babybear31PrimeField = U32MontgomeryBackendPrimeField<2013265921>;
@@ -31,7 +26,7 @@ mod tests {
     mod test_babybear_31_bytes_ops {
         use super::*;
         use crate::{
-            field::{element::FieldElement, errors::FieldError, traits::IsField},
+            field::{element::FieldElement, errors::FieldError},
             traits::ByteConversion,
         };
         type FE = FieldElement<Babybear31PrimeField>;
@@ -123,7 +118,7 @@ mod tests {
         #[test]
         fn inv_2() {
             let a: FE = FE::from(2);
-            assert_eq!(&a * a.inv().unwrap(), FE::from(1));
+            assert_eq!(a * a.inv().unwrap(), FE::from(1));
         }
 
         #[test]
@@ -166,7 +161,7 @@ mod tests {
         fn two_plus_its_additive_inv_is_0() {
             let two = FE::from(2);
 
-            assert_eq!(&two + (-&two), FE::from(0))
+            assert_eq!(two + (-&two), FE::from(0))
         }
 
         #[test]

--- a/math/src/field/fields/fft_friendly/babybear_u32.rs
+++ b/math/src/field/fields/fft_friendly/babybear_u32.rs
@@ -30,86 +30,198 @@ mod tests {
 
     mod test_babybear_31_bytes_ops {
         use super::*;
-        use crate::{field::element::FieldElement, traits::ByteConversion};
+        use crate::{
+            field::{element::FieldElement, errors::FieldError, traits::IsField},
+            traits::ByteConversion,
+        };
+        type FE = FieldElement<Babybear31PrimeField>;
 
         #[test]
         fn two_plus_one_is_three() {
-            let a = FieldElement::<Babybear31PrimeField>::from(2);
-            let b = FieldElement::<Babybear31PrimeField>::one();
-            let res = FieldElement::<Babybear31PrimeField>::from(3);
+            let a = FE::from(2);
+            let b = FE::one();
+            let res = FE::from(3);
 
             assert_eq!(a + b, res)
         }
 
         #[test]
         fn one_minus_two_is_minus_one() {
-            let a = FieldElement::<Babybear31PrimeField>::from(2);
-            let b = FieldElement::<Babybear31PrimeField>::one();
-            let res = FieldElement::<Babybear31PrimeField>::from(2013265921);
-            let zero = FieldElement::<Babybear31PrimeField>::zero();
-
-            println!("Zero: {:?}", zero);
-            println!("Zero representative: {:?}", zero.representative());
-            println!("Mod: {:?}", res);
-            println!("Mod representative: {:?}", res.representative());
-            println!("-B:  {:?}", (-b).representative());
-            println!("A: {:?}", a);
-            println!("A representative: {:?}", a.representative());
-            println!("MOD plus 1: {:?}", (res + b).representative());
+            let a = FE::from(2);
+            let b = FE::one();
+            let res = FE::from(2013265920);
             assert_eq!(b - a, res)
         }
 
         #[test]
         fn mul_by_zero_is_zero() {
-            let a = FieldElement::<Babybear31PrimeField>::from(2);
-            let b = FieldElement::<Babybear31PrimeField>::zero();
+            let a = FE::from(2);
+            let b = FE::zero();
             assert_eq!(a * b, b)
         }
 
         #[test]
         fn neg_zero_is_zero() {
-            let zero = FieldElement::<Babybear31PrimeField>::from(0);
+            let zero = FE::from(0);
 
             assert_eq!(-&zero, zero);
         }
 
         #[test]
-        #[cfg(feature = "alloc")]
-        fn byte_serialization_for_a_number_matches_with_byte_conversion_implementation_le() {
-            let element =
-                FieldElement::<Babybear31PrimeField>::from_hex("0x0123456701234567").unwrap();
-            let bytes = element.to_bytes_le();
-            let expected_bytes: [u8; 8] = ByteConversion::to_bytes_le(&element).try_into().unwrap();
-            assert_eq!(bytes, expected_bytes);
+        fn doubling() {
+            assert_eq!(FE::from(2).double(), FE::from(2) + FE::from(2),);
+        }
+
+        const ORDER: usize = 2013265921;
+
+        #[test]
+        fn max_order_pis_0() {
+            assert_eq!(FE::from((ORDER - 1) as u64) + FE::from(1), FE::from(0));
         }
 
         #[test]
-        #[cfg(feature = "alloc")]
-        fn byte_serialization_for_a_number_matches_with_byte_conversion_implementation_be() {
-            let element =
-                FieldElement::<Babybear31PrimeField>::from_hex("0123456701234567").unwrap();
-            let bytes = element.to_bytes_be();
-            let expected_bytes: [u8; 8] = ByteConversion::to_bytes_be(&element).try_into().unwrap();
-            assert_eq!(bytes, expected_bytes);
+        fn when_comparing_13_and_13_they_are_equal() {
+            let a: FE = FE::from(13);
+            let b: FE = FE::from(13);
+            assert_eq!(a, b);
         }
 
         #[test]
-        fn byte_serialization_and_deserialization_works_le() {
-            let element =
-                FieldElement::<Babybear31PrimeField>::from_hex("0x7654321076543210").unwrap();
-            let bytes = element.to_bytes_le();
-            let from_bytes = FieldElement::<Babybear31PrimeField>::from_bytes_le(&bytes).unwrap();
-            assert_eq!(element, from_bytes);
+        fn when_comparing_13_and_8_they_are_different() {
+            let a: FE = FE::from(13);
+            let b: FE = FE::from(8);
+            assert_ne!(a, b);
         }
 
         #[test]
-        fn byte_serialization_and_deserialization_works_be() {
-            let element =
-                FieldElement::<Babybear31PrimeField>::from_hex("7654321076543210").unwrap();
-            let bytes = element.to_bytes_be();
-            let from_bytes = FieldElement::<Babybear31PrimeField>::from_bytes_be(&bytes).unwrap();
-            assert_eq!(element, from_bytes);
+        fn mul_neutral_element() {
+            let a: FE = FE::from(1);
+            let b: FE = FE::from(2);
+            assert_eq!(a * b, FE::from(2));
         }
+
+        #[test]
+        fn mul_2_3_is_6() {
+            let a: FE = FE::from(2);
+            let b: FE = FE::from(3);
+            assert_eq!(a * b, FE::from(6));
+        }
+
+        #[test]
+        fn mul_order_minus_1() {
+            let a: FE = FE::from((ORDER - 1) as u64);
+            let b: FE = FE::from((ORDER - 1) as u64);
+            assert_eq!(a * b, FE::from(1));
+        }
+
+        #[test]
+        fn inv_0_error() {
+            let result = FE::from(0).inv();
+            assert!(matches!(result, Err(FieldError::InvZeroError)))
+        }
+
+        #[test]
+        fn inv_2() {
+            let a: FE = FE::from(2);
+            assert_eq!(&a * a.inv().unwrap(), FE::from(1));
+        }
+
+        #[test]
+        fn square_2_is_4() {
+            assert_eq!(FE::from(2).square(), FE::from(4))
+        }
+
+        #[test]
+        fn pow_2_3() {
+            assert_eq!(FE::from(2).pow(3_u64), FE::from(8))
+        }
+
+        #[test]
+        fn pow_p_minus_1() {
+            assert_eq!(FE::from(2).pow(ORDER - 1), FE::from(1))
+        }
+
+        #[test]
+        fn div_1() {
+            assert_eq!(FE::from(2) / FE::from(1), FE::from(2))
+        }
+
+        #[test]
+        fn div_4_2() {
+            assert_eq!(FE::from(4) / FE::from(2), FE::from(2))
+        }
+
+        #[test]
+        fn three_inverse_mul_three_is_one() {
+            let a = FE::from(3);
+            assert_eq!(a.inv().unwrap() * a, FE::one())
+        }
+
+        #[test]
+        fn div_4_3() {
+            assert_eq!(FE::from(4) / FE::from(3) * FE::from(3), FE::from(4))
+        }
+
+        #[test]
+        fn two_plus_its_additive_inv_is_0() {
+            let two = FE::from(2);
+
+            assert_eq!(&two + (-&two), FE::from(0))
+        }
+
+        #[test]
+        fn four_minus_three_is_1() {
+            let four = FE::from(4);
+            let three = FE::from(3);
+
+            assert_eq!(four - three, FE::from(1))
+        }
+
+        #[test]
+        fn zero_minus_1_is_order_minus_1() {
+            let zero = FE::from(0);
+            let one = FE::from(1);
+
+            assert_eq!(zero - one, FE::from((ORDER - 1) as u64))
+        }
+
+        // #[test]
+        // #[cfg(feature = "alloc")]
+        // fn byte_serialization_for_a_number_matches_with_byte_conversion_implementation_le() {
+        //     let element =
+        //         FieldElement::<Babybear31PrimeField>::from_hex("0x0123456701234567").unwrap();
+        //     let bytes = element.to_bytes_le();
+        //     let expected_bytes: [u8; 8] = ByteConversion::to_bytes_le(&element).try_into().unwrap();
+        //     assert_eq!(bytes, expected_bytes);
+        // }
+
+        // #[test]
+        // #[cfg(feature = "alloc")]
+        // fn byte_serialization_for_a_number_matches_with_byte_conversion_implementation_be() {
+        //     let element =
+        //         FieldElement::<Babybear31PrimeField>::from_hex("0123456701234567").unwrap();
+        //     let bytes = element.to_bytes_be();
+        //     let expected_bytes: [u8; 8] = ByteConversion::to_bytes_be(&element).try_into().unwrap();
+        //     assert_eq!(bytes, expected_bytes);
+        // }
+
+        // #[test]
+        // fn byte_serialization_and_deserialization_works_le() {
+        //     let element =
+        //         FieldElement::<Babybear31PrimeField>::from_hex("0x7654321076543210").unwrap();
+        //     let bytes = element.to_bytes_le();
+        //     let from_bytes = FieldElement::<Babybear31PrimeField>::from_bytes_le(&bytes).unwrap();
+        //     assert_eq!(element, from_bytes);
+        // }
+
+        // #[test]
+        // fn byte_serialization_and_deserialization_works_be() {
+        //     let element =
+        //         FieldElement::<Babybear31PrimeField>::from_hex("7654321076543210").unwrap();
+        //     let bytes = element.to_bytes_be();
+        //     let from_bytes = FieldElement::<Babybear31PrimeField>::from_bytes_be(&bytes).unwrap();
+        //     assert_eq!(element, from_bytes);
+        // }
     }
 
     #[cfg(all(feature = "std", not(feature = "instruments")))]

--- a/math/src/field/fields/fft_friendly/babybear_u32.rs
+++ b/math/src/field/fields/fft_friendly/babybear_u32.rs
@@ -185,43 +185,40 @@ mod tests {
             assert_eq!(zero - one, FE::from((ORDER - 1) as u64))
         }
 
-        // #[test]
-        // #[cfg(feature = "alloc")]
-        // fn byte_serialization_for_a_number_matches_with_byte_conversion_implementation_le() {
-        //     let element =
-        //         FieldElement::<Babybear31PrimeField>::from_hex("0x0123456701234567").unwrap();
-        //     let bytes = element.to_bytes_le();
-        //     let expected_bytes: [u8; 8] = ByteConversion::to_bytes_le(&element).try_into().unwrap();
-        //     assert_eq!(bytes, expected_bytes);
-        // }
+        #[test]
+        #[cfg(feature = "alloc")]
+        fn byte_serialization_for_a_number_matches_with_byte_conversion_implementation_le() {
+            let element = FieldElement::<Babybear31PrimeField>::from_hex("0123456701234567").unwrap();
+            let bytes = element.to_bytes_le();
+            let expected_bytes: [u8; 8] = ByteConversion::to_bytes_le(&element).try_into().unwrap();
+            assert_eq!(bytes, expected_bytes);
+        }
 
-        // #[test]
-        // #[cfg(feature = "alloc")]
-        // fn byte_serialization_for_a_number_matches_with_byte_conversion_implementation_be() {
-        //     let element =
-        //         FieldElement::<Babybear31PrimeField>::from_hex("0123456701234567").unwrap();
-        //     let bytes = element.to_bytes_be();
-        //     let expected_bytes: [u8; 8] = ByteConversion::to_bytes_be(&element).try_into().unwrap();
-        //     assert_eq!(bytes, expected_bytes);
-        // }
+        #[test]
+        #[cfg(feature = "alloc")]
+        fn byte_serialization_for_a_number_matches_with_byte_conversion_implementation_be() {
+            let element = FieldElement::<Babybear31PrimeField>::from_hex("01234567").unwrap();
+            println!("ELEMENT: {:?}", element);
+            let bytes = element.to_bytes_be();
+            let expected_bytes: [u8; 8] = ByteConversion::to_bytes_be(&element).try_into().unwrap();
+            assert_eq!(bytes, expected_bytes);
+        }
 
-        // #[test]
-        // fn byte_serialization_and_deserialization_works_le() {
-        //     let element =
-        //         FieldElement::<Babybear31PrimeField>::from_hex("0x7654321076543210").unwrap();
-        //     let bytes = element.to_bytes_le();
-        //     let from_bytes = FieldElement::<Babybear31PrimeField>::from_bytes_le(&bytes).unwrap();
-        //     assert_eq!(element, from_bytes);
-        // }
+        #[test]
+        fn byte_serialization_and_deserialization_works_le() {
+            let element = FieldElement::<Babybear31PrimeField>::from_hex("0x76543210").unwrap();
+            let bytes = element.to_bytes_le();
+            let from_bytes = FieldElement::<Babybear31PrimeField>::from_bytes_le(&bytes).unwrap();
+            assert_eq!(element, from_bytes);
+        }
 
-        // #[test]
-        // fn byte_serialization_and_deserialization_works_be() {
-        //     let element =
-        //         FieldElement::<Babybear31PrimeField>::from_hex("7654321076543210").unwrap();
-        //     let bytes = element.to_bytes_be();
-        //     let from_bytes = FieldElement::<Babybear31PrimeField>::from_bytes_be(&bytes).unwrap();
-        //     assert_eq!(element, from_bytes);
-        // }
+        #[test]
+        fn byte_serialization_and_deserialization_works_be() {
+            let element = FieldElement::<Babybear31PrimeField>::from_hex("76543210").unwrap();
+            let bytes = element.to_bytes_be();
+            let from_bytes = FieldElement::<Babybear31PrimeField>::from_bytes_be(&bytes).unwrap();
+            assert_eq!(element, from_bytes);
+        }
     }
 
     #[cfg(all(feature = "std", not(feature = "instruments")))]

--- a/math/src/field/fields/fft_friendly/babybear_u32.rs
+++ b/math/src/field/fields/fft_friendly/babybear_u32.rs
@@ -188,9 +188,10 @@ mod tests {
         #[test]
         #[cfg(feature = "alloc")]
         fn byte_serialization_for_a_number_matches_with_byte_conversion_implementation_le() {
-            let element = FieldElement::<Babybear31PrimeField>::from_hex("0123456701234567").unwrap();
+            let element =
+                FieldElement::<Babybear31PrimeField>::from_hex("0123456701234567").unwrap();
             let bytes = element.to_bytes_le();
-            let expected_bytes: [u8; 8] = ByteConversion::to_bytes_le(&element).try_into().unwrap();
+            let expected_bytes: [u8; 4] = ByteConversion::to_bytes_le(&element).try_into().unwrap();
             assert_eq!(bytes, expected_bytes);
         }
 
@@ -200,7 +201,7 @@ mod tests {
             let element = FieldElement::<Babybear31PrimeField>::from_hex("01234567").unwrap();
             println!("ELEMENT: {:?}", element);
             let bytes = element.to_bytes_be();
-            let expected_bytes: [u8; 8] = ByteConversion::to_bytes_be(&element).try_into().unwrap();
+            let expected_bytes: [u8; 4] = ByteConversion::to_bytes_be(&element).try_into().unwrap();
             assert_eq!(bytes, expected_bytes);
         }
 

--- a/math/src/field/fields/fft_friendly/mod.rs
+++ b/math/src/field/fields/fft_friendly/mod.rs
@@ -10,3 +10,6 @@ pub mod stark_252_prime_field;
 pub mod u64_goldilocks;
 /// Implemenation of the Mersenne Prime field p = 2^31 - 1
 pub mod u64_mersenne_montgomery_field;
+
+/// Inmplementation of the Babybear Prime Field p = 2^31 - 2^27 + 1 using u32
+pub mod babybear_u32;

--- a/math/src/field/fields/mod.rs
+++ b/math/src/field/fields/mod.rs
@@ -13,6 +13,7 @@ pub mod secp256k1_field;
 pub mod secp256k1_scalarfield;
 /// Implementation of secp256r1 base field.
 pub mod secp256r1_field;
+pub mod u32_montgomery_backend_prime_field;
 /// Implementation of the u64 Goldilocks Prime field (p = 2^64 - 2^32 + 1)
 pub mod u64_goldilocks_field;
 /// Implementation of prime fields over 64 bit unsigned integers.

--- a/math/src/field/fields/u32_montgomery_backend_prime_field.rs
+++ b/math/src/field/fields/u32_montgomery_backend_prime_field.rs
@@ -121,25 +121,39 @@ impl<const MODULUS: u32> IsField for U32MontgomeryBackendPrimeField<MODULUS> {
             Self::new_monty(sum)
         }
     */
+
     #[inline(always)]
-    fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
-        // if Self::MODULUS_HAS_ONE_SPARE_BIT {
-        //     MontgomeryAlgorithms::cios_optimized_for_moduli_with_one_spare_bit(
-        //         *a,
-        //         *b,
-        //         MODULUS,
-        //         Self::MU,
-        //     )
-        // } else {
-        MontgomeryAlgorithms::cios(a, b, &MODULUS, &Self::MU)
-        // }
+    fn mul(lhs: &u32, rhs: &u32) -> u32 {
+        let mut o64: u64 = (*lhs as u64).wrapping_mul(*rhs as u64);
+        let low: u32 = 0u32.wrapping_sub(o64 as u32);
+        let red = &Self::MU.wrapping_mul(low);
+        o64 = o64.wrapping_add((*red as u64).wrapping_mul(MODULUS as u64));
+        let ret = (o64 >> 32) as u32;
+        if ret >= MODULUS {
+            ret.wrapping_sub(MODULUS)
+        } else {
+            ret
+        }
     }
+    /*
+        fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+            // if Self::MODULUS_HAS_ONE_SPARE_BIT {
+            //     MontgomeryAlgorithms::cios_optimized_for_moduli_with_one_spare_bit(
+            //         *a,
+            //         *b,
+            //         MODULUS,
+            //         Self::MU,
+            //     )
+            // } else {
+            MontgomeryAlgorithms::cios(a, b, &MODULUS, &Self::MU)
+            // }
+        }
 
-    // #[inline(always)]
-    // fn square(a: &Self::BaseType) -> Self::BaseType {
-    //     MontgomeryAlgorithms::sos_square(*a, MODULUS, &Self::MU)
-    // }
-
+        // #[inline(always)]
+        // fn square(a: &Self::BaseType) -> Self::BaseType {
+        //     MontgomeryAlgorithms::sos_square(*a, MODULUS, &Self::MU)
+        // }
+    */
     #[inline(always)]
     fn sub(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         if b <= a {

--- a/math/src/field/fields/u32_montgomery_backend_prime_field.rs
+++ b/math/src/field/fields/u32_montgomery_backend_prime_field.rs
@@ -1,0 +1,1343 @@
+use crate::errors::CreationError;
+use crate::field::element::FieldElement;
+use crate::field::errors::FieldError;
+use crate::field::traits::IsPrimeField;
+#[cfg(feature = "alloc")]
+use crate::traits::AsBytes;
+use crate::traits::ByteConversion;
+use crate::{field::traits::IsField, unsigned_integer::element::UnsignedInteger};
+
+use core::fmt::Debug;
+
+#[cfg_attr(
+    any(
+        feature = "lambdaworks-serde-binary",
+        feature = "lambdaworks-serde-string"
+    ),
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Clone, Debug, Hash, Copy)]
+pub struct U32MontgomeryBackendPrimeField<const MODULUS: u32>;
+
+impl<const MODULUS: u32> U32MontgomeryBackendPrimeField<MODULUS> {
+    pub const R2: u32 = 1172168163;
+    pub const MU: u32 = 2281701377;
+    pub const ZERO: u32 = 0;
+    pub const ONE: u32 = MontgomeryAlgorithms::cios(&1, &Self::R2, &MODULUS, &Self::MU);
+    const MODULUS_HAS_ONE_SPARE_BIT: bool = true;
+
+    /// Computes `- modulus^{-1} mod 2^{64}`
+    /// This algorithm is given  by Dussé and Kaliski Jr. in
+    /// "S. R. Dussé and B. S. Kaliski Jr. A cryptographic library for the Motorola
+    /// DSP56000. In I. Damgård, editor, Advances in Cryptology – EUROCRYPT’90,
+    /// volume 473 of Lecture Notes in Computer Science, pages 230–244. Springer,
+    /// Heidelberg, May 1991."
+    // const fn compute_mu_parameter() -> u32 {
+    //     let mut y: u32 = 1;
+    //     let word_size = 32;
+    //     let mut i: usize = 2;
+    //     while i <= word_size {
+    //         let (_, lo) = &MODULUS.overflowing_mul(y);
+    //         let least_significant_limb = lo.limbs[0];
+    //         if (least_significant_limb << (word_size - i)) >> (word_size - i) != 1 {
+    //             y += 1 << (i - 1);
+    //         }
+    //         i += 1;
+    //     }
+    //     y.wrapping_neg()
+    // }
+
+    /// Computes 2^{384 * 2} modulo `modulus`
+    // const fn compute_r2_parameter() -> u32 {
+    //     let word_size = 64;
+    //     let mut l: usize = 0;
+    //     let zero: u32 = 0;
+    //     // Define `c` as the largest power of 2 smaller than `modulus`
+    //     while l < word_size {
+    //         if &MODULUS << l != 0 {
+    //             break;
+    //         }
+    //         l += 1;
+    //     }
+    //     let mut c: u32 = 1 << l;
+
+    // // Double `c` and reduce modulo `modulus` until getting
+    // // `2^{2 * number_limbs * word_size}` mod `modulus`
+    // let mut i: usize = 1;
+    // while i <= 2 * word_size - l {
+    //     let (double_c, overflow) = &c.overflowing_add(c);
+    //     c = if (&MODULUS <= &double_c) || *overflow {
+    //         double_c.overflowing_sub(MODULUS).0
+    //     } else {
+    //         *double_c
+    //     };
+    //     i += 1;
+    // }
+    // c
+    // }
+
+    /// Checks whether the most significant limb of the modulus is ats
+    /// most `0x7FFFFFFFFFFFFFFE`. This check is useful since special
+    /// optimizations exist for this kind of moduli.
+    #[inline(always)]
+    const fn modulus_has_one_spare_bit() -> bool {
+        MODULUS < (1u32 << 31) - 1
+    }
+}
+
+impl<const MODULUS: u32> IsField for U32MontgomeryBackendPrimeField<MODULUS> {
+    type BaseType = u32;
+
+    #[inline(always)]
+    fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        let (sum, overflow) = a.overflowing_add(*b);
+        if Self::MODULUS_HAS_ONE_SPARE_BIT {
+            if sum >= MODULUS {
+                sum - MODULUS
+            } else {
+                sum
+            }
+        } else if overflow || sum >= MODULUS {
+            sum - MODULUS
+        } else {
+            sum
+        }
+    }
+
+    #[inline(always)]
+    fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        if Self::MODULUS_HAS_ONE_SPARE_BIT {
+            MontgomeryAlgorithms::cios_optimized_for_moduli_with_one_spare_bit(
+                *a,
+                *b,
+                MODULUS,
+                Self::MU,
+            )
+        } else {
+            MontgomeryAlgorithms::cios(a, b, &MODULUS, &Self::MU)
+        }
+    }
+
+    #[inline(always)]
+    fn square(a: &Self::BaseType) -> Self::BaseType {
+        MontgomeryAlgorithms::sos_square(*a, MODULUS, &Self::MU)
+    }
+
+    #[inline(always)]
+    fn sub(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        if b <= a {
+            a - b
+        } else {
+            MODULUS - (b - a)
+        }
+    }
+
+    #[inline(always)]
+    fn neg(a: &Self::BaseType) -> Self::BaseType {
+        if a == &Self::ZERO {
+            *a
+        } else {
+            MODULUS - a
+        }
+    }
+
+    #[inline(always)]
+    fn inv(a: &Self::BaseType) -> Result<Self::BaseType, FieldError> {
+        if a == &Self::ZERO {
+            Err(FieldError::InvZeroError)
+        } else {
+            // Guajardo Kumar Paar Pelzl
+            // Efficient Software-Implementation of Finite Fields with Applications to
+            // Cryptography
+            // Algorithm 16 (BEA for Inversion in Fp)
+
+            //These can be done with const  functions
+            let modulus_has_spare_bits = MODULUS >> 31 == 0;
+
+            let mut u: u32 = *a;
+            let mut v = MODULUS;
+            let mut b = Self::R2; // Avoids unnecessary reduction step.
+            let mut c = Self::zero();
+
+            while u != 1 && v != 1 {
+                while u & 1 == 0 {
+                    u >>= 1;
+                    if b & 1 == 0 {
+                        b >>= 1;
+                    } else {
+                        let carry;
+                        (b, carry) = b.overflowing_add(MODULUS);
+                        b >>= 1;
+                        if !modulus_has_spare_bits && carry {
+                            b |= 1 << 31;
+                        }
+                    }
+                }
+
+                while v & 1 == 0 {
+                    v >>= 1;
+
+                    if c & 1 == 0 {
+                        c >>= 1;
+                    } else {
+                        let carry;
+                        (c, carry) = c.overflowing_add(MODULUS);
+                        c >>= 1;
+                        if !modulus_has_spare_bits && carry {
+                            c |= 1 << 31;
+                        }
+                    }
+                }
+
+                if v <= u {
+                    u = u - v;
+                    if b < c {
+                        b = MODULUS - c + b;
+                    } else {
+                        b = b - c;
+                    }
+                } else {
+                    v = v - u;
+                    if c < b {
+                        c = MODULUS - b + c;
+                    } else {
+                        c = c - b;
+                    }
+                }
+            }
+
+            if u == 1 {
+                Ok(b)
+            } else {
+                Ok(c)
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn div(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        Self::mul(a, &Self::inv(b).unwrap())
+    }
+
+    #[inline(always)]
+    fn eq(a: &Self::BaseType, b: &Self::BaseType) -> bool {
+        a == b
+    }
+
+    #[inline(always)]
+    fn zero() -> Self::BaseType {
+        Self::ZERO
+    }
+
+    #[inline(always)]
+    fn one() -> Self::BaseType {
+        Self::ONE
+    }
+
+    #[inline(always)]
+    fn from_u64(x: u64) -> Self::BaseType {
+        let x_u32 = x as u32;
+        MontgomeryAlgorithms::cios(&x_u32, &Self::R2, &MODULUS, &Self::MU)
+    }
+
+    #[inline(always)]
+    fn from_base_type(x: Self::BaseType) -> Self::BaseType {
+        MontgomeryAlgorithms::cios(&x, &Self::R2, &MODULUS, &Self::MU)
+    }
+}
+
+impl<const MODULUS: u32> IsPrimeField for U32MontgomeryBackendPrimeField<MODULUS> {
+    type RepresentativeType = Self::BaseType;
+
+    fn representative(x: &Self::BaseType) -> Self::RepresentativeType {
+        MontgomeryAlgorithms::cios(x, &1u32, &MODULUS, &Self::MU)
+    }
+
+    fn field_bit_size() -> usize {
+        let mut evaluated_bit = 32 - 1;
+        let max_element = &MODULUS - 1;
+
+        while ((max_element >> evaluated_bit) & 1) != 1 {
+            evaluated_bit -= 1;
+        }
+
+        evaluated_bit + 1
+    }
+
+    fn from_hex(hex_string: &str) -> Result<Self::BaseType, crate::errors::CreationError> {
+        let mut hex_string = hex_string;
+        // Remove 0x if it's on the string
+        let mut char_iterator = hex_string.chars();
+        if hex_string.len() > 2
+            && char_iterator.next().unwrap() == '0'
+            && char_iterator.next().unwrap() == 'x'
+        {
+            hex_string = &hex_string[2..];
+        }
+        let integer =
+            u32::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)?;
+
+        Ok(MontgomeryAlgorithms::cios(
+            &integer,
+            &Self::R2,
+            &MODULUS,
+            &Self::MU,
+        ))
+    }
+
+    #[cfg(feature = "std")]
+    fn to_hex(x: &Self::BaseType) -> String {
+        format!("{:x}", x)
+    }
+}
+
+impl<const MODULUS: u32> FieldElement<U32MontgomeryBackendPrimeField<MODULUS>> {}
+
+impl<const MODULUS: u32> ByteConversion for FieldElement<U32MontgomeryBackendPrimeField<MODULUS>> {
+    #[cfg(feature = "alloc")]
+    fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {
+        MontgomeryAlgorithms::cios(
+            self.value(),
+            &1,
+            &MODULUS,
+            &U32MontgomeryBackendPrimeField::<MODULUS>::MU,
+        )
+        .to_be_bytes()
+        .to_vec()
+    }
+
+    #[cfg(feature = "alloc")]
+    fn to_bytes_le(&self) -> alloc::vec::Vec<u8> {
+        MontgomeryAlgorithms::cios(
+            self.value(),
+            &1u32,
+            &MODULUS,
+            &U32MontgomeryBackendPrimeField::<MODULUS>::MU,
+        )
+        .to_le_bytes()
+        .to_vec()
+    }
+
+    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError> {
+        let value = u32::from_be_bytes(bytes.try_into().unwrap());
+        Ok(Self::new(value))
+    }
+
+    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError> {
+        let value = u32::from_le_bytes(bytes.try_into().unwrap());
+        Ok(Self::new(value))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MODULUS: u32> AsBytes for FieldElement<U32MontgomeryBackendPrimeField<MODULUS>> {
+    fn as_bytes(&self) -> alloc::vec::Vec<u8> {
+        self.value().to_be_bytes().to_vec()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MODULUS: u32> From<FieldElement<U32MontgomeryBackendPrimeField<MODULUS>>>
+    for alloc::vec::Vec<u8>
+{
+    fn from(value: FieldElement<U32MontgomeryBackendPrimeField<MODULUS>>) -> alloc::vec::Vec<u8> {
+        value.value().to_be_bytes().to_vec()
+    }
+}
+
+pub struct MontgomeryAlgorithms;
+impl MontgomeryAlgorithms {
+    /// Compute CIOS multiplication of `a` * `b`
+    /// `q` is the modulus
+    /// `mu` is the inverse of -q modulo 2^{32}
+    /// Notice CIOS stands for Coarsely Integrated Operand Scanning
+    /// For more information see section 2.3.2 of Tolga Acar's thesis
+    /// https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
+    #[inline(always)]
+    pub const fn cios(a: &u32, b: &u32, q: &u32, mu: &u32) -> u32 {
+        let t = *a as u64 * *b as u64;
+        let m = ((t as u32).wrapping_mul(*mu)) as u64;
+
+        let t = t + m * (*q as u64);
+
+        let c = t >> 32;
+        let mut result = c as u32;
+        if result >= *q {
+            result = result.wrapping_sub(*q);
+        }
+        result
+    }
+
+    /// Compute CIOS multiplication of `a` * `b`
+    /// This is the Algorithm 2 described in the paper
+    /// "EdMSM: Multi-Scalar-Multiplication for SNARKs and Faster Montgomery multiplication"
+    /// https://eprint.iacr.org/2022/1400.pdf.
+    /// It is only suited for moduli with `q[0]` smaller than `2^63 - 1`.
+    /// `q` is the modulus
+    /// `mu` is the inverse of -q modulo 2^{64} -> change this (Juan)
+    #[inline(always)]
+    pub fn cios_optimized_for_moduli_with_one_spare_bit(a: u32, b: u32, q: u32, mu: u32) -> u32 {
+        let t: u64 = (a as u64) * (b as u64);
+
+        let m = ((t as u32).wrapping_mul(mu)) as u64;
+
+        let t = t + m * (q as u64);
+
+        let c = t >> 32;
+        let mut result = c as u32;
+
+        if result >= q {
+            result = result.wrapping_sub(q);
+        }
+        result
+    }
+
+    // Separated Operand Scanning Method (2.3.1)
+    #[inline(always)]
+    pub fn sos_square(a: u32, q: u32, mu: &u32) -> u32 {
+        // NOTE: we use explicit `while` loops in this function because profiling pointed
+        // at iterators of the form `(<x>..<y>).rev()` as the main performance bottleneck.
+        let t: u64 = (a as u64) * (a as u64);
+        let m = ((t as u32).wrapping_mul(*mu)) as u64;
+        let t = t + m * (q as u64);
+
+        let c = t >> 32;
+        let mut result = c as u32;
+
+        if result >= q {
+            result = result.wrapping_sub(q);
+        }
+
+        result
+    }
+}
+
+// #[cfg(test)]
+// mod tests_u384_prime_fields {
+//     use crate::field::element::FieldElement;
+//     use crate::field::errors::FieldError;
+//     use crate::field::fields::fft_friendly::babybear::Babybear31PrimeField;
+//     use crate::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
+
+//     use crate::field::fields::montgomery_backed_prime_fields::{
+//         IsModulus, U256PrimeField, U384PrimeField,
+//     };
+//     use crate::field::traits::IsField;
+//     use crate::field::traits::IsPrimeField;
+//     #[cfg(feature = "alloc")]
+//     use crate::traits::ByteConversion;
+//     use crate::unsigned_integer::element::U384;
+//     use crate::unsigned_integer::element::{UnsignedInteger, U256};
+
+//     type F = U384PrimeField<U384Modulus23>;
+//     type U384F23Element = FieldElement<U384F23>;
+
+//     #[test]
+//     fn u384_mod_23_uses_5_bits() {
+//         assert_eq!(U384F23::field_bit_size(), 5);
+//     }
+
+//     #[test]
+//     fn stark_252_prime_field_uses_252_bits() {
+//         assert_eq!(Stark252PrimeField::field_bit_size(), 252);
+//     }
+
+//     #[test]
+//     fn u256_mod_2_uses_1_bit() {
+//         #[derive(Clone, Debug)]
+//         struct U256Modulus1;
+//         impl IsModulus<U256> for U256Modulus1 {
+//             const MODULUS: U256 = UnsignedInteger::from_u64(2);
+//         }
+//         type U256OneField = U256PrimeField<U256Modulus1>;
+//         assert_eq!(U256OneField::field_bit_size(), 1);
+//     }
+
+//     #[test]
+//     fn u256_with_first_bit_set_uses_256_bit() {
+//         #[derive(Clone, Debug)]
+//         struct U256ModulusBig;
+//         impl IsModulus<U256> for U256ModulusBig {
+//             const MODULUS: U256 = UnsignedInteger::from_hex_unchecked(
+//                 "F0000000F0000000F0000000F0000000F0000000F0000000F0000000F0000000",
+//             );
+//         }
+//         type U256OneField = U256PrimeField<U256ModulusBig>;
+//         assert_eq!(U256OneField::field_bit_size(), 256);
+//     }
+
+//     #[test]
+//     fn montgomery_backend_primefield_compute_r2_parameter() {
+//         let r2: U384 = UnsignedInteger {
+//             limbs: [0, 0, 0, 0, 0, 6],
+//         };
+//         assert_eq!(U384F23::R2, r2);
+//     }
+
+//     #[test]
+//     fn montgomery_backend_primefield_compute_mu_parameter() {
+//         assert_eq!(U384F23::MU, 3208129404123400281);
+//     }
+
+//     #[test]
+//     fn montgomery_backend_primefield_compute_zero_parameter() {
+//         let zero: U384 = UnsignedInteger {
+//             limbs: [0, 0, 0, 0, 0, 0],
+//         };
+//         assert_eq!(U384F23::ZERO, zero);
+//     }
+
+//     #[test]
+//     fn montgomery_backend_primefield_from_u64() {
+//         let a: U384 = UnsignedInteger {
+//             limbs: [0, 0, 0, 0, 0, 17],
+//         };
+//         assert_eq!(U384F23::from_u64(770_u64), a);
+//     }
+
+//     #[test]
+//     fn montgomery_backend_primefield_representative() {
+//         let a: U384 = UnsignedInteger {
+//             limbs: [0, 0, 0, 0, 0, 11],
+//         };
+//         assert_eq!(U384F23::representative(&U384F23::from_u64(770_u64)), a);
+//     }
+
+//     #[test]
+//     fn montgomery_backend_multiplication_works_0() {
+//         let x = U384F23Element::from(11_u64);
+//         let y = U384F23Element::from(10_u64);
+//         let c = U384F23Element::from(110_u64);
+//         assert_eq!(x * y, c);
+//     }
+
+//     #[test]
+//     #[cfg(feature = "lambdaworks-serde-string")]
+//     fn montgomery_backend_serialization_deserialization() {
+//         let x = U384F23Element::from(11_u64);
+//         let x_serialized = serde_json::to_string(&x).unwrap();
+//         let x_deserialized: U384F23Element = serde_json::from_str(&x_serialized).unwrap();
+//         // assert_eq!(x_serialized, "{\"value\":\"0xb\"}"); // serialization is no longer as hex string
+//         assert_eq!(x_deserialized, x);
+//     }
+
+//     #[test]
+//     fn doubling() {
+//         assert_eq!(
+//             U384F23Element::from(2).double(),
+//             U384F23Element::from(2) + U384F23Element::from(2),
+//         );
+//     }
+
+//     const ORDER: usize = 23;
+//     #[test]
+//     fn two_plus_one_is_three() {
+//         assert_eq!(
+//             U384F23Element::from(2) + U384F23Element::from(1),
+//             U384F23Element::from(3)
+//         );
+//     }
+
+//     #[test]
+//     fn max_order_plus_1_is_0() {
+//         assert_eq!(
+//             U384F23Element::from((ORDER - 1) as u64) + U384F23Element::from(1),
+//             U384F23Element::from(0)
+//         );
+//     }
+
+//     #[test]
+//     fn when_comparing_13_and_13_they_are_equal() {
+//         let a: U384F23Element = U384F23Element::from(13);
+//         let b: U384F23Element = U384F23Element::from(13);
+//         assert_eq!(a, b);
+//     }
+
+//     #[test]
+//     fn when_comparing_13_and_8_they_are_different() {
+//         let a: U384F23Element = U384F23Element::from(13);
+//         let b: U384F23Element = U384F23Element::from(8);
+//         assert_ne!(a, b);
+//     }
+
+//     #[test]
+//     fn mul_neutral_element() {
+//         let a: U384F23Element = U384F23Element::from(1);
+//         let b: U384F23Element = U384F23Element::from(2);
+//         assert_eq!(a * b, U384F23Element::from(2));
+//     }
+
+//     #[test]
+//     fn mul_2_3_is_6() {
+//         let a: U384F23Element = U384F23Element::from(2);
+//         let b: U384F23Element = U384F23Element::from(3);
+//         assert_eq!(a * b, U384F23Element::from(6));
+//     }
+
+//     #[test]
+//     fn mul_order_minus_1() {
+//         let a: U384F23Element = U384F23Element::from((ORDER - 1) as u64);
+//         let b: U384F23Element = U384F23Element::from((ORDER - 1) as u64);
+//         assert_eq!(a * b, U384F23Element::from(1));
+//     }
+
+//     #[test]
+//     fn inv_0_error() {
+//         let result = U384F23Element::from(0).inv();
+//         assert!(matches!(result, Err(FieldError::InvZeroError)))
+//     }
+
+//     #[test]
+//     fn inv_2() {
+//         let a: U384F23Element = U384F23Element::from(2);
+//         assert_eq!(&a * a.inv().unwrap(), U384F23Element::from(1));
+//     }
+
+//     #[test]
+//     fn pow_2_3() {
+//         assert_eq!(U384F23Element::from(2).pow(3_u64), U384F23Element::from(8))
+//     }
+
+//     #[test]
+//     fn pow_p_minus_1() {
+//         assert_eq!(
+//             U384F23Element::from(2).pow(ORDER - 1),
+//             U384F23Element::from(1)
+//         )
+//     }
+
+//     #[test]
+//     fn div_1() {
+//         assert_eq!(
+//             U384F23Element::from(2) / U384F23Element::from(1),
+//             U384F23Element::from(2)
+//         )
+//     }
+
+//     #[test]
+//     fn div_4_2() {
+//         assert_eq!(
+//             U384F23Element::from(4) / U384F23Element::from(2),
+//             U384F23Element::from(2)
+//         )
+//     }
+
+//     #[test]
+//     fn three_inverse() {
+//         let a = U384F23Element::from(3);
+//         let expected = U384F23Element::from(8);
+//         assert_eq!(a.inv().unwrap(), expected)
+//     }
+
+//     #[test]
+//     fn div_4_3() {
+//         assert_eq!(
+//             U384F23Element::from(4) / U384F23Element::from(3) * U384F23Element::from(3),
+//             U384F23Element::from(4)
+//         )
+//     }
+
+//     #[test]
+//     fn two_plus_its_additive_inv_is_0() {
+//         let two = U384F23Element::from(2);
+
+//         assert_eq!(&two + (-&two), U384F23Element::from(0))
+//     }
+
+//     #[test]
+//     fn four_minus_three_is_1() {
+//         let four = U384F23Element::from(4);
+//         let three = U384F23Element::from(3);
+
+//         assert_eq!(four - three, U384F23Element::from(1))
+//     }
+
+//     #[test]
+//     fn zero_minus_1_is_order_minus_1() {
+//         let zero = U384F23Element::from(0);
+//         let one = U384F23Element::from(1);
+
+//         assert_eq!(zero - one, U384F23Element::from((ORDER - 1) as u64))
+//     }
+
+//     #[test]
+//     fn neg_zero_is_zero() {
+//         let zero = U384F23Element::from(0);
+
+//         assert_eq!(-&zero, zero);
+//     }
+
+//     // FP1
+//     #[derive(Clone, Debug)]
+//     struct U384ModulusP1;
+//     impl IsModulus<U384> for U384ModulusP1 {
+//         const MODULUS: U384 = UnsignedInteger {
+//             limbs: [
+//                 0,
+//                 0,
+//                 0,
+//                 3450888597,
+//                 5754816256417943771,
+//                 15923941673896418529,
+//             ],
+//         };
+//     }
+
+//     type U384FP1 = U384PrimeField<U384ModulusP1>;
+//     type U384FP1Element = FieldElement<U384FP1>;
+
+//     #[test]
+//     fn montgomery_prime_field_from_bad_hex_errs() {
+//         assert!(U384FP1Element::from_hex("0xTEST").is_err());
+//     }
+
+//     #[test]
+//     fn montgomery_prime_field_addition_works_0() {
+//         let x = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
+//             "05ed176deb0e80b4deb7718cdaa075165f149c",
+//         ));
+//         let y = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
+//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
+//         ));
+//         let c = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
+//             "64fd5279bf47fe02d4185ce279d8aa55e00352",
+//         ));
+//         assert_eq!(x + y, c);
+//     }
+
+//     #[test]
+//     fn montgomery_prime_field_multiplication_works_0() {
+//         let x = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
+//             "05ed176deb0e80b4deb7718cdaa075165f149c",
+//         ));
+//         let y = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
+//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
+//         ));
+//         let c = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
+//             "73d23e8d462060dc23d5c15c00fc432d95621a3c",
+//         ));
+//         assert_eq!(x * y, c);
+//     }
+
+//     // FP2
+//     #[derive(Clone, Debug)]
+//     struct U384ModulusP2;
+//     impl IsModulus<U384> for U384ModulusP2 {
+//         const MODULUS: U384 = UnsignedInteger {
+//             limbs: [
+//                 18446744073709551615,
+//                 18446744073709551615,
+//                 18446744073709551615,
+//                 18446744073709551615,
+//                 18446744073709551615,
+//                 18446744073709551275,
+//             ],
+//         };
+//     }
+
+//     type U384FP2 = U384PrimeField<U384ModulusP2>;
+//     type U384FP2Element = FieldElement<U384FP2>;
+
+//     #[test]
+//     fn montgomery_prime_field_addition_works_1() {
+//         let x = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "05ed176deb0e80b4deb7718cdaa075165f149c",
+//         ));
+//         let y = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
+//         ));
+//         let c = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "64fd5279bf47fe02d4185ce279d8aa55e00352",
+//         ));
+//         assert_eq!(x + y, c);
+//     }
+
+//     #[test]
+//     fn montgomery_prime_field_multiplication_works_1() {
+//         let x = U384FP2Element::one();
+//         let y = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
+//         ));
+//         assert_eq!(&y * x, y);
+//     }
+
+//     #[test]
+//     #[cfg(feature = "alloc")]
+//     fn to_bytes_from_bytes_be_is_the_identity() {
+//         let x = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
+//         ));
+//         assert_eq!(U384FP2Element::from_bytes_be(&x.to_bytes_be()).unwrap(), x);
+//     }
+
+//     #[test]
+//     #[cfg(feature = "alloc")]
+//     fn from_bytes_to_bytes_be_is_the_identity_for_one() {
+//         let bytes = [
+//             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+//         ];
+//         assert_eq!(
+//             U384FP2Element::from_bytes_be(&bytes).unwrap().to_bytes_be(),
+//             bytes
+//         );
+//     }
+
+//     #[test]
+//     #[cfg(feature = "alloc")]
+//     fn to_bytes_from_bytes_le_is_the_identity() {
+//         let x = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
+//         ));
+//         assert_eq!(U384FP2Element::from_bytes_le(&x.to_bytes_le()).unwrap(), x);
+//     }
+
+//     #[test]
+//     #[cfg(feature = "alloc")]
+//     fn from_bytes_to_bytes_le_is_the_identity_for_one() {
+//         let bytes = [
+//             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//         ];
+//         assert_eq!(
+//             U384FP2Element::from_bytes_le(&bytes).unwrap().to_bytes_le(),
+//             bytes
+//         );
+//     }
+// }
+
+// #[cfg(test)]
+// mod tests_u256_prime_fields {
+//     use crate::field::element::FieldElement;
+//     use crate::field::errors::FieldError;
+//     use crate::field::fields::montgomery_backed_prime_fields::{IsModulus, U256PrimeField};
+//     use crate::field::traits::IsField;
+//     use crate::field::traits::IsPrimeField;
+//     #[cfg(feature = "alloc")]
+//     use crate::traits::ByteConversion;
+//     use crate::unsigned_integer::element::U256;
+//     use crate::unsigned_integer::element::{UnsignedInteger, U64};
+//     use proptest::prelude::*;
+
+//     use super::U64PrimeField;
+
+//     #[derive(Clone, Debug)]
+//     struct U256Modulus29;
+//     impl IsModulus<U256> for U256Modulus29 {
+//         const MODULUS: U256 = UnsignedInteger::from_u64(29);
+//     }
+
+//     type U256F29 = U256PrimeField<U256Modulus29>;
+//     type U256F29Element = FieldElement<U256F29>;
+
+//     #[test]
+//     fn montgomery_backend_primefield_compute_r2_parameter() {
+//         let r2: U256 = UnsignedInteger {
+//             limbs: [0, 0, 0, 24],
+//         };
+//         assert_eq!(U256F29::R2, r2);
+//     }
+
+//     #[test]
+//     fn montgomery_backend_primefield_compute_mu_parameter() {
+//         // modular multiplicative inverse
+//         assert_eq!(U256F29::MU, 14630176334321368523);
+//     }
+
+//     #[test]
+//     fn montgomery_backend_primefield_compute_zero_parameter() {
+//         let zero: U256 = UnsignedInteger {
+//             limbs: [0, 0, 0, 0],
+//         };
+//         assert_eq!(U256F29::ZERO, zero);
+//     }
+
+//     #[test]
+//     fn montgomery_backend_primefield_from_u64() {
+//         // (770*2**(256))%29
+//         let a: U256 = UnsignedInteger {
+//             limbs: [0, 0, 0, 24],
+//         };
+//         assert_eq!(U256F29::from_u64(770_u64), a);
+//     }
+
+//     #[test]
+//     fn montgomery_backend_primefield_representative() {
+//         // 770%29
+//         let a: U256 = UnsignedInteger {
+//             limbs: [0, 0, 0, 16],
+//         };
+//         assert_eq!(U256F29::representative(&U256F29::from_u64(770_u64)), a);
+//     }
+
+//     #[test]
+//     fn montgomery_backend_multiplication_works_0() {
+//         let x = U256F29Element::from(11_u64);
+//         let y = U256F29Element::from(10_u64);
+//         let c = U256F29Element::from(110_u64);
+//         assert_eq!(x * y, c);
+//     }
+
+//     #[test]
+//     fn doubling() {
+//         assert_eq!(
+//             U256F29Element::from(2).double(),
+//             U256F29Element::from(2) + U256F29Element::from(2),
+//         );
+//     }
+
+//     const ORDER: usize = 29;
+//     #[test]
+//     fn two_plus_one_is_three() {
+//         assert_eq!(
+//             U256F29Element::from(2) + U256F29Element::from(1),
+//             U256F29Element::from(3)
+//         );
+//     }
+
+//     #[test]
+//     fn max_order_plus_1_is_0() {
+//         assert_eq!(
+//             U256F29Element::from((ORDER - 1) as u64) + U256F29Element::from(1),
+//             U256F29Element::from(0)
+//         );
+//     }
+
+//     #[test]
+//     fn when_comparing_13_and_13_they_are_equal() {
+//         let a: U256F29Element = U256F29Element::from(13);
+//         let b: U256F29Element = U256F29Element::from(13);
+//         assert_eq!(a, b);
+//     }
+
+//     #[test]
+//     fn when_comparing_13_and_8_they_are_different() {
+//         let a: U256F29Element = U256F29Element::from(13);
+//         let b: U256F29Element = U256F29Element::from(8);
+//         assert_ne!(a, b);
+//     }
+
+//     #[test]
+//     fn mul_neutral_element() {
+//         let a: U256F29Element = U256F29Element::from(1);
+//         let b: U256F29Element = U256F29Element::from(2);
+//         assert_eq!(a * b, U256F29Element::from(2));
+//     }
+
+//     #[test]
+//     fn mul_2_3_is_6() {
+//         let a: U256F29Element = U256F29Element::from(2);
+//         let b: U256F29Element = U256F29Element::from(3);
+//         assert_eq!(a * b, U256F29Element::from(6));
+//     }
+
+//     #[test]
+//     fn mul_order_minus_1() {
+//         let a: U256F29Element = U256F29Element::from((ORDER - 1) as u64);
+//         let b: U256F29Element = U256F29Element::from((ORDER - 1) as u64);
+//         assert_eq!(a * b, U256F29Element::from(1));
+//     }
+
+//     #[test]
+//     fn inv_0_error() {
+//         let result = U256F29Element::from(0).inv();
+//         assert!(matches!(result, Err(FieldError::InvZeroError)));
+//     }
+
+//     #[test]
+//     fn inv_2() {
+//         let a: U256F29Element = U256F29Element::from(2);
+//         assert_eq!(&a * a.inv().unwrap(), U256F29Element::from(1));
+//     }
+
+//     #[test]
+//     fn pow_2_3() {
+//         assert_eq!(U256F29Element::from(2).pow(3_u64), U256F29Element::from(8))
+//     }
+
+//     #[test]
+//     fn pow_p_minus_1() {
+//         assert_eq!(
+//             U256F29Element::from(2).pow(ORDER - 1),
+//             U256F29Element::from(1)
+//         )
+//     }
+
+//     #[test]
+//     fn div_1() {
+//         assert_eq!(
+//             U256F29Element::from(2) / U256F29Element::from(1),
+//             U256F29Element::from(2)
+//         )
+//     }
+
+//     #[test]
+//     fn div_4_2() {
+//         let a = U256F29Element::from(4);
+//         let b = U256F29Element::from(2);
+//         assert_eq!(a / &b, b)
+//     }
+
+//     #[test]
+//     fn div_4_3() {
+//         assert_eq!(
+//             U256F29Element::from(4) / U256F29Element::from(3) * U256F29Element::from(3),
+//             U256F29Element::from(4)
+//         )
+//     }
+
+//     #[test]
+//     fn two_plus_its_additive_inv_is_0() {
+//         let two = U256F29Element::from(2);
+
+//         assert_eq!(&two + (-&two), U256F29Element::from(0))
+//     }
+
+//     #[test]
+//     fn four_minus_three_is_1() {
+//         let four = U256F29Element::from(4);
+//         let three = U256F29Element::from(3);
+
+//         assert_eq!(four - three, U256F29Element::from(1))
+//     }
+
+//     #[test]
+//     fn zero_minus_1_is_order_minus_1() {
+//         let zero = U256F29Element::from(0);
+//         let one = U256F29Element::from(1);
+
+//         assert_eq!(zero - one, U256F29Element::from((ORDER - 1) as u64))
+//     }
+
+//     #[test]
+//     fn neg_zero_is_zero() {
+//         let zero = U256F29Element::from(0);
+
+//         assert_eq!(-&zero, zero);
+//     }
+
+//     // FP1
+//     #[derive(Clone, Debug)]
+//     struct U256ModulusP1;
+//     impl IsModulus<U256> for U256ModulusP1 {
+//         const MODULUS: U256 = UnsignedInteger {
+//             limbs: [
+//                 8366,
+//                 8155137382671976874,
+//                 227688614771682406,
+//                 15723111795979912613,
+//             ],
+//         };
+//     }
+
+//     type U256FP1 = U256PrimeField<U256ModulusP1>;
+//     type U256FP1Element = FieldElement<U256FP1>;
+
+//     #[test]
+//     fn montgomery_prime_field_addition_works_0() {
+//         let x = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
+//             "93e712950bf3fe589aa030562a44b1cec66b09192c4bcf705a5",
+//         ));
+//         let y = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
+//             "10a712235c1f6b4172a1e35da6aef1a7ec6b09192c4bb88cfa5",
+//         ));
+//         let c = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
+//             "a48e24b86813699a0d4213b3d0f3a376b2d61232589787fd54a",
+//         ));
+//         assert_eq!(x + y, c);
+//     }
+
+//     #[test]
+//     fn montgomery_prime_field_multiplication_works_0() {
+//         let x = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
+//             "93e712950bf3fe589aa030562a44b1cec66b09192c4bcf705a5",
+//         ));
+//         let y = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
+//             "10a712235c1f6b4172a1e35da6aef1a7ec6b09192c4bb88cfa5",
+//         ));
+//         let c = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
+//             "7808e74c3208d9a66791ef9cc15a46acc9951ee312102684021",
+//         ));
+//         assert_eq!(x * y, c);
+//     }
+
+//     // FP2
+//     #[derive(Clone, Debug)]
+//     struct ModulusP2;
+//     impl IsModulus<U256> for ModulusP2 {
+//         const MODULUS: U256 = UnsignedInteger {
+//             limbs: [
+//                 18446744073709551615,
+//                 18446744073709551615,
+//                 18446744073709551615,
+//                 18446744073709551427,
+//             ],
+//         };
+//     }
+
+//     type FP2 = U256PrimeField<ModulusP2>;
+//     type FP2Element = FieldElement<FP2>;
+
+//     #[test]
+//     fn montgomery_prime_field_addition_works_1() {
+//         let x = FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "acbbb7ca01c65cfffffc72815b397fff9ab130ad53a5ffffffb8f21b207dfedf",
+//         ));
+//         let y = FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "d65ddbe509d3fffff21f494c588cbdbfe43e929b0543e3ffffffffffffffff43",
+//         ));
+//         let c = FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "831993af0b9a5cfff21bbbcdb3c63dbf7eefc34858e9e3ffffb8f21b207dfedf",
+//         ));
+//         assert_eq!(x + y, c);
+//     }
+
+//     #[test]
+//     fn montgomery_prime_field_multiplication_works_1() {
+//         let x = FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "acbbb7ca01c65cfffffc72815b397fff9ab130ad53a5ffffffb8f21b207dfedf",
+//         ));
+//         let y = FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "d65ddbe509d3fffff21f494c588cbdbfe43e929b0543e3ffffffffffffffff43",
+//         ));
+//         let c = FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "2b1e80d553ecab2e4d41eb53c4c8ad89ebacac6cf6b91dcf2213f311093aa05d",
+//         ));
+//         assert_eq!(&y * x, c);
+//     }
+
+//     #[test]
+//     #[cfg(feature = "alloc")]
+//     fn to_bytes_from_bytes_be_is_the_identity() {
+//         let x = FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
+//         ));
+//         assert_eq!(FP2Element::from_bytes_be(&x.to_bytes_be()).unwrap(), x);
+//     }
+
+//     #[test]
+//     #[cfg(feature = "alloc")]
+//     fn from_bytes_to_bytes_be_is_the_identity_for_one() {
+//         let bytes = [
+//             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//             0, 0, 1,
+//         ];
+//         assert_eq!(
+//             FP2Element::from_bytes_be(&bytes).unwrap().to_bytes_be(),
+//             bytes
+//         );
+//     }
+
+//     #[test]
+//     #[cfg(feature = "alloc")]
+//     fn to_bytes_from_bytes_le_is_the_identity() {
+//         let x = FP2Element::new(UnsignedInteger::from_hex_unchecked(
+//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
+//         ));
+//         assert_eq!(FP2Element::from_bytes_le(&x.to_bytes_le()).unwrap(), x);
+//     }
+
+//     #[test]
+//     #[cfg(feature = "alloc")]
+//     fn from_bytes_to_bytes_le_is_the_identity_for_one() {
+//         let bytes = [
+//             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//             0, 0, 0,
+//         ];
+//         assert_eq!(
+//             FP2Element::from_bytes_le(&bytes).unwrap().to_bytes_le(),
+//             bytes
+//         );
+//     }
+
+//     #[test]
+//     #[cfg(feature = "alloc")]
+//     fn creating_a_field_element_from_its_representative_returns_the_same_element_1() {
+//         let change = U256::from_u64(1);
+//         let f1 = U256FP1Element::new(U256ModulusP1::MODULUS + change);
+//         let f2 = U256FP1Element::new(f1.representative());
+//         assert_eq!(f1, f2);
+//     }
+
+//     #[test]
+//     fn creating_a_field_element_from_its_representative_returns_the_same_element_2() {
+//         let change = U256::from_u64(27);
+//         let f1 = U256F29Element::new(U256Modulus29::MODULUS + change);
+//         let f2 = U256F29Element::new(f1.representative());
+//         assert_eq!(f1, f2);
+//     }
+
+//     #[test]
+//     fn creating_a_field_element_from_hex_works_1() {
+//         let a = U256FP1Element::from_hex_unchecked("eb235f6144d9e91f4b14");
+//         let b = U256FP1Element::new(U256 {
+//             limbs: [0, 0, 60195, 6872850209053821716],
+//         });
+//         assert_eq!(a, b);
+//     }
+
+//     #[test]
+//     fn creating_a_field_element_from_hex_too_big_errors() {
+//         let a = U256FP1Element::from_hex(&"f".repeat(65));
+//         assert!(a.is_err());
+//         assert_eq!(
+//             a.unwrap_err(),
+//             crate::errors::CreationError::HexStringIsTooBig
+//         )
+//     }
+
+//     #[test]
+//     fn creating_a_field_element_from_hex_works_on_the_size_limit() {
+//         let a = U256FP1Element::from_hex(&"f".repeat(64));
+//         assert!(a.is_ok());
+//     }
+
+//     #[test]
+//     fn creating_a_field_element_from_hex_works_2() {
+//         let a = U256F29Element::from_hex_unchecked("aa");
+//         let b = U256F29Element::from(25);
+//         assert_eq!(a, b);
+//     }
+
+//     #[test]
+//     fn creating_a_field_element_from_hex_works_3() {
+//         let a = U256F29Element::from_hex_unchecked("1d");
+//         let b = U256F29Element::zero();
+//         assert_eq!(a, b);
+//     }
+
+//     #[cfg(feature = "std")]
+//     #[test]
+//     fn to_hex_test_works_1() {
+//         let a = U256FP1Element::from_hex_unchecked("eb235f6144d9e91f4b14");
+//         let b = U256FP1Element::new(U256 {
+//             limbs: [0, 0, 60195, 6872850209053821716],
+//         });
+
+//         assert_eq!(U256FP1Element::to_hex(&a), U256FP1Element::to_hex(&b));
+//     }
+
+//     #[cfg(feature = "std")]
+//     #[test]
+//     fn to_hex_test_works_2() {
+//         let a = U256F29Element::from_hex_unchecked("1d");
+//         let b = U256F29Element::zero();
+
+//         assert_eq!(U256F29Element::to_hex(&a), U256F29Element::to_hex(&b));
+//     }
+
+//     #[cfg(feature = "std")]
+//     #[test]
+//     fn to_hex_test_works_3() {
+//         let a = U256F29Element::from_hex_unchecked("aa");
+//         let b = U256F29Element::from(25);
+
+//         assert_eq!(U256F29Element::to_hex(&a), U256F29Element::to_hex(&b));
+//     }
+
+//     // Goldilocks
+//     #[derive(Clone, Debug)]
+//     struct GoldilocksModulus;
+//     impl IsModulus<U64> for GoldilocksModulus {
+//         const MODULUS: U64 = UnsignedInteger {
+//             limbs: [18446744069414584321],
+//         };
+//     }
+
+//     type GoldilocksField = U64PrimeField<GoldilocksModulus>;
+//     type GoldilocksElement = FieldElement<GoldilocksField>;
+
+//     #[derive(Clone, Debug)]
+//     struct SecpModulus;
+//     impl IsModulus<U256> for SecpModulus {
+//         const MODULUS: U256 = UnsignedInteger::from_hex_unchecked(
+//             "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
+//         );
+//     }
+//     type SecpMontField = U256PrimeField<SecpModulus>;
+//     type SecpMontElement = FieldElement<SecpMontField>;
+
+//     #[test]
+//     fn secp256k1_minus_three_pow_2_is_9_with_all_operations() {
+//         let minus_3 = -SecpMontElement::from_hex_unchecked("0x3");
+//         let minus_3_mul_minus_3 = &minus_3 * &minus_3;
+//         let minus_3_squared = minus_3.square();
+//         let minus_3_pow_2 = minus_3.pow(2_u32);
+//         let nine = SecpMontElement::from_hex_unchecked("0x9");
+
+//         assert_eq!(minus_3_mul_minus_3, nine);
+//         assert_eq!(minus_3_squared, nine);
+//         assert_eq!(minus_3_pow_2, nine);
+//     }
+
+//     #[test]
+//     fn secp256k1_inv_works() {
+//         let a = SecpMontElement::from_hex_unchecked("0x456");
+//         let a_inv = a.inv().unwrap();
+
+//         assert_eq!(a * a_inv, SecpMontElement::one());
+//     }
+
+//     #[test]
+//     fn test_cios_overflow_case() {
+//         let a = GoldilocksElement::from(732582227915286439);
+//         let b = GoldilocksElement::from(3906369333256140342);
+//         let expected_sum = GoldilocksElement::from(4638951561171426781);
+//         assert_eq!(a + b, expected_sum);
+//     }
+
+//     // Tests for the Montgomery Algorithms
+//     proptest! {
+//         #[test]
+//         fn cios_vs_cios_optimized(a in any::<[u64; 6]>(), b in any::<[u64; 6]>()) {
+//             let x = U384::from_limbs(a);
+//             let y = U384::from_limbs(b);
+//             let m = U384::from_hex_unchecked("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
+//             let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
+//             assert_eq!(
+//                 MontgomeryAlgorithms::cios(&x, &y, &m, &mu),
+//                 MontgomeryAlgorithms::cios_optimized_for_moduli_with_one_spare_bit(&x, &y, &m, &mu)
+//             );
+//         }
+
+//         #[test]
+//         fn cios_vs_sos_square(a in any::<[u64; 6]>()) {
+//             let x = U384::from_limbs(a);
+//             let m = U384::from_hex_unchecked("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
+//             let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
+//             assert_eq!(
+//                 MontgomeryAlgorithms::cios(&x, &x, &m, &mu),
+//                 MontgomeryAlgorithms::sos_square(&x, &m, &mu)
+//             );
+//         }
+//     }
+//     #[test]
+//     fn montgomery_multiplication_works_0() {
+//         let x = U384::from_u64(11_u64);
+//         let y = U384::from_u64(10_u64);
+//         let m = U384::from_u64(23_u64); //
+//         let mu: u64 = 3208129404123400281; // negative of the inverse of `m` modulo 2^{64}.
+//         let c = U384::from_u64(13_u64); // x * y * (r^{-1}) % m, where r = 2^{64 * 6} and r^{-1} mod m = 2.
+//         assert_eq!(MontgomeryAlgorithms::cios(&x, &y, &m, &mu), c);
+//     }
+
+//     #[test]
+//     fn montgomery_multiplication_works_1() {
+//         let x = U384::from_hex_unchecked("05ed176deb0e80b4deb7718cdaa075165f149c");
+//         let y = U384::from_hex_unchecked("5f103b0bd4397d4df560eb559f38353f80eeb6");
+//         let m = U384::from_hex_unchecked("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
+//         let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
+//         let c = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc"); // x * y * (r^{-1}) % m, where r = 2^{64 * 6}
+//         assert_eq!(MontgomeryAlgorithms::cios(&x, &y, &m, &mu), c);
+//     }
+
+//     #[test]
+//     fn montgomery_multiplication_works_2() {
+//         let x = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc");
+//         let m = U384::from_hex_unchecked("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
+//         let r_mod_m = U384::from_hex_unchecked("58dfb0e1b3dd5e674bdcde4f42eb5533b8759d33");
+//         let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
+//         let c = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc");
+//         assert_eq!(MontgomeryAlgorithms::cios(&x, &r_mod_m, &m, &mu), c);
+//     }
+// }

--- a/math/src/field/fields/u32_montgomery_backend_prime_field.rs
+++ b/math/src/field/fields/u32_montgomery_backend_prime_field.rs
@@ -1,14 +1,13 @@
 use crate::errors::CreationError;
 use crate::field::element::FieldElement;
 use crate::field::errors::FieldError;
+use crate::field::traits::IsField;
 use crate::field::traits::IsPrimeField;
 #[cfg(feature = "alloc")]
 use crate::traits::AsBytes;
 use crate::traits::ByteConversion;
-use crate::{field::traits::IsField, unsigned_integer::element::UnsignedInteger};
 
 use core::fmt::Debug;
-
 #[cfg_attr(
     any(
         feature = "lambdaworks-serde-binary",
@@ -23,8 +22,7 @@ impl<const MODULUS: u32> U32MontgomeryBackendPrimeField<MODULUS> {
     pub const R2: u32 = Self::compute_r2_parameter();
     pub const MU: u32 = Self::compute_mu_parameter();
     pub const ZERO: u32 = 0;
-    pub const ONE: u32 = MontgomeryAlgorithms::cios(&1, &Self::R2, &MODULUS, &Self::MU);
-    const MODULUS_HAS_ONE_SPARE_BIT: bool = true;
+    pub const ONE: u32 = MontgomeryAlgorithms::mul(&1, &Self::R2, &MODULUS, &Self::MU);
 
     // Computes `modulus^{-1} mod 2^{32}`
     // Algorithm adapted from `compute_mu_parameter()` from `montgomery_backed_prime_fields.rs` in Lambdaworks.
@@ -70,14 +68,6 @@ impl<const MODULUS: u32> U32MontgomeryBackendPrimeField<MODULUS> {
         }
         c
     }
-
-    /// Checks whether the most significant limb of the modulus is ats
-    /// most `0x7FFFFFFFFFFFFFFE`. This check is useful since special
-    /// optimizations exist for this kind of moduli.
-    #[inline(always)]
-    const fn modulus_has_one_spare_bit() -> bool {
-        MODULUS < (1u32 << 31) - 1
-    }
 }
 
 impl<const MODULUS: u32> IsField for U32MontgomeryBackendPrimeField<MODULUS> {
@@ -91,64 +81,13 @@ impl<const MODULUS: u32> IsField for U32MontgomeryBackendPrimeField<MODULUS> {
             sum = corr_sum;
         }
         sum
-
-        // let (sum, overflow) = a.overflowing_add(*b);
-        // if Self::MODULUS_HAS_ONE_SPARE_BIT {
-        //     if sum >= MODULUS {
-        //         sum - MODULUS
-        //     } else {
-        //         sum
-        //     }
-        // } else if overflow || sum >= MODULUS {
-        //     sum - MODULUS
-        // } else {
-        //     sum
-        // }
     }
-    /*
-
-        fn add(self, rhs: Self) -> Self {
-            let mut sum = self.value + rhs.value;
-            let (corr_sum, over) = sum.overflowing_sub(FP::PRIME);
-            if !over {
-                sum = corr_sum;
-            }
-            Self::new_monty(sum)
-        }
-    */
 
     #[inline(always)]
-    fn mul(lhs: &u32, rhs: &u32) -> u32 {
-        let mut o64: u64 = (*lhs as u64).wrapping_mul(*rhs as u64);
-        let low: u32 = 0u32.wrapping_sub(o64 as u32);
-        let red = &Self::MU.wrapping_mul(low);
-        o64 = o64.wrapping_add((*red as u64).wrapping_mul(MODULUS as u64));
-        let ret = (o64 >> 32) as u32;
-        if ret >= MODULUS {
-            ret.wrapping_sub(MODULUS)
-        } else {
-            ret
-        }
+    fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        MontgomeryAlgorithms::mul(a, b, &MODULUS, &Self::MU)
     }
-    /*
-        fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
-            // if Self::MODULUS_HAS_ONE_SPARE_BIT {
-            //     MontgomeryAlgorithms::cios_optimized_for_moduli_with_one_spare_bit(
-            //         *a,
-            //         *b,
-            //         MODULUS,
-            //         Self::MU,
-            //     )
-            // } else {
-            MontgomeryAlgorithms::cios(a, b, &MODULUS, &Self::MU)
-            // }
-        }
 
-        // #[inline(always)]
-        // fn square(a: &Self::BaseType) -> Self::BaseType {
-        //     MontgomeryAlgorithms::sos_square(*a, MODULUS, &Self::MU)
-        // }
-    */
     #[inline(always)]
     fn sub(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         if b <= a {
@@ -167,154 +106,43 @@ impl<const MODULUS: u32> IsField for U32MontgomeryBackendPrimeField<MODULUS> {
         }
     }
 
+    /// Computes multiplicative inverse using Fermat's Little Theorem
+    /// It states that for any non-zero element a in field F_p: a^(p-1) ≡ 1 (mod p)
+    /// Therefore: a^(p-2) * a ≡ 1 (mod p), so a^(p-2) is the multiplicative inverse
+    /// Implementation inspired by Plonky3's work.
+    /// <https://github.com/Plonky3/Plonky3/blob/636ed23f3b0de1fe16e87b67d1f25402414fa5d7/baby-bear/src/baby_bear.rs#L36>
     #[inline(always)]
-
     fn inv(a: &Self::BaseType) -> Result<Self::BaseType, FieldError> {
         if *a == Self::ZERO {
             return Err(FieldError::InvZeroError);
         }
-
         let p100000000 = MontgomeryAlgorithms::exp_power_of_2(a, 8, &MODULUS);
-
         let p100000001 = Self::mul(&p100000000, a);
-
         let p10000000000000000 = MontgomeryAlgorithms::exp_power_of_2(&p100000000, 8, &MODULUS);
-
         let p10000000100000001 = Self::mul(&p10000000000000000, &p100000001);
-
         let p10000000100000001000 =
             MontgomeryAlgorithms::exp_power_of_2(&p10000000100000001, 3, &MODULUS);
-
         let p1000000010000000100000000 =
             MontgomeryAlgorithms::exp_power_of_2(&p10000000100000001000, 5, &MODULUS);
-
         let p1000000010000000100000001 = Self::mul(&p1000000010000000100000000, a);
-
         let p1000010010000100100001001 =
             Self::mul(&p1000000010000000100000001, &p10000000100000001000);
-
         let p10000000100000001000000010 = Self::square(&p1000000010000000100000001);
 
         let p11000010110000101100001011 =
             Self::mul(&p10000000100000001000000010, &p1000010010000100100001001);
-
         let p100000001000000010000000100 = Self::square(&p10000000100000001000000010);
-
         let p111000011110000111100001111 =
             Self::mul(&p100000001000000010000000100, &p11000010110000101100001011);
-
         let p1110000111100001111000011110000 =
             MontgomeryAlgorithms::exp_power_of_2(&p111000011110000111100001111, 4, &MODULUS);
-
         let p1110111111111111111111111111111 = Self::mul(
             &p1110000111100001111000011110000,
             &p111000011110000111100001111,
         );
-
         Ok(p1110111111111111111111111111111)
     }
 
-    /*fn inv(a: &Self::BaseType) -> Result<Self::BaseType, FieldError> {
-           // if a == &Self::ZERO {
-           //     return Err(FieldError::InvZeroError);
-           // }
-
-           // // From Fermat's little theorem, in a prime field `F_p`, the inverse of `a` is `a^(p-2)`.
-           // // Here p-2 = 2013265919 = 1110111111111111111111111111111_2.
-           // // Uses 30 Squares + 7 Multiplications => 37 Operations total.
-           // let p100000000 = MontgomeryAlgorithms::exp_power_of_2(a, 8, &MODULUS) as u64;
-           // let p100000001 = p100000000 * a;
-           // let p10000000000000000 = MontgomeryAlgorithms::exp_power_of_2(&p100000000, 8, &MODULUS);
-           // let p10000000100000001 = p10000000000000000 * p100000001;
-           // let p10000000100000001000 =
-           //     MontgomeryAlgorithms::exp_power_of_2(&p10000000100000001, 3, &MODULUS);
-           // let p1000000010000000100000000 =
-           //     MontgomeryAlgorithms::exp_power_of_2(&p10000000100000001000, 5, &MODULUS);
-           // let p1000000010000000100000001 = p1000000010000000100000000 * a;
-           // let p1000010010000100100001001 = p1000000010000000100000001 * p10000000100000001000;
-           // let p10000000100000001000000010 = p1000000010000000100000001.pow(2);
-           // let p11000010110000101100001011 = p10000000100000001000000010 * p1000010010000100100001001;
-           // let p100000001000000010000000100 = p10000000100000001000000010.pow(2);
-           // let p111000011110000111100001111 =
-           //     p100000001000000010000000100 * p11000010110000101100001011;
-           // let p1110000111100001111000011110000 =
-           //     MontgomeryAlgorithms::exp_power_of_2(&p111000011110000111100001111, 4, &MODULUS);
-           // let p1110111111111111111111111111111 =
-           //     p1110000111100001111000011110000 * p111000011110000111100001111;
-
-           // Ok(p1110111111111111111111111111111 as u32)
-
-           if a == &Self::ZERO {
-               Err(FieldError::InvZeroError)
-           } else {
-               // Guajardo Kumar Paar Pelzl
-               // Efficient Software-Implementation of Finite Fields with Applications to
-               // Cryptography
-               // Algorithm 16 (BEA for Inversion in Fp)
-
-               //These can be done with const  functions
-               let modulus_has_spare_bits = MODULUS >> 31 == 0;
-
-               let mut u: u32 = *a;
-               let mut v = MODULUS;
-               let mut b = Self::R2; // Avoids unnecessary reduction step.
-               let mut c = Self::zero();
-
-               while u != 1 && v != 1 {
-                   while u & 1 == 0 {
-                       u >>= 1;
-                       if b & 1 == 0 {
-                           b >>= 1;
-                       } else {
-                           let carry;
-                           (b, carry) = b.overflowing_add(MODULUS);
-                           b >>= 1;
-                           if !modulus_has_spare_bits && carry {
-                               b |= 1 << 31;
-                           }
-                       }
-                   }
-
-                   while v & 1 == 0 {
-                       v >>= 1;
-
-                       if c & 1 == 0 {
-                           c >>= 1;
-                       } else {
-                           let carry;
-                           (c, carry) = c.overflowing_add(MODULUS);
-                           c >>= 1;
-                           if !modulus_has_spare_bits && carry {
-                               c |= 1 << 31;
-                           }
-                       }
-                   }
-
-                   if v <= u {
-                       u = u - v;
-                       if b < c {
-                           b = MODULUS - c + b;
-                       } else {
-                           b = b - c;
-                       }
-                   } else {
-                       v = v - u;
-                       if c < b {
-                           c = MODULUS - b + c;
-                       } else {
-                           c = c - b;
-                       }
-                   }
-               }
-
-               if u == 1 {
-                   Ok(b)
-               } else {
-                   Ok(c)
-               }
-           }
-       }
-    */
     #[inline(always)]
     fn div(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         Self::mul(a, &Self::inv(b).unwrap())
@@ -338,12 +166,12 @@ impl<const MODULUS: u32> IsField for U32MontgomeryBackendPrimeField<MODULUS> {
     #[inline(always)]
     fn from_u64(x: u64) -> Self::BaseType {
         let x_u32 = x as u32;
-        MontgomeryAlgorithms::cios(&x_u32, &Self::R2, &MODULUS, &Self::MU)
+        MontgomeryAlgorithms::mul(&x_u32, &Self::R2, &MODULUS, &Self::MU)
     }
 
     #[inline(always)]
     fn from_base_type(x: Self::BaseType) -> Self::BaseType {
-        MontgomeryAlgorithms::cios(&x, &Self::R2, &MODULUS, &Self::MU)
+        MontgomeryAlgorithms::mul(&x, &Self::R2, &MODULUS, &Self::MU)
     }
 }
 
@@ -351,7 +179,7 @@ impl<const MODULUS: u32> IsPrimeField for U32MontgomeryBackendPrimeField<MODULUS
     type RepresentativeType = Self::BaseType;
 
     fn representative(x: &Self::BaseType) -> Self::RepresentativeType {
-        MontgomeryAlgorithms::cios(x, &1u32, &MODULUS, &Self::MU)
+        MontgomeryAlgorithms::mul(x, &1u32, &MODULUS, &Self::MU)
     }
 
     fn field_bit_size() -> usize {
@@ -367,7 +195,6 @@ impl<const MODULUS: u32> IsPrimeField for U32MontgomeryBackendPrimeField<MODULUS
 
     fn from_hex(hex_string: &str) -> Result<Self::BaseType, crate::errors::CreationError> {
         let mut hex_string = hex_string;
-        // Remove 0x if it's on the string
         let mut char_iterator = hex_string.chars();
         if hex_string.len() > 2
             && char_iterator.next().unwrap() == '0'
@@ -380,15 +207,6 @@ impl<const MODULUS: u32> IsPrimeField for U32MontgomeryBackendPrimeField<MODULUS
 
         let reduced_value = (value % MODULUS as u64) as u32;
         Ok(reduced_value)
-        //u32::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
-        // println!("INTEGER: {:?}", integer);
-
-        // Ok(MontgomeryAlgorithms::cios(
-        //     &integer,
-        //     &Self::R2,
-        //     &MODULUS,
-        //     &Self::MU,
-        // ))
     }
 
     #[cfg(feature = "std")]
@@ -402,7 +220,7 @@ impl<const MODULUS: u32> FieldElement<U32MontgomeryBackendPrimeField<MODULUS>> {
 impl<const MODULUS: u32> ByteConversion for FieldElement<U32MontgomeryBackendPrimeField<MODULUS>> {
     #[cfg(feature = "alloc")]
     fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {
-        MontgomeryAlgorithms::cios(
+        MontgomeryAlgorithms::mul(
             self.value(),
             &1,
             &MODULUS,
@@ -414,7 +232,7 @@ impl<const MODULUS: u32> ByteConversion for FieldElement<U32MontgomeryBackendPri
 
     #[cfg(feature = "alloc")]
     fn to_bytes_le(&self) -> alloc::vec::Vec<u8> {
-        MontgomeryAlgorithms::cios(
+        MontgomeryAlgorithms::mul(
             self.value(),
             &1u32,
             &MODULUS,
@@ -453,1002 +271,30 @@ impl<const MODULUS: u32> From<FieldElement<U32MontgomeryBackendPrimeField<MODULU
 
 pub struct MontgomeryAlgorithms;
 impl MontgomeryAlgorithms {
-    /// Compute CIOS multiplication of `a` * `b`
-    /// `q` is the modulus
-    /// `mu` is the inverse of -q modulo 2^{32}
-    /// Notice CIOS stands for Coarsely Integrated Operand Scanning
-    /// For more information see section 2.3.2 of Tolga Acar's thesis
-    /// https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
+    /// Montgomery reduction based on Plonky3's implementation
+    ///
+    /// Converts a value from Montgomery domain using reductions mod p
     #[inline(always)]
-    pub const fn cios(a: &u32, b: &u32, q: &u32, mu: &u32) -> u32 {
-        let x = *a as u64 * *b as u64;
+    const fn monty_reduce(x: u64, mu: &u32, q: &u32) -> u32 {
         let t = x.wrapping_mul(*mu as u64) & (u32::MAX as u64);
         let u = t * (*q as u64);
-
         let (x_sub_u, over) = x.overflowing_sub(u);
         let x_sub_u_hi = (x_sub_u >> 32) as u32;
         let corr = if over { q } else { &0 };
         x_sub_u_hi.wrapping_add(*corr)
     }
 
+    #[inline(always)]
+    pub const fn mul(a: &u32, b: &u32, q: &u32, mu: &u32) -> u32 {
+        let x = *a as u64 * *b as u64;
+        Self::monty_reduce(x, mu, q)
+    }
+
     pub fn exp_power_of_2(a: &u32, power_log: usize, q: &u32) -> u32 {
-        let mut res = a.clone();
+        let mut res = *a;
         for _ in 0..power_log {
-            res = Self::cios(&res, &res, q, &2281701377);
+            res = Self::mul(&res, &res, q, &2281701377);
         }
         res
     }
-
-    /// Compute CIOS multiplication of `a` * `b`
-    /// This is the Algorithm 2 described in the paper
-    /// "EdMSM: Multi-Scalar-Multiplication for SNARKs and Faster Montgomery multiplication"
-    /// https://eprint.iacr.org/2022/1400.pdf.
-    /// It is only suited for moduli with `q[0]` smaller than `2^63 - 1`.
-    /// `q` is the modulus
-    /// `mu` is the inverse of -q modulo 2^{64} -> change this (Juan)
-    #[inline(always)]
-    pub fn cios_optimized_for_moduli_with_one_spare_bit(a: u32, b: u32, q: u32, mu: u32) -> u32 {
-        let t: u64 = (a as u64) * (b as u64);
-
-        let m = ((t as u32).wrapping_mul(mu)) as u64;
-
-        let t = t + m * (q as u64);
-
-        let c = t >> 32;
-        let mut result = c as u32;
-
-        if result >= q {
-            result = result.wrapping_sub(q);
-        }
-        result
-    }
-
-    // Separated Operand Scanning Method (2.3.1)
-    #[inline(always)]
-    pub fn sos_square(a: u32, q: u32, mu: &u32) -> u32 {
-        // NOTE: we use explicit `while` loops in this function because profiling pointed
-        // at iterators of the form `(<x>..<y>).rev()` as the main performance bottleneck.
-        let t: u64 = (a as u64) * (a as u64);
-        let m = ((t as u32).wrapping_mul(*mu)) as u64;
-        let t = t + m * (q as u64);
-
-        let c = t >> 32;
-        let mut result = c as u32;
-
-        if result >= q {
-            result = result.wrapping_sub(q);
-        }
-
-        result
-    }
 }
-
-// #[cfg(test)]
-// mod tests_u384_prime_fields {
-//     use crate::field::element::FieldElement;
-//     use crate::field::errors::FieldError;
-//     use crate::field::fields::fft_friendly::babybear::Babybear31PrimeField;
-//     use crate::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
-
-//     use crate::field::fields::montgomery_backed_prime_fields::{
-//         IsModulus, U256PrimeField, U384PrimeField,
-//     };
-//     use crate::field::traits::IsField;
-//     use crate::field::traits::IsPrimeField;
-//     #[cfg(feature = "alloc")]
-//     use crate::traits::ByteConversion;
-//     use crate::unsigned_integer::element::U384;
-//     use crate::unsigned_integer::element::{UnsignedInteger, U256};
-
-//     type F = U384PrimeField<U384Modulus23>;
-//     type U384F23Element = FieldElement<U384F23>;
-
-//     #[test]
-//     fn u384_mod_23_uses_5_bits() {
-//         assert_eq!(U384F23::field_bit_size(), 5);
-//     }
-
-//     #[test]
-//     fn stark_252_prime_field_uses_252_bits() {
-//         assert_eq!(Stark252PrimeField::field_bit_size(), 252);
-//     }
-
-//     #[test]
-//     fn u256_mod_2_uses_1_bit() {
-//         #[derive(Clone, Debug)]
-//         struct U256Modulus1;
-//         impl IsModulus<U256> for U256Modulus1 {
-//             const MODULUS: U256 = UnsignedInteger::from_u64(2);
-//         }
-//         type U256OneField = U256PrimeField<U256Modulus1>;
-//         assert_eq!(U256OneField::field_bit_size(), 1);
-//     }
-
-//     #[test]
-//     fn u256_with_first_bit_set_uses_256_bit() {
-//         #[derive(Clone, Debug)]
-//         struct U256ModulusBig;
-//         impl IsModulus<U256> for U256ModulusBig {
-//             const MODULUS: U256 = UnsignedInteger::from_hex_unchecked(
-//                 "F0000000F0000000F0000000F0000000F0000000F0000000F0000000F0000000",
-//             );
-//         }
-//         type U256OneField = U256PrimeField<U256ModulusBig>;
-//         assert_eq!(U256OneField::field_bit_size(), 256);
-//     }
-
-//     #[test]
-//     fn montgomery_backend_primefield_compute_r2_parameter() {
-//         let r2: U384 = UnsignedInteger {
-//             limbs: [0, 0, 0, 0, 0, 6],
-//         };
-//         assert_eq!(U384F23::R2, r2);
-//     }
-
-//     #[test]
-//     fn montgomery_backend_primefield_compute_mu_parameter() {
-//         assert_eq!(U384F23::MU, 3208129404123400281);
-//     }
-
-//     #[test]
-//     fn montgomery_backend_primefield_compute_zero_parameter() {
-//         let zero: U384 = UnsignedInteger {
-//             limbs: [0, 0, 0, 0, 0, 0],
-//         };
-//         assert_eq!(U384F23::ZERO, zero);
-//     }
-
-//     #[test]
-//     fn montgomery_backend_primefield_from_u64() {
-//         let a: U384 = UnsignedInteger {
-//             limbs: [0, 0, 0, 0, 0, 17],
-//         };
-//         assert_eq!(U384F23::from_u64(770_u64), a);
-//     }
-
-//     #[test]
-//     fn montgomery_backend_primefield_representative() {
-//         let a: U384 = UnsignedInteger {
-//             limbs: [0, 0, 0, 0, 0, 11],
-//         };
-//         assert_eq!(U384F23::representative(&U384F23::from_u64(770_u64)), a);
-//     }
-
-//     #[test]
-//     fn montgomery_backend_multiplication_works_0() {
-//         let x = U384F23Element::from(11_u64);
-//         let y = U384F23Element::from(10_u64);
-//         let c = U384F23Element::from(110_u64);
-//         assert_eq!(x * y, c);
-//     }
-
-//     #[test]
-//     #[cfg(feature = "lambdaworks-serde-string")]
-//     fn montgomery_backend_serialization_deserialization() {
-//         let x = U384F23Element::from(11_u64);
-//         let x_serialized = serde_json::to_string(&x).unwrap();
-//         let x_deserialized: U384F23Element = serde_json::from_str(&x_serialized).unwrap();
-//         // assert_eq!(x_serialized, "{\"value\":\"0xb\"}"); // serialization is no longer as hex string
-//         assert_eq!(x_deserialized, x);
-//     }
-
-//     #[test]
-//     fn doubling() {
-//         assert_eq!(
-//             U384F23Element::from(2).double(),
-//             U384F23Element::from(2) + U384F23Element::from(2),
-//         );
-//     }
-
-//     const ORDER: usize = 23;
-//     #[test]
-//     fn two_plus_one_is_three() {
-//         assert_eq!(
-//             U384F23Element::from(2) + U384F23Element::from(1),
-//             U384F23Element::from(3)
-//         );
-//     }
-
-//     #[test]
-//     fn max_order_plus_1_is_0() {
-//         assert_eq!(
-//             U384F23Element::from((ORDER - 1) as u64) + U384F23Element::from(1),
-//             U384F23Element::from(0)
-//         );
-//     }
-
-//     #[test]
-//     fn when_comparing_13_and_13_they_are_equal() {
-//         let a: U384F23Element = U384F23Element::from(13);
-//         let b: U384F23Element = U384F23Element::from(13);
-//         assert_eq!(a, b);
-//     }
-
-//     #[test]
-//     fn when_comparing_13_and_8_they_are_different() {
-//         let a: U384F23Element = U384F23Element::from(13);
-//         let b: U384F23Element = U384F23Element::from(8);
-//         assert_ne!(a, b);
-//     }
-
-//     #[test]
-//     fn mul_neutral_element() {
-//         let a: U384F23Element = U384F23Element::from(1);
-//         let b: U384F23Element = U384F23Element::from(2);
-//         assert_eq!(a * b, U384F23Element::from(2));
-//     }
-
-//     #[test]
-//     fn mul_2_3_is_6() {
-//         let a: U384F23Element = U384F23Element::from(2);
-//         let b: U384F23Element = U384F23Element::from(3);
-//         assert_eq!(a * b, U384F23Element::from(6));
-//     }
-
-//     #[test]
-//     fn mul_order_minus_1() {
-//         let a: U384F23Element = U384F23Element::from((ORDER - 1) as u64);
-//         let b: U384F23Element = U384F23Element::from((ORDER - 1) as u64);
-//         assert_eq!(a * b, U384F23Element::from(1));
-//     }
-
-//     #[test]
-//     fn inv_0_error() {
-//         let result = U384F23Element::from(0).inv();
-//         assert!(matches!(result, Err(FieldError::InvZeroError)))
-//     }
-
-//     #[test]
-//     fn inv_2() {
-//         let a: U384F23Element = U384F23Element::from(2);
-//         assert_eq!(&a * a.inv().unwrap(), U384F23Element::from(1));
-//     }
-
-//     #[test]
-//     fn pow_2_3() {
-//         assert_eq!(U384F23Element::from(2).pow(3_u64), U384F23Element::from(8))
-//     }
-
-//     #[test]
-//     fn pow_p_minus_1() {
-//         assert_eq!(
-//             U384F23Element::from(2).pow(ORDER - 1),
-//             U384F23Element::from(1)
-//         )
-//     }
-
-//     #[test]
-//     fn div_1() {
-//         assert_eq!(
-//             U384F23Element::from(2) / U384F23Element::from(1),
-//             U384F23Element::from(2)
-//         )
-//     }
-
-//     #[test]
-//     fn div_4_2() {
-//         assert_eq!(
-//             U384F23Element::from(4) / U384F23Element::from(2),
-//             U384F23Element::from(2)
-//         )
-//     }
-
-//     #[test]
-//     fn three_inverse() {
-//         let a = U384F23Element::from(3);
-//         let expected = U384F23Element::from(8);
-//         assert_eq!(a.inv().unwrap(), expected)
-//     }
-
-//     #[test]
-//     fn div_4_3() {
-//         assert_eq!(
-//             U384F23Element::from(4) / U384F23Element::from(3) * U384F23Element::from(3),
-//             U384F23Element::from(4)
-//         )
-//     }
-
-//     #[test]
-//     fn two_plus_its_additive_inv_is_0() {
-//         let two = U384F23Element::from(2);
-
-//         assert_eq!(&two + (-&two), U384F23Element::from(0))
-//     }
-
-//     #[test]
-//     fn four_minus_three_is_1() {
-//         let four = U384F23Element::from(4);
-//         let three = U384F23Element::from(3);
-
-//         assert_eq!(four - three, U384F23Element::from(1))
-//     }
-
-//     #[test]
-//     fn zero_minus_1_is_order_minus_1() {
-//         let zero = U384F23Element::from(0);
-//         let one = U384F23Element::from(1);
-
-//         assert_eq!(zero - one, U384F23Element::from((ORDER - 1) as u64))
-//     }
-
-//     #[test]
-//     fn neg_zero_is_zero() {
-//         let zero = U384F23Element::from(0);
-
-//         assert_eq!(-&zero, zero);
-//     }
-
-//     // FP1
-//     #[derive(Clone, Debug)]
-//     struct U384ModulusP1;
-//     impl IsModulus<U384> for U384ModulusP1 {
-//         const MODULUS: U384 = UnsignedInteger {
-//             limbs: [
-//                 0,
-//                 0,
-//                 0,
-//                 3450888597,
-//                 5754816256417943771,
-//                 15923941673896418529,
-//             ],
-//         };
-//     }
-
-//     type U384FP1 = U384PrimeField<U384ModulusP1>;
-//     type U384FP1Element = FieldElement<U384FP1>;
-
-//     #[test]
-//     fn montgomery_prime_field_from_bad_hex_errs() {
-//         assert!(U384FP1Element::from_hex("0xTEST").is_err());
-//     }
-
-//     #[test]
-//     fn montgomery_prime_field_addition_works_0() {
-//         let x = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
-//             "05ed176deb0e80b4deb7718cdaa075165f149c",
-//         ));
-//         let y = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
-//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
-//         ));
-//         let c = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
-//             "64fd5279bf47fe02d4185ce279d8aa55e00352",
-//         ));
-//         assert_eq!(x + y, c);
-//     }
-
-//     #[test]
-//     fn montgomery_prime_field_multiplication_works_0() {
-//         let x = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
-//             "05ed176deb0e80b4deb7718cdaa075165f149c",
-//         ));
-//         let y = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
-//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
-//         ));
-//         let c = U384FP1Element::new(UnsignedInteger::from_hex_unchecked(
-//             "73d23e8d462060dc23d5c15c00fc432d95621a3c",
-//         ));
-//         assert_eq!(x * y, c);
-//     }
-
-//     // FP2
-//     #[derive(Clone, Debug)]
-//     struct U384ModulusP2;
-//     impl IsModulus<U384> for U384ModulusP2 {
-//         const MODULUS: U384 = UnsignedInteger {
-//             limbs: [
-//                 18446744073709551615,
-//                 18446744073709551615,
-//                 18446744073709551615,
-//                 18446744073709551615,
-//                 18446744073709551615,
-//                 18446744073709551275,
-//             ],
-//         };
-//     }
-
-//     type U384FP2 = U384PrimeField<U384ModulusP2>;
-//     type U384FP2Element = FieldElement<U384FP2>;
-
-//     #[test]
-//     fn montgomery_prime_field_addition_works_1() {
-//         let x = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "05ed176deb0e80b4deb7718cdaa075165f149c",
-//         ));
-//         let y = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
-//         ));
-//         let c = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "64fd5279bf47fe02d4185ce279d8aa55e00352",
-//         ));
-//         assert_eq!(x + y, c);
-//     }
-
-//     #[test]
-//     fn montgomery_prime_field_multiplication_works_1() {
-//         let x = U384FP2Element::one();
-//         let y = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
-//         ));
-//         assert_eq!(&y * x, y);
-//     }
-
-//     #[test]
-//     #[cfg(feature = "alloc")]
-//     fn to_bytes_from_bytes_be_is_the_identity() {
-//         let x = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
-//         ));
-//         assert_eq!(U384FP2Element::from_bytes_be(&x.to_bytes_be()).unwrap(), x);
-//     }
-
-//     #[test]
-//     #[cfg(feature = "alloc")]
-//     fn from_bytes_to_bytes_be_is_the_identity_for_one() {
-//         let bytes = [
-//             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-//             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-//         ];
-//         assert_eq!(
-//             U384FP2Element::from_bytes_be(&bytes).unwrap().to_bytes_be(),
-//             bytes
-//         );
-//     }
-
-//     #[test]
-//     #[cfg(feature = "alloc")]
-//     fn to_bytes_from_bytes_le_is_the_identity() {
-//         let x = U384FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
-//         ));
-//         assert_eq!(U384FP2Element::from_bytes_le(&x.to_bytes_le()).unwrap(), x);
-//     }
-
-//     #[test]
-//     #[cfg(feature = "alloc")]
-//     fn from_bytes_to_bytes_le_is_the_identity_for_one() {
-//         let bytes = [
-//             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-//             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-//         ];
-//         assert_eq!(
-//             U384FP2Element::from_bytes_le(&bytes).unwrap().to_bytes_le(),
-//             bytes
-//         );
-//     }
-// }
-
-// #[cfg(test)]
-// mod tests_u256_prime_fields {
-//     use crate::field::element::FieldElement;
-//     use crate::field::errors::FieldError;
-//     use crate::field::fields::montgomery_backed_prime_fields::{IsModulus, U256PrimeField};
-//     use crate::field::traits::IsField;
-//     use crate::field::traits::IsPrimeField;
-//     #[cfg(feature = "alloc")]
-//     use crate::traits::ByteConversion;
-//     use crate::unsigned_integer::element::U256;
-//     use crate::unsigned_integer::element::{UnsignedInteger, U64};
-//     use proptest::prelude::*;
-
-//     use super::U64PrimeField;
-
-//     #[derive(Clone, Debug)]
-//     struct U256Modulus29;
-//     impl IsModulus<U256> for U256Modulus29 {
-//         const MODULUS: U256 = UnsignedInteger::from_u64(29);
-//     }
-
-//     type U256F29 = U256PrimeField<U256Modulus29>;
-//     type U256F29Element = FieldElement<U256F29>;
-
-//     #[test]
-//     fn montgomery_backend_primefield_compute_r2_parameter() {
-//         let r2: U256 = UnsignedInteger {
-//             limbs: [0, 0, 0, 24],
-//         };
-//         assert_eq!(U256F29::R2, r2);
-//     }
-
-//     #[test]
-//     fn montgomery_backend_primefield_compute_mu_parameter() {
-//         // modular multiplicative inverse
-//         assert_eq!(U256F29::MU, 14630176334321368523);
-//     }
-
-//     #[test]
-//     fn montgomery_backend_primefield_compute_zero_parameter() {
-//         let zero: U256 = UnsignedInteger {
-//             limbs: [0, 0, 0, 0],
-//         };
-//         assert_eq!(U256F29::ZERO, zero);
-//     }
-
-//     #[test]
-//     fn montgomery_backend_primefield_from_u64() {
-//         // (770*2**(256))%29
-//         let a: U256 = UnsignedInteger {
-//             limbs: [0, 0, 0, 24],
-//         };
-//         assert_eq!(U256F29::from_u64(770_u64), a);
-//     }
-
-//     #[test]
-//     fn montgomery_backend_primefield_representative() {
-//         // 770%29
-//         let a: U256 = UnsignedInteger {
-//             limbs: [0, 0, 0, 16],
-//         };
-//         assert_eq!(U256F29::representative(&U256F29::from_u64(770_u64)), a);
-//     }
-
-//     #[test]
-//     fn montgomery_backend_multiplication_works_0() {
-//         let x = U256F29Element::from(11_u64);
-//         let y = U256F29Element::from(10_u64);
-//         let c = U256F29Element::from(110_u64);
-//         assert_eq!(x * y, c);
-//     }
-
-//     #[test]
-//     fn doubling() {
-//         assert_eq!(
-//             U256F29Element::from(2).double(),
-//             U256F29Element::from(2) + U256F29Element::from(2),
-//         );
-//     }
-
-//     const ORDER: usize = 29;
-//     #[test]
-//     fn two_plus_one_is_three() {
-//         assert_eq!(
-//             U256F29Element::from(2) + U256F29Element::from(1),
-//             U256F29Element::from(3)
-//         );
-//     }
-
-//     #[test]
-//     fn max_order_plus_1_is_0() {
-//         assert_eq!(
-//             U256F29Element::from((ORDER - 1) as u64) + U256F29Element::from(1),
-//             U256F29Element::from(0)
-//         );
-//     }
-
-//     #[test]
-//     fn when_comparing_13_and_13_they_are_equal() {
-//         let a: U256F29Element = U256F29Element::from(13);
-//         let b: U256F29Element = U256F29Element::from(13);
-//         assert_eq!(a, b);
-//     }
-
-//     #[test]
-//     fn when_comparing_13_and_8_they_are_different() {
-//         let a: U256F29Element = U256F29Element::from(13);
-//         let b: U256F29Element = U256F29Element::from(8);
-//         assert_ne!(a, b);
-//     }
-
-//     #[test]
-//     fn mul_neutral_element() {
-//         let a: U256F29Element = U256F29Element::from(1);
-//         let b: U256F29Element = U256F29Element::from(2);
-//         assert_eq!(a * b, U256F29Element::from(2));
-//     }
-
-//     #[test]
-//     fn mul_2_3_is_6() {
-//         let a: U256F29Element = U256F29Element::from(2);
-//         let b: U256F29Element = U256F29Element::from(3);
-//         assert_eq!(a * b, U256F29Element::from(6));
-//     }
-
-//     #[test]
-//     fn mul_order_minus_1() {
-//         let a: U256F29Element = U256F29Element::from((ORDER - 1) as u64);
-//         let b: U256F29Element = U256F29Element::from((ORDER - 1) as u64);
-//         assert_eq!(a * b, U256F29Element::from(1));
-//     }
-
-//     #[test]
-//     fn inv_0_error() {
-//         let result = U256F29Element::from(0).inv();
-//         assert!(matches!(result, Err(FieldError::InvZeroError)));
-//     }
-
-//     #[test]
-//     fn inv_2() {
-//         let a: U256F29Element = U256F29Element::from(2);
-//         assert_eq!(&a * a.inv().unwrap(), U256F29Element::from(1));
-//     }
-
-//     #[test]
-//     fn pow_2_3() {
-//         assert_eq!(U256F29Element::from(2).pow(3_u64), U256F29Element::from(8))
-//     }
-
-//     #[test]
-//     fn pow_p_minus_1() {
-//         assert_eq!(
-//             U256F29Element::from(2).pow(ORDER - 1),
-//             U256F29Element::from(1)
-//         )
-//     }
-
-//     #[test]
-//     fn div_1() {
-//         assert_eq!(
-//             U256F29Element::from(2) / U256F29Element::from(1),
-//             U256F29Element::from(2)
-//         )
-//     }
-
-//     #[test]
-//     fn div_4_2() {
-//         let a = U256F29Element::from(4);
-//         let b = U256F29Element::from(2);
-//         assert_eq!(a / &b, b)
-//     }
-
-//     #[test]
-//     fn div_4_3() {
-//         assert_eq!(
-//             U256F29Element::from(4) / U256F29Element::from(3) * U256F29Element::from(3),
-//             U256F29Element::from(4)
-//         )
-//     }
-
-//     #[test]
-//     fn two_plus_its_additive_inv_is_0() {
-//         let two = U256F29Element::from(2);
-
-//         assert_eq!(&two + (-&two), U256F29Element::from(0))
-//     }
-
-//     #[test]
-//     fn four_minus_three_is_1() {
-//         let four = U256F29Element::from(4);
-//         let three = U256F29Element::from(3);
-
-//         assert_eq!(four - three, U256F29Element::from(1))
-//     }
-
-//     #[test]
-//     fn zero_minus_1_is_order_minus_1() {
-//         let zero = U256F29Element::from(0);
-//         let one = U256F29Element::from(1);
-
-//         assert_eq!(zero - one, U256F29Element::from((ORDER - 1) as u64))
-//     }
-
-//     #[test]
-//     fn neg_zero_is_zero() {
-//         let zero = U256F29Element::from(0);
-
-//         assert_eq!(-&zero, zero);
-//     }
-
-//     // FP1
-//     #[derive(Clone, Debug)]
-//     struct U256ModulusP1;
-//     impl IsModulus<U256> for U256ModulusP1 {
-//         const MODULUS: U256 = UnsignedInteger {
-//             limbs: [
-//                 8366,
-//                 8155137382671976874,
-//                 227688614771682406,
-//                 15723111795979912613,
-//             ],
-//         };
-//     }
-
-//     type U256FP1 = U256PrimeField<U256ModulusP1>;
-//     type U256FP1Element = FieldElement<U256FP1>;
-
-//     #[test]
-//     fn montgomery_prime_field_addition_works_0() {
-//         let x = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
-//             "93e712950bf3fe589aa030562a44b1cec66b09192c4bcf705a5",
-//         ));
-//         let y = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
-//             "10a712235c1f6b4172a1e35da6aef1a7ec6b09192c4bb88cfa5",
-//         ));
-//         let c = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
-//             "a48e24b86813699a0d4213b3d0f3a376b2d61232589787fd54a",
-//         ));
-//         assert_eq!(x + y, c);
-//     }
-
-//     #[test]
-//     fn montgomery_prime_field_multiplication_works_0() {
-//         let x = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
-//             "93e712950bf3fe589aa030562a44b1cec66b09192c4bcf705a5",
-//         ));
-//         let y = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
-//             "10a712235c1f6b4172a1e35da6aef1a7ec6b09192c4bb88cfa5",
-//         ));
-//         let c = U256FP1Element::new(UnsignedInteger::from_hex_unchecked(
-//             "7808e74c3208d9a66791ef9cc15a46acc9951ee312102684021",
-//         ));
-//         assert_eq!(x * y, c);
-//     }
-
-//     // FP2
-//     #[derive(Clone, Debug)]
-//     struct ModulusP2;
-//     impl IsModulus<U256> for ModulusP2 {
-//         const MODULUS: U256 = UnsignedInteger {
-//             limbs: [
-//                 18446744073709551615,
-//                 18446744073709551615,
-//                 18446744073709551615,
-//                 18446744073709551427,
-//             ],
-//         };
-//     }
-
-//     type FP2 = U256PrimeField<ModulusP2>;
-//     type FP2Element = FieldElement<FP2>;
-
-//     #[test]
-//     fn montgomery_prime_field_addition_works_1() {
-//         let x = FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "acbbb7ca01c65cfffffc72815b397fff9ab130ad53a5ffffffb8f21b207dfedf",
-//         ));
-//         let y = FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "d65ddbe509d3fffff21f494c588cbdbfe43e929b0543e3ffffffffffffffff43",
-//         ));
-//         let c = FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "831993af0b9a5cfff21bbbcdb3c63dbf7eefc34858e9e3ffffb8f21b207dfedf",
-//         ));
-//         assert_eq!(x + y, c);
-//     }
-
-//     #[test]
-//     fn montgomery_prime_field_multiplication_works_1() {
-//         let x = FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "acbbb7ca01c65cfffffc72815b397fff9ab130ad53a5ffffffb8f21b207dfedf",
-//         ));
-//         let y = FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "d65ddbe509d3fffff21f494c588cbdbfe43e929b0543e3ffffffffffffffff43",
-//         ));
-//         let c = FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "2b1e80d553ecab2e4d41eb53c4c8ad89ebacac6cf6b91dcf2213f311093aa05d",
-//         ));
-//         assert_eq!(&y * x, c);
-//     }
-
-//     #[test]
-//     #[cfg(feature = "alloc")]
-//     fn to_bytes_from_bytes_be_is_the_identity() {
-//         let x = FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
-//         ));
-//         assert_eq!(FP2Element::from_bytes_be(&x.to_bytes_be()).unwrap(), x);
-//     }
-
-//     #[test]
-//     #[cfg(feature = "alloc")]
-//     fn from_bytes_to_bytes_be_is_the_identity_for_one() {
-//         let bytes = [
-//             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-//             0, 0, 1,
-//         ];
-//         assert_eq!(
-//             FP2Element::from_bytes_be(&bytes).unwrap().to_bytes_be(),
-//             bytes
-//         );
-//     }
-
-//     #[test]
-//     #[cfg(feature = "alloc")]
-//     fn to_bytes_from_bytes_le_is_the_identity() {
-//         let x = FP2Element::new(UnsignedInteger::from_hex_unchecked(
-//             "5f103b0bd4397d4df560eb559f38353f80eeb6",
-//         ));
-//         assert_eq!(FP2Element::from_bytes_le(&x.to_bytes_le()).unwrap(), x);
-//     }
-
-//     #[test]
-//     #[cfg(feature = "alloc")]
-//     fn from_bytes_to_bytes_le_is_the_identity_for_one() {
-//         let bytes = [
-//             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-//             0, 0, 0,
-//         ];
-//         assert_eq!(
-//             FP2Element::from_bytes_le(&bytes).unwrap().to_bytes_le(),
-//             bytes
-//         );
-//     }
-
-//     #[test]
-//     #[cfg(feature = "alloc")]
-//     fn creating_a_field_element_from_its_representative_returns_the_same_element_1() {
-//         let change = U256::from_u64(1);
-//         let f1 = U256FP1Element::new(U256ModulusP1::MODULUS + change);
-//         let f2 = U256FP1Element::new(f1.representative());
-//         assert_eq!(f1, f2);
-//     }
-
-//     #[test]
-//     fn creating_a_field_element_from_its_representative_returns_the_same_element_2() {
-//         let change = U256::from_u64(27);
-//         let f1 = U256F29Element::new(U256Modulus29::MODULUS + change);
-//         let f2 = U256F29Element::new(f1.representative());
-//         assert_eq!(f1, f2);
-//     }
-
-//     #[test]
-//     fn creating_a_field_element_from_hex_works_1() {
-//         let a = U256FP1Element::from_hex_unchecked("eb235f6144d9e91f4b14");
-//         let b = U256FP1Element::new(U256 {
-//             limbs: [0, 0, 60195, 6872850209053821716],
-//         });
-//         assert_eq!(a, b);
-//     }
-
-//     #[test]
-//     fn creating_a_field_element_from_hex_too_big_errors() {
-//         let a = U256FP1Element::from_hex(&"f".repeat(65));
-//         assert!(a.is_err());
-//         assert_eq!(
-//             a.unwrap_err(),
-//             crate::errors::CreationError::HexStringIsTooBig
-//         )
-//     }
-
-//     #[test]
-//     fn creating_a_field_element_from_hex_works_on_the_size_limit() {
-//         let a = U256FP1Element::from_hex(&"f".repeat(64));
-//         assert!(a.is_ok());
-//     }
-
-//     #[test]
-//     fn creating_a_field_element_from_hex_works_2() {
-//         let a = U256F29Element::from_hex_unchecked("aa");
-//         let b = U256F29Element::from(25);
-//         assert_eq!(a, b);
-//     }
-
-//     #[test]
-//     fn creating_a_field_element_from_hex_works_3() {
-//         let a = U256F29Element::from_hex_unchecked("1d");
-//         let b = U256F29Element::zero();
-//         assert_eq!(a, b);
-//     }
-
-//     #[cfg(feature = "std")]
-//     #[test]
-//     fn to_hex_test_works_1() {
-//         let a = U256FP1Element::from_hex_unchecked("eb235f6144d9e91f4b14");
-//         let b = U256FP1Element::new(U256 {
-//             limbs: [0, 0, 60195, 6872850209053821716],
-//         });
-
-//         assert_eq!(U256FP1Element::to_hex(&a), U256FP1Element::to_hex(&b));
-//     }
-
-//     #[cfg(feature = "std")]
-//     #[test]
-//     fn to_hex_test_works_2() {
-//         let a = U256F29Element::from_hex_unchecked("1d");
-//         let b = U256F29Element::zero();
-
-//         assert_eq!(U256F29Element::to_hex(&a), U256F29Element::to_hex(&b));
-//     }
-
-//     #[cfg(feature = "std")]
-//     #[test]
-//     fn to_hex_test_works_3() {
-//         let a = U256F29Element::from_hex_unchecked("aa");
-//         let b = U256F29Element::from(25);
-
-//         assert_eq!(U256F29Element::to_hex(&a), U256F29Element::to_hex(&b));
-//     }
-
-//     // Goldilocks
-//     #[derive(Clone, Debug)]
-//     struct GoldilocksModulus;
-//     impl IsModulus<U64> for GoldilocksModulus {
-//         const MODULUS: U64 = UnsignedInteger {
-//             limbs: [18446744069414584321],
-//         };
-//     }
-
-//     type GoldilocksField = U64PrimeField<GoldilocksModulus>;
-//     type GoldilocksElement = FieldElement<GoldilocksField>;
-
-//     #[derive(Clone, Debug)]
-//     struct SecpModulus;
-//     impl IsModulus<U256> for SecpModulus {
-//         const MODULUS: U256 = UnsignedInteger::from_hex_unchecked(
-//             "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
-//         );
-//     }
-//     type SecpMontField = U256PrimeField<SecpModulus>;
-//     type SecpMontElement = FieldElement<SecpMontField>;
-
-//     #[test]
-//     fn secp256k1_minus_three_pow_2_is_9_with_all_operations() {
-//         let minus_3 = -SecpMontElement::from_hex_unchecked("0x3");
-//         let minus_3_mul_minus_3 = &minus_3 * &minus_3;
-//         let minus_3_squared = minus_3.square();
-//         let minus_3_pow_2 = minus_3.pow(2_u32);
-//         let nine = SecpMontElement::from_hex_unchecked("0x9");
-
-//         assert_eq!(minus_3_mul_minus_3, nine);
-//         assert_eq!(minus_3_squared, nine);
-//         assert_eq!(minus_3_pow_2, nine);
-//     }
-
-//     #[test]
-//     fn secp256k1_inv_works() {
-//         let a = SecpMontElement::from_hex_unchecked("0x456");
-//         let a_inv = a.inv().unwrap();
-
-//         assert_eq!(a * a_inv, SecpMontElement::one());
-//     }
-
-//     #[test]
-//     fn test_cios_overflow_case() {
-//         let a = GoldilocksElement::from(732582227915286439);
-//         let b = GoldilocksElement::from(3906369333256140342);
-//         let expected_sum = GoldilocksElement::from(4638951561171426781);
-//         assert_eq!(a + b, expected_sum);
-//     }
-
-//     // Tests for the Montgomery Algorithms
-//     proptest! {
-//         #[test]
-//         fn cios_vs_cios_optimized(a in any::<[u64; 6]>(), b in any::<[u64; 6]>()) {
-//             let x = U384::from_limbs(a);
-//             let y = U384::from_limbs(b);
-//             let m = U384::from_hex_unchecked("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
-//             let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
-//             assert_eq!(
-//                 MontgomeryAlgorithms::cios(&x, &y, &m, &mu),
-//                 MontgomeryAlgorithms::cios_optimized_for_moduli_with_one_spare_bit(&x, &y, &m, &mu)
-//             );
-//         }
-
-//         #[test]
-//         fn cios_vs_sos_square(a in any::<[u64; 6]>()) {
-//             let x = U384::from_limbs(a);
-//             let m = U384::from_hex_unchecked("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
-//             let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
-//             assert_eq!(
-//                 MontgomeryAlgorithms::cios(&x, &x, &m, &mu),
-//                 MontgomeryAlgorithms::sos_square(&x, &m, &mu)
-//             );
-//         }
-//     }
-//     #[test]
-//     fn montgomery_multiplication_works_0() {
-//         let x = U384::from_u64(11_u64);
-//         let y = U384::from_u64(10_u64);
-//         let m = U384::from_u64(23_u64); //
-//         let mu: u64 = 3208129404123400281; // negative of the inverse of `m` modulo 2^{64}.
-//         let c = U384::from_u64(13_u64); // x * y * (r^{-1}) % m, where r = 2^{64 * 6} and r^{-1} mod m = 2.
-//         assert_eq!(MontgomeryAlgorithms::cios(&x, &y, &m, &mu), c);
-//     }
-
-//     #[test]
-//     fn montgomery_multiplication_works_1() {
-//         let x = U384::from_hex_unchecked("05ed176deb0e80b4deb7718cdaa075165f149c");
-//         let y = U384::from_hex_unchecked("5f103b0bd4397d4df560eb559f38353f80eeb6");
-//         let m = U384::from_hex_unchecked("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
-//         let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
-//         let c = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc"); // x * y * (r^{-1}) % m, where r = 2^{64 * 6}
-//         assert_eq!(MontgomeryAlgorithms::cios(&x, &y, &m, &mu), c);
-//     }
-
-//     #[test]
-//     fn montgomery_multiplication_works_2() {
-//         let x = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc");
-//         let m = U384::from_hex_unchecked("cdb061954fdd36e5176f50dbdcfd349570a29ce1"); // this is prime
-//         let r_mod_m = U384::from_hex_unchecked("58dfb0e1b3dd5e674bdcde4f42eb5533b8759d33");
-//         let mu: u64 = 16085280245840369887; // negative of the inverse of `m` modulo 2^{64}
-//         let c = U384::from_hex_unchecked("8d65cdee621682815d59f465d2641eea8a1274dc");
-//         assert_eq!(MontgomeryAlgorithms::cios(&x, &r_mod_m, &m, &mu), c);
-//     }
-// }

--- a/math/src/field/fields/u32_montgomery_backend_prime_field.rs
+++ b/math/src/field/fields/u32_montgomery_backend_prime_field.rs
@@ -320,8 +320,12 @@ impl<const MODULUS: u32> IsPrimeField for U32MontgomeryBackendPrimeField<MODULUS
         {
             hex_string = &hex_string[2..];
         }
+        let value =
+            u64::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)?;
 
-        u32::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
+        let reduced_value = (value % MODULUS as u64) as u32;
+        Ok(reduced_value)
+        //u32::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
         // println!("INTEGER: {:?}", integer);
 
         // Ok(MontgomeryAlgorithms::cios(


### PR DESCRIPTION
# Add Montgomery u32 backend for BabyBear

## Description

This PR implements a 32-bit Montgomery arithmetic backend for BabyBear finite field operations.

These operations show significant performance improvements versus the actual u64 backend.
Performance parity with Plonky3 is achieved 

Results for 1.000.000 operations

| Operation      | Lambdaworks BabyBear u32 | Lambdaworks BabyBear u64 | Plonky3| Lambdaworks Babybear u32 speedup vs. u64 | Lambdaworks Babybear u32 speedup vs. Plonky3 |
|----------------|-------------------------|-------------------------|-----------|------------------------------------------|---------------------------------------------|
| Addition       | 748.21 µs               | 826.51 µs               | 755.57 µs | 9.47%                                    | 0.97%                                        |
| Multiplication | 1.3702 ms               | 1.5962 ms               | 1.3359 ms | 14.16%                                   | -2.57%                                       |
| Squaring       | 1.2121 ms               | 2.6171 ms               | 1.2184 ms | 53.69%                                   | 0.52%                                        |
| Division       | 95.317 ms               | 190.70 ms               | 95.533 ms | 50.01%                                   | 0.23%                                        |
| Inversion      | 94.065 ms               | 184.34 ms               | 94.898 ms | 48.97%                                   | 0.88%                                        |


## Type of change


- [ x] Optimization

## Checklist

  - [ x] Benchmarks added/run
