### PR TITLE
docs: Fix Typos, Broken Links, and Documentation Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The following links, repos, companies and projects have been important in the de
 - [BrainSTARK](https://aszepieniec.github.io/stark-brainfuck/)
 - [Plonky2](https://github.com/mir-protocol/plonky2)
 - [Arkworks](https://github.com/arkworks-rs)
-- [Thank goodness it's FRIday](https://vitalik.ca/general/2017/11/22/starks_part_2.html)
+- [Thank goodness it's FRIday](https://vitalik.eth.limo/general/2017/11/22/starks_part_2.html)
 - [Diving DEEP FRI](https://blog.lambdaclass.com/diving-deep-fri/)
 - [Periodic constraints](https://blog.lambdaclass.com/periodic-constraints-and-recursion-in-zk-starks/)
 - [Chiplets Miden VM](https://wiki.polygon.technology/docs/miden/design/chiplets/main/)

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ make run-fuzzer FUZZER=stark252
 
 The list of fuzzers can be found in `fuzz/no_gpu_fuzz`
 
-Fuzzers for FTT in Metal and Cuda can be run with `make run-metal-fuzzer` and `make run-cuda-fuzzer`
+Fuzzers for FFT in Metal and Cuda can be run with `make run-metal-fuzzer` and `make run-cuda-fuzzer`
 
 
 Run a specific fuzzer from the ones contained in **fuzz/fuzz_targets/** folder with`cargo`, for example to run the one for the target `field_from_hex`:

--- a/docs/src/plonk/implementation.md
+++ b/docs/src/plonk/implementation.md
@@ -51,7 +51,7 @@ assert!(verifier.verify(
 ));
 ```
 
-Let's brake it down. The helper function `test_common_preprocessed_input_2()` returns an instance of the following struct for the particular test circuit:
+Let's break it down. The helper function `test_common_preprocessed_input_2()` returns an instance of the following struct for the particular test circuit:
 ```rust
 pub struct CommonPreprocessedInput<F: IsField> {
     pub n: usize,

--- a/docs/src/plonk/recap.md
+++ b/docs/src/plonk/recap.md
@@ -38,7 +38,7 @@ The idea here is that the verifier holds some value $x$, say $x=3$. He gives it 
 
 In the context of PLONK, both the inputs and outputs of the program are considered _public inputs_. This may sound odd, but it is because these are the inputs to the verification algorithm. This is the algorithm that takes, in this case, the tuple $(3, 8, \pi)$ and outputs _Accept_ if the toy program was executed with input $x=3$, some private value $e$ not revealed to the verifier, and out came $8$. Otherwise it outputs _Reject_.
 
-PLONK can be used to delegate program executions to untrusted parties, but it can also be used as a proof of knowledge. Our program could be used by a prover to demostrate that she knows the multiplicative inverse of some value $x$ in the finite field without revealing it. She would do it by sending the verifier the tuple $(x, 0, \pi)$, where $\pi$ is the proof of the execution of our toy program.
+PLONK can be used to delegate program executions to untrusted parties, but it can also be used as a proof of knowledge. Our program could be used by a prover to demonstrate that she knows the multiplicative inverse of some value $x$ in the finite field without revealing it. She would do it by sending the verifier the tuple $(x, 0, \pi)$, where $\pi$ is the proof of the execution of our toy program.
 
 In our toy example this is pointless because inverting field elements is easily performed by any verifier. But change our program to the following and you get proofs of knowledge of the preimage of SHA256 digests.
 

--- a/docs/src/starks/cairo_rap.md
+++ b/docs/src/starks/cairo_rap.md
@@ -2,7 +2,7 @@
 
 The verifier sends challenges $\alpha, z \in \mathbb{F}$ (or the prover samples them from the transcript). Additional columns are added to incorporate the memory constraints. To define them the prover follows these steps:
 1. Stack the rows of the submatrix of $T$ defined by the columns `pc, dst_addr, op0_addr, op1_addr` into a vector `a` of length $2^{n+2}$ (this means that the first entries of `a` are `pc[0], dst_addr[0], op0_addr[0], op1_addr[0], pc[1], dst_addr[1],...`).
-1. Stack the the rows of the submatrix defined by the columns `inst, dst, op0, op1` into a vector `v` of length $2^{n+2}$.
+1. Stack the rows of the submatrix defined by the columns `inst, dst, op0, op1` into a vector `v` of length $2^{n+2}$.
 1. Define $M_{\text{Mem}}\in\mathbb{F}^{2^{n+2}\times 2}$ to be the matrix with columns $a$, $v$.
 1. Define $M_{\text{MemRepl}}\in\mathbb{F}^{2^{n+2}\times 2}$ to be the matrix that's equal to $M_{\text{Mem}}$ in the first $2^{n+2} - L_{\text{pub}}$ rows, and its last $L_{\text{pub}}$ entries are the addresses and values of the actual public memory (program code).
 1. Sort $M_{\text{MemRepl}}$ by the first column in increasing order. The result is a matrix $M_{\text{MemReplSorted}}$ of size $2^{n+2}\times 2$. Denote its columns by $a'$ and $v'$.

--- a/docs/src/starks/protocol_overview.md
+++ b/docs/src/starks/protocol_overview.md
@@ -123,7 +123,7 @@ This is equivalent to running the open protocol $L$ times, one for each term $p_
 
 - [Summary on FRI low degree test](https://eprint.iacr.org/2022/1216)
 - [DEEP FRI](https://eprint.iacr.org/2019/336)
-- [Thank goodness it's FRIday](https://vitalik.ca/general/2017/11/22/starks_part_2.html)
+- [Thank goodness it's FRIday](https://vitalik.eth.limo/general/2017/11/22/starks_part_2.html)
 - [Diving DEEP FRI](https://blog.lambdaclass.com/diving-deep-fri/)
 - [Transparent Polynomial Commitment Scheme with Polylogarithmic Communication Complexity](https://eprint.iacr.org/2019/1020)
 

--- a/docs/src/starks/stone_prover/trace_plain_layout.md
+++ b/docs/src/starks/stone_prover/trace_plain_layout.md
@@ -43,7 +43,7 @@ As can be seen in the [Cairo whitepaper](https://eprint.iacr.org/2021/1063.pdf) 
 
 $\tilde{f_{i}} = \sum_{j=i}^{14}2^{j-i} f_i$
 
-so that $\tilde{f_{0}}$ is the full 15 bit value and $\tilde{f_{15}} = 0$. This way, instead of allocating 15 virtual columns for each flag, we can allocate one of lenght 16 (for each step of the Cairo execution), with the values $\tilde{f_{i}}$. **These are the actual values that appear on the Stone prover trace, rather than the 0s or 1s.**
+so that $\tilde{f_{0}}$ is the full 15 bit value and $\tilde{f_{15}} = 0$. This way, instead of allocating 15 virtual columns for each flag, we can allocate one of length 16 (for each step of the Cairo execution), with the values $\tilde{f_{i}}$. **These are the actual values that appear on the Stone prover trace, rather than the 0s or 1s.**
 
 Noting that $\tilde{f_{i}} - 2\tilde{f}_{i+1} = f_i$, we get that the constraint over this virtual column becomes
 
@@ -98,7 +98,7 @@ For example, if the public memory is:
         (3, 3245444)
 ```
 
-and the total dummy accesses are (in total, one more than the actual publc memory):
+and the total dummy accesses are (in total, one more than the actual public memory):
 ```
         (0, 0)
         (0, 0)

--- a/docs/src/starks/under_the_hood.md
+++ b/docs/src/starks/under_the_hood.md
@@ -2,7 +2,7 @@
 
 In this section we go over how a few things in the `prove` and `verify` functions are implemented. If you just need to *use* the prover, then you probably don't need to read this. If you're going through the code to try to understand it, read on.
 
-We will once again use the fibonacci example as an ilustration. Recall from the `recap` that the main steps for the prover and verifier are the following:
+We will once again use the fibonacci example as an illustration. Recall from the `recap` that the main steps for the prover and verifier are the following:
 
 ### Prover side
 

--- a/docs/src/starks/virtual_cols.md
+++ b/docs/src/starks/virtual_cols.md
@@ -9,7 +9,7 @@ For example, in the Cairo VM, we have 15 flags. These flags include  "DstReg", "
 
 Now, let's assume we have 4 steps in our trace. If we were to only use plain columns, the layout would look like this:
 
-| FlagA| FlagB| FlagB|
+| FlagA| FlagB| FlagC|
 |  --  |  --  | --   |
 |  A0  |  B0  |  C0  |
 |  A1  |  B1  |  C1  |


### PR DESCRIPTION
# TITLE

## Description

This pull request addresses a series of typos, broken links, and small errors across several documentation files. The changes improve readability, ensure correct references, and enhance the overall clarity of the project documentation.


## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
