### PR TITLE
Fix typos

### DIFF
--- a/docs/src/starks/recap.md
+++ b/docs/src/starks/recap.md
@@ -60,9 +60,9 @@ Ultimately, our goal is to give the tools to write a STARK prover for the cairo 
 
 Use the fibonacci example as your go-to for understanding all the moving parts; keep the Cairo example in mind as the thing we are actually building towards.
 
-# Fibonacci step by step walkthrough
+# Fibonacci step-by-step walkthrough
 
-Below we go through a step by step explanation of a STARK prover. We will assume the trace of the fibonacci sequence mentioned above; it consists of only one column of length \\(2^n\\). In this case, we'll take `n=3`. The trace looks like this
+Below we go through a step-by-step explanation of a STARK prover. We will assume the trace of the fibonacci sequence mentioned above; it consists of only one column of length \\(2^n\\). In this case, we'll take `n=3`. The trace looks like this
 
 | a_i    | 
 | ------ |
@@ -102,7 +102,7 @@ In terms of `t`, this translates to
 
 ## Composition Polynomial
 
-To convince the verifier that the trace polynomial satisfies the relationships above, the prover will construct another polynomial that shows that both the boundary and transition constraints are satisfied and commit to it. We call this polynomial the `composition polynomial`, and usually denote it with \\(H\\). Constructing it involves a lot of different things, so we'll go step by step introducing all the moving parts required.
+To convince the verifier that the trace polynomial satisfies the relationships above, the prover will construct another polynomial that shows that both the boundary and transition constraints are satisfied and commit to it. We call this polynomial the `composition polynomial`, and usually denote it with \\(H\\). Constructing it involves a lot of different things, so we'll go step-by-step introducing all the moving parts required.
 
 ### Boundary polynomial
 

--- a/docs/src/starks/starks.md
+++ b/docs/src/starks/starks.md
@@ -1,3 +1,3 @@
 # STARK Prover
 
-The goal of this document is to give a good a understanding of our stark prover code. To this end, in the first section we go through a recap of how the proving system works at a high level mathematically; then we dive into how that's actually implemented in our code.
+The goal of this document is to give a good an understanding of our stark prover code. To this end, in the first section we go through a recap of how the proving system works at a high level mathematically; then we dive into how that's actually implemented in our code.


### PR DESCRIPTION
This pull request addresses several grammatical and typographical errors in the STARK prover documentation:

- Corrected the usage of "step by step" to "step-by-step" in multiple instances to ensure proper hyphenation.
- Fixed the incorrect article usage ("a" vs "an") in the introduction of the STARK prover explanation.

These changes aim to improve the clarity and readability of the documentation.

### Type of change:
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

### Checklist:
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
