### PR TITLE
fix: fixed incorrect method argument type in prover.rs

### DIFF
--- a/provers/stark/src/prover.rs
+++ b/provers/stark/src/prover.rs
@@ -222,7 +222,7 @@ pub trait IsStarkProver<A: AIR> {
         A::Field: IsSubFieldOf<A::FieldExtension>,
     {
         // Interpolate columns of `trace`.
-        let trace_polys = trace.compute_trace_polys_main::<A::Field>();
+        let trace_polys = trace.compute_trace_polys_main::<A::FieldExtension>();
 
         // Evaluate those polynomials t_j on the large domain D_LDE.
         let lde_trace_evaluations =


### PR DESCRIPTION
# TITLE

## Description

In the code, there was a mismatch in the type used for the method `compute_trace_polys_main`.
The method was being called with `A::Field`, but it should use `A::FieldExtension` to match the expected type in the rest of the code. The corrected line is:

```rust
let trace_polys = trace.compute_trace_polys_main::<A::FieldExtension>();
```

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [] Bug fix
- [x] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] This change is an Optimization
  - [ ] Benchmarks added/run
