### PR TITLE
Add input check on BabySnark

### DIFF
--- a/examples/baby-snark/README.md
+++ b/examples/baby-snark/README.md
@@ -24,6 +24,8 @@ Below is a simple example demonstrating the usage of BabySnark:
     let ssp = SquareSpanProgram::from_scs(SquareConstraintSystem::from_matrix(u, public.len()));
 ```
 
+*Note:* You must ensure that the first element of the `input` is 1. In the code above we can see how to build a Span Program for an And Gate. There, the variable `witness` is of the form `[input_1, input_2, output]` (which satisfy `input_1 ∧ input_2 = output`) and the `public` variable must be `[1]`.
+
 **Step 2:** Setup Proving and Verification Keys:
 ```rust
     let (pk, vk) = setup(&ssp);

--- a/examples/baby-snark/src/prover.rs
+++ b/examples/baby-snark/src/prover.rs
@@ -10,6 +10,7 @@ pub struct Proof {
 #[derive(Debug)]
 pub enum Error {
     WrongWitness,
+    FirstInputElementIsNotOne,
 }
 
 pub struct Prover;
@@ -19,6 +20,9 @@ impl Prover {
         ssp: &SquareSpanProgram,
         pk: &ProvingKey,
     ) -> Result<Proof, Error> {
+        if inputs[0].ne(&FrElement::one()) {
+            return Err(Error::FirstInputElementIsNotOne);
+        }
         if !ssp.check_valid(inputs) {
             return Err(Error::WrongWitness);
         }

--- a/examples/baby-snark/tests/integration_tests.rs
+++ b/examples/baby-snark/tests/integration_tests.rs
@@ -24,7 +24,7 @@ fn size_not_pow2() {
     let input: &[i64] = &[1, 2, 3, 4, 5];
 
     let witness = i64_vec_to_field(&[3, 4, 5]);
-    let public = i64_vec_to_field(&[1, 2]);
+    let public = i64_vec_to_field(&[1, 2]); // Note that the first element must be 1.
     let input_field = i64_vec_to_field(input);
     let u_field = normalize(i64_matrix_to_field(u), &input_field);
 
@@ -39,8 +39,8 @@ fn and_gate() {
         i64_vec_to_field(&[-1, 0, 0, 2]),
         i64_vec_to_field(&[-1, 2, 2, -4]),
     ];
-    let witness = i64_vec_to_field(&[1, 1, 1]);
-    let public = i64_vec_to_field(&[1]);
+    let witness = i64_vec_to_field(&[1, 1, 1]); // [input_1, input_2, output]
+    let public = i64_vec_to_field(&[1]); // This must be 1.
 
     test_integration(u, witness, public)
 }


### PR DESCRIPTION
# Add input check on BabySnark

## Description

This PR adds an additional check to the input values to ensure that the first element of the input  is 1. This constraint is necessary to maintain the consistency of quadratic constraints 

The variable `public` must be 1 because it is the first element of the `input` that the `prover` receives. For a more detailed explanation, refer to the [BabySNARK](https://github.com/initc3/babySNARK/blob/master/babysnark.pdf) paper.



## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
