### PR TITLE
Update  Merkle Tree CLI example

### DIFF
--- a/examples/merkle-tree-cli/README.md
+++ b/examples/merkle-tree-cli/README.md
@@ -63,7 +63,7 @@ This will:
 ```bash
 cargo run --release generate-proof sample_tree.csv 0
 ```
-Two will generate:
+This will generate:
 
 - `sample_tree_proof_0.json` will contain the proof for the leaf at position 0.
 

--- a/examples/merkle-tree-cli/README.md
+++ b/examples/merkle-tree-cli/README.md
@@ -28,12 +28,39 @@ For example, the provided **`sample_tree.csv`** looks like this:
 ```bash
 cargo run --release generate-tree sample_tree.csv
 ```
+This will command will:
+- Generate a `json` file with the tree structure and save it to the same directory as the `csv` file.
+
+- Save the root of the tree in a `txt` file named `<CSV_FILENAME>_root.txt`.
+
+    For example:
+
+    ```
+    sample_tree_root.txt
+    ```
+
+- Print the root of the tree in the terminal
+
 
 ### To generate proof for a Merkle Tree you can use: 
 
 ```bash
 cargo run --release generate-proof <TREE_PATH> <POSITION>
 ```
+This will:
+- Generate a  `json` file with the proof for the leaf at the specified position and save it to the same directory as the `csv` file.
+
+    For example:
+    ```bash
+    sample_tree_proof_0.json
+    ```
+
+- Save the value of the leaf in a `txt` file named `<CSV_FILENAME>_leaf_<POSITION>.txt`.
+
+    For example:
+    ```bash
+    sample_tree_leaf_0.txt
+    ```
 
 **`generate-proof` example:**
 
@@ -47,12 +74,12 @@ cargo run --release generate-proof sample_tree.csv 0
 cargo run --release verify-proof <ROOT_PATH> <INDEX> <PROOF_PATH> <LEAF_PATH>
 ```
 
-The format of a root `txt` file is a simple text file which only containts the root as a hex string. Using the root that yields the merkle tree generated from the `sample_tree` provided, **`root.txt`** would look like this:
+The format of a root `txt` file is a simple text file which only containts the root as a hex string. Using the root that yields the merkle tree generated from the `sample_tree` provided, in this case **`sample_tree_root.txt`** would look like this:
 ```
 0xa3bbbb9eac9f79d18862b802ea79f87e75efc37d4f4af4464976784c14a851b69c09aa04b1e8a8d1eb9825b713dc6ca
 ```
 
-Likewise, the format of a leaf `txt` file is a simple text file which only contains the leaf as a hex string. Using the first element (index 0) of the provided `sample_tree.csv` as out leaf, **`leaf.txt`** would look like this:
+Likewise, the format of a leaf `txt` file is a simple text file which only contains the leaf as a hex string. Using the first element (index 0) of the provided `sample_tree.csv` as out leaf, **`sample_tree_leaf_0.txt`** would look like this:
 ```
 0x12345
 ```
@@ -60,5 +87,5 @@ Likewise, the format of a leaf `txt` file is a simple text file which only conta
 **`verify-proof` example:**
 
 ```bash
-cargo run --release verify-proof root.txt 0 sample_tree_proof_0.json leaf.txt
+cargo run --release verify-proof sample_tree_root.txt 0 sample_tree_proof_0.json sample_tree_leaf_0.txt
 ```

--- a/examples/merkle-tree-cli/README.md
+++ b/examples/merkle-tree-cli/README.md
@@ -38,6 +38,11 @@ This will command will:
     ```
     sample_tree_root.txt
     ```
+    will contain 
+    ```
+    0xa3bbbb9eac9f79d18862b802ea79f87e75efc37d4f4af4464976784c14a851b69c09aa04b1e8a8d1eb9825b713dc6ca
+    ```
+
 
 - Print the root of the tree in the terminal
 
@@ -61,6 +66,10 @@ This will:
     ```bash
     sample_tree_leaf_0.txt
     ```
+    will contain 
+    ```
+    0x12345
+    ```
 
 **`generate-proof` example:**
 
@@ -74,15 +83,6 @@ cargo run --release generate-proof sample_tree.csv 0
 cargo run --release verify-proof <ROOT_PATH> <INDEX> <PROOF_PATH> <LEAF_PATH>
 ```
 
-The format of a root `txt` file is a simple text file which only containts the root as a hex string. Using the root that yields the merkle tree generated from the `sample_tree` provided, in this case **`sample_tree_root.txt`** would look like this:
-```
-0xa3bbbb9eac9f79d18862b802ea79f87e75efc37d4f4af4464976784c14a851b69c09aa04b1e8a8d1eb9825b713dc6ca
-```
-
-Likewise, the format of a leaf `txt` file is a simple text file which only contains the leaf as a hex string. Using the first element (index 0) of the provided `sample_tree.csv` as out leaf, **`sample_tree_leaf_0.txt`** would look like this:
-```
-0x12345
-```
 
 **`verify-proof` example:**
 

--- a/examples/merkle-tree-cli/README.md
+++ b/examples/merkle-tree-cli/README.md
@@ -28,7 +28,7 @@ For example, the provided **`sample_tree.csv`** looks like this:
 ```bash
 cargo run --release generate-tree sample_tree.csv
 ```
-This will command will:
+This will:
 - Generate a `json` file with the tree structure and save it to the same directory as the `csv` file.
 
 - Save the root of the tree in a `txt` file named `<CSV_FILENAME>_root.txt`.
@@ -55,27 +55,22 @@ cargo run --release generate-proof <TREE_PATH> <POSITION>
 This will:
 - Generate a  `json` file with the proof for the leaf at the specified position and save it to the same directory as the `csv` file.
 
-    For example:
-    ```bash
-    sample_tree_proof_0.json
-    ```
-
 - Save the value of the leaf in a `txt` file named `<CSV_FILENAME>_leaf_<POSITION>.txt`.
 
-    For example:
-    ```bash
-    sample_tree_leaf_0.txt
-    ```
-    will contain 
-    ```
-    0x12345
-    ```
 
 **`generate-proof` example:**
 
 ```bash
 cargo run --release generate-proof sample_tree.csv 0
 ```
+Two will generate:
+
+- `sample_tree_proof_0.json` will contain the proof for the leaf at position 0.
+
+- `sample_tree_leaf_0.txt` will contain the value of the leaf at position 0. For example:
+    ```
+    0x12345
+    ```
 
 ### To verify a proof you can use:
 

--- a/examples/merkle-tree-cli/src/main.rs
+++ b/examples/merkle-tree-cli/src/main.rs
@@ -60,10 +60,26 @@ fn generate_merkle_proof(tree_path: String, pos: usize) -> Result<(), io::Error>
     };
 
     let proof_path = tree_path.replace(".csv", format!("_proof_{pos}.json").as_str());
-    let file = File::create(proof_path)?;
+    let file = File::create(&proof_path)?;
     let mut writer = BufWriter::new(file);
     serde_json::to_writer_pretty(&mut writer, &proof)?;
-    writer.flush()
+    writer.flush()?;
+
+    let leaf_value = values
+        .get(pos)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Invalid position"))?
+        .representative()
+        .to_string();
+
+    let leaf_file_path = tree_path.replace(".csv", format!("_leaf_{pos}.txt").as_str());
+    let mut leaf_file = File::create(&leaf_file_path)?;
+    leaf_file.write_all(leaf_value.as_bytes())?;
+    println!(
+        "Generated proof and saved to {}. Leaf saved to {}",
+        proof_path, leaf_file_path
+    );
+
+    Ok(())
 }
 
 fn verify_merkle_proof(

--- a/examples/merkle-tree-cli/src/main.rs
+++ b/examples/merkle-tree-cli/src/main.rs
@@ -41,6 +41,12 @@ fn generate_merkle_tree(tree_path: String) -> Result<(), io::Error> {
     let mut writer = BufWriter::new(file);
     serde_json::to_writer_pretty(&mut writer, &merkle_tree)?;
     println!("Saved tree to file");
+
+    let root_file_path = tree_path.replace(".csv", "_root.txt");
+    let mut root_file = File::create(root_file_path)?;
+    root_file.write_all(root.as_bytes())?;
+    println!("Saved root file");
+
     Ok(())
 }
 


### PR DESCRIPTION
# Update docs for Merkle Tree CLI example

## Description

This PR updates ```the generate_merkle_tree``` and ```generate_merkle_proof``` functions to create the root and leaf files, removing the need for manual creation.
The documentation was updated to reflect these changes
