### PR TITLE
Change elliptic curve new point function

### DIFF
--- a/crypto/src/hash/monolith/mod.rs
+++ b/crypto/src/hash/monolith/mod.rs
@@ -120,8 +120,8 @@ impl<const WIDTH: usize, const NUM_FULL_ROUNDS: usize> MonolithMersenne31<WIDTH,
     // S-box lookups
     fn bars(&self, state: &mut [u32]) {
         for state in state.iter_mut().take(NUM_BARS) {
-            *state = (self.lookup2[(*state >> 16) as u16 as usize] as u32) << 16
-                | self.lookup1[*state as u16 as usize] as u32;
+            *state = ((self.lookup2[(*state >> 16) as u16 as usize] as u32) << 16)
+                | (self.lookup1[*state as u16 as usize] as u32);
         }
     }
 

--- a/math/benches/criterion_elliptic_curve.rs
+++ b/math/benches/criterion_elliptic_curve.rs
@@ -10,6 +10,6 @@ use elliptic_curves::{
 criterion_group!(
     name = elliptic_curve_benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bn_254_elliptic_curve_benchmarks,
+    targets = bn_254_elliptic_curve_benchmarks, bls12_377_elliptic_curve_benchmarks, bls12_381_elliptic_curve_benchmarks
 );
 criterion_main!(elliptic_curve_benches);

--- a/math/benches/criterion_elliptic_curve.rs
+++ b/math/benches/criterion_elliptic_curve.rs
@@ -10,6 +10,6 @@ use elliptic_curves::{
 criterion_group!(
     name = elliptic_curve_benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets =bls12_377_elliptic_curve_benchmarks,bn_254_elliptic_curve_benchmarks,bls12_381_elliptic_curve_benchmarks
+    targets = bn_254_elliptic_curve_benchmarks,bls12_381_elliptic_curve_benchmarks,bls12_377_elliptic_curve_benchmarks
 );
 criterion_main!(elliptic_curve_benches);

--- a/math/benches/criterion_elliptic_curve.rs
+++ b/math/benches/criterion_elliptic_curve.rs
@@ -10,6 +10,6 @@ use elliptic_curves::{
 criterion_group!(
     name = elliptic_curve_benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bn_254_elliptic_curve_benchmarks,bls12_381_elliptic_curve_benchmarks,bls12_377_elliptic_curve_benchmarks
+    targets = bn_254_elliptic_curve_benchmarks,
 );
 criterion_main!(elliptic_curve_benches);

--- a/math/benches/criterion_elliptic_curve.rs
+++ b/math/benches/criterion_elliptic_curve.rs
@@ -10,6 +10,6 @@ use elliptic_curves::{
 criterion_group!(
     name = elliptic_curve_benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bn_254_elliptic_curve_benchmarks,bls12_381_elliptic_curve_benchmarks,bls12_377_elliptic_curve_benchmarks
+    targets =bls12_377_elliptic_curve_benchmarks,bn_254_elliptic_curve_benchmarks,bls12_381_elliptic_curve_benchmarks
 );
 criterion_main!(elliptic_curve_benches);

--- a/math/benches/elliptic_curves/bls12_377.rs
+++ b/math/benches/elliptic_curves/bls12_377.rs
@@ -15,7 +15,7 @@ pub fn bls12_377_elliptic_curve_benchmarks(c: &mut Criterion) {
     let a = BLS12377Curve::generator().operate_with_self(a_val);
     let b = BLS12377Curve::generator().operate_with_self(b_val);
 
-    let mut group = c.benchmark_group("BLS12-381 Ops");
+    let mut group = c.benchmark_group("BLS12-377 Ops");
     group.significance_level(0.1).sample_size(10000);
     group.throughput(criterion::Throughput::Elements(1));
 

--- a/math/benches/elliptic_curves/bls12_377.rs
+++ b/math/benches/elliptic_curves/bls12_377.rs
@@ -15,7 +15,7 @@ pub fn bls12_377_elliptic_curve_benchmarks(c: &mut Criterion) {
     let a = BLS12377Curve::generator().operate_with_self(a_val);
     let b = BLS12377Curve::generator().operate_with_self(b_val);
 
-    let mut group = c.benchmark_group("BLS12-377 Ops");
+    let mut group = c.benchmark_group("BLS12-381 Ops");
     group.significance_level(0.1).sample_size(10000);
     group.throughput(criterion::Throughput::Elements(1));
 

--- a/math/benches/elliptic_curves/bn_254.rs
+++ b/math/benches/elliptic_curves/bn_254.rs
@@ -26,22 +26,17 @@ type G2 = ShortWeierstrassProjectivePoint<BN254TwistCurve>;
 #[allow(dead_code)]
 pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
+    let a_val: u128 = rng.gen();
+    let b_val: u128 = rng.gen();
+    let a_g1 = BN254Curve::generator().operate_with_self(a_val).to_affine();
+    let b_g1 = BN254Curve::generator().operate_with_self(b_val).to_affine();
 
-    // let a_val: u128 = rng.gen();
-    // let b_val: u128 = rng.gen();
-    let a_val: u128 = 2;
-    let b_val: u128 = 93;
-    let p = BN254Curve::generator();
-    let q = BN254TwistCurve::generator();
-    let a_g1 = BN254Curve::generator().operate_with(&p);
-    let b_g1 = BN254Curve::generator().operate_with_self(b_val);
-
-    //let a_g2 = BN254TwistCurve::generator().operate_with_self(2u32);
-    let a_g2 = BN254TwistCurve::generator().operate_with_self(2u32);
-    assert!(a_g2.is_in_subgroup(), "a_g2 is not in the subgroup!");
-
-    let b_g2 = BN254TwistCurve::generator().operate_with_self(b_val);
-
+    let a_g2 = BN254TwistCurve::generator()
+        .operate_with_self(b_val)
+        .to_affine();
+    let b_g2 = BN254TwistCurve::generator()
+        .operate_with_self(b_val)
+        .to_affine();
     let f_12 = Fp12E::from_coefficients(&[
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12",
     ]);

--- a/math/benches/elliptic_curves/bn_254.rs
+++ b/math/benches/elliptic_curves/bn_254.rs
@@ -28,21 +28,17 @@ pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
     let a_val: u128 = rng.gen();
     let b_val: u128 = rng.gen();
-    let a_g1 = BN254Curve::generator().operate_with_self(a_val).to_affine();
-    let b_g1 = BN254Curve::generator().operate_with_self(b_val).to_affine();
+    let a_g1 = BN254Curve::generator().operate_with_self(a_val);
+    let b_g1 = BN254Curve::generator().operate_with_self(b_val);
 
-    let a_g2 = BN254TwistCurve::generator()
-        .operate_with_self(b_val)
-        .to_affine();
-    let b_g2 = BN254TwistCurve::generator()
-        .operate_with_self(b_val)
-        .to_affine();
+    let a_g2 = BN254TwistCurve::generator().operate_with_self(b_val);
+    let b_g2 = BN254TwistCurve::generator().operate_with_self(b_val);
     let f_12 = Fp12E::from_coefficients(&[
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12",
     ]);
     let f_2 = Fp2E::new([FpE::from(a_val as u64), FpE::from(b_val as u64)]);
 
-    let miller_loop_output = miller_optimized(&a_g1, &a_g2);
+    let miller_loop_output = miller_optimized(&a_g1.to_affine(), &a_g2.to_affine());
 
     let mut group = c.benchmark_group("BN254 Ops");
 

--- a/math/benches/elliptic_curves/bn_254.rs
+++ b/math/benches/elliptic_curves/bn_254.rs
@@ -26,13 +26,22 @@ type G2 = ShortWeierstrassProjectivePoint<BN254TwistCurve>;
 #[allow(dead_code)]
 pub fn bn_254_elliptic_curve_benchmarks(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
-    let a_val: u128 = rng.gen();
-    let b_val: u128 = rng.gen();
-    let a_g1 = BN254Curve::generator().operate_with_self(a_val);
+
+    // let a_val: u128 = rng.gen();
+    // let b_val: u128 = rng.gen();
+    let a_val: u128 = 2;
+    let b_val: u128 = 93;
+    let p = BN254Curve::generator();
+    let q = BN254TwistCurve::generator();
+    let a_g1 = BN254Curve::generator().operate_with(&p);
     let b_g1 = BN254Curve::generator().operate_with_self(b_val);
 
-    let a_g2 = BN254TwistCurve::generator().operate_with_self(a_val);
+    //let a_g2 = BN254TwistCurve::generator().operate_with_self(2u32);
+    let a_g2 = BN254TwistCurve::generator().operate_with_self(2u32);
+    assert!(a_g2.is_in_subgroup(), "a_g2 is not in the subgroup!");
+
     let b_g2 = BN254TwistCurve::generator().operate_with_self(b_val);
+
     let f_12 = Fp12E::from_coefficients(&[
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12",
     ]);

--- a/math/benches/fields/baby_bear.rs
+++ b/math/benches/fields/baby_bear.rs
@@ -10,7 +10,7 @@ use lambdaworks_math::field::{
 };
 
 use p3_baby_bear::BabyBear;
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 
 use rand::random;
 use rand::Rng;
@@ -26,11 +26,13 @@ pub fn rand_field_elements(num: usize) -> Vec<(F, F)> {
     }
     result
 }
-
+fn random_baby_bear<R: Rng>(rng: &mut R) -> BabyBear {
+    BabyBear::new(rng.gen::<u32>())
+}
 fn rand_babybear_elements_p3(num: usize) -> Vec<(BabyBear, BabyBear)> {
     let mut rng = rand::thread_rng();
     (0..num)
-        .map(|_| (rng.gen::<BabyBear>(), rng.gen::<BabyBear>()))
+        .map(|_| (random_baby_bear(&mut rng), random_baby_bear(&mut rng)))
         .collect()
 }
 

--- a/math/benches/fields/baby_bear.rs
+++ b/math/benches/fields/baby_bear.rs
@@ -14,8 +14,8 @@ use lambdaworks_math::field::{
 };
 
 use p3_baby_bear::BabyBear;
-use p3_field::{Field, PrimeCharacteristicRing};
 use p3_field::extension::BinomialExtensionField;
+use p3_field::{Field, PrimeCharacteristicRing};
 
 use rand::random;
 use rand::Rng;
@@ -83,7 +83,9 @@ pub fn rand_babybear_u32_fp4_elements(num: usize) -> Vec<(Fp4Eu32, Fp4Eu32)> {
     }
     result
 }
-
+fn random_baby_bear<R: Rng>(rng: &mut R) -> BabyBear {
+    BabyBear::new(rng.gen::<u32>())
+}
 fn rand_babybear_elements_p3(num: usize) -> Vec<(BabyBear, BabyBear)> {
     let mut rng = rand::thread_rng();
     (0..num)
@@ -94,7 +96,12 @@ fn rand_babybear_elements_p3(num: usize) -> Vec<(BabyBear, BabyBear)> {
 fn rand_babybear_fp4_elements_p3(num: usize) -> Vec<(EF4, EF4)> {
     let mut rng = rand::thread_rng();
     (0..num)
-        .map(|_| (rng.gen::<EF4>(), rng.gen::<EF4>()))
+        .map(|_| {
+            (
+                EF4::from(random_baby_bear(&mut rng)),
+                EF4::from(random_baby_bear(&mut rng)),
+            )
+        })
         .collect()
 }
 

--- a/math/benches/fields/mersenne31.rs
+++ b/math/benches/fields/mersenne31.rs
@@ -15,7 +15,6 @@ pub type Fp2E = FieldElement<Degree2ExtensionField>;
 pub type Fp4E = FieldElement<Degree4ExtensionField>;
 
 #[inline(never)]
-#[no_mangle]
 #[export_name = "util::rand_mersenne31_field_elements"]
 pub fn rand_field_elements(num: usize) -> Vec<(F, F)> {
     let mut result = Vec::with_capacity(num);

--- a/math/benches/fields/mersenne31_montgomery.rs
+++ b/math/benches/fields/mersenne31_montgomery.rs
@@ -22,7 +22,6 @@ pub type F = FieldElement<Mersenne31MontgomeryPrimeField>;
 const NUM_LIMBS: usize = 1;
 
 #[inline(never)]
-#[no_mangle]
 #[export_name = "util::rand_mersenne31_mont_field_elements"]
 pub fn rand_field_elements(num: usize) -> Vec<(F, F)> {
     let mut result = Vec::with_capacity(num);

--- a/math/benches/fields/stark252.rs
+++ b/math/benches/fields/stark252.rs
@@ -21,7 +21,6 @@ use rand::random;
 pub type F = FieldElement<Stark252PrimeField>;
 
 #[inline(never)]
-#[no_mangle]
 #[export_name = "util::rand_field_elements"]
 pub fn rand_field_elements(num: usize) -> Vec<(F, F)> {
     let mut result = Vec::with_capacity(num);

--- a/math/benches/utils/stark252_utils.rs
+++ b/math/benches/utils/stark252_utils.rs
@@ -14,14 +14,12 @@ pub type FE = FieldElement<F>;
 
 // NOTE: intentional duplicate to help IAI skip setup code
 #[inline(never)]
-#[no_mangle]
 #[export_name = "util::bitrev_permute"]
 pub fn bitrev_permute(input: &mut [FE]) {
     in_place_bit_reverse_permute(input);
 }
 
 #[inline(never)]
-#[no_mangle]
 #[export_name = "util::rand_field_elements"]
 pub fn rand_field_elements(order: u64) -> Vec<FE> {
     let mut result = Vec::with_capacity(1 << order);
@@ -33,14 +31,12 @@ pub fn rand_field_elements(order: u64) -> Vec<FE> {
 }
 
 #[inline(never)]
-#[no_mangle]
 #[export_name = "util::rand_poly"]
 pub fn rand_poly(order: u64) -> Polynomial<FE> {
     Polynomial::new(&rand_field_elements(order))
 }
 
 #[inline(never)]
-#[no_mangle]
 #[export_name = "util::get_twiddles"]
 pub fn twiddles(order: u64, config: RootsConfig) -> Vec<FE> {
     get_twiddles(order, config).unwrap()

--- a/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
+++ b/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
@@ -12,11 +12,6 @@ impl IsEllipticCurve for BandersnatchCurve {
     type BaseField = BaseBandersnatchFieldElement;
     type PointRepresentation = EdwardsProjectivePoint<Self>;
 
-    // Values are from https://github.com/arkworks-rs/curves/blob/5a41d7f27a703a7ea9c48512a4148443ec6c747e/ed_on_bls12_381_bandersnatch/src/curves/mod.rs#L120
-    // converted to Hex.
-    // SAFETY: The creation of the generator point is safe since it is a constant that belongs to the curve.
-    // check which version of the comment is correct.
-
     /// Returns the generator point of the Bandersnatch curve.
     ///
     /// The generator point is defined with coordinates `(x, y, 1)`, where `x` and `y`

--- a/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
+++ b/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
@@ -33,18 +33,17 @@ impl IsEllipticCurve for BandersnatchCurve {
         //   impossible given that they are constants taken from a trusted source.
         // - `unwrap_unchecked()` avoids unnecessary checks, as we guarantee
         //   correctness based on external verification.
-        unsafe {
-            Self::PointRepresentation::new([
-                FieldElement::<Self::BaseField>::new_base(
-                    "29C132CC2C0B34C5743711777BBE42F32B79C022AD998465E1E71866A252AE18",
-                ),
-                FieldElement::<Self::BaseField>::new_base(
-                    "2A6C669EDA123E0F157D8B50BADCD586358CAD81EEE464605E3167B6CC974166",
-                ),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            FieldElement::<Self::BaseField>::new_base(
+                "29C132CC2C0B34C5743711777BBE42F32B79C022AD998465E1E71866A252AE18",
+            ),
+            FieldElement::<Self::BaseField>::new_base(
+                "2A6C669EDA123E0F157D8B50BADCD586358CAD81EEE464605E3167B6CC974166",
+            ),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
+++ b/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
@@ -33,8 +33,7 @@ impl IsEllipticCurve for BandersnatchCurve {
         //   impossible given that they are constants taken from a trusted source.
         // - `unwrap_unchecked()` avoids unnecessary checks, as we guarantee
         //   correctness based on external verification.
-
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::new_base(
                 "29C132CC2C0B34C5743711777BBE42F32B79C022AD998465E1E71866A252AE18",
             ),
@@ -42,8 +41,9 @@ impl IsEllipticCurve for BandersnatchCurve {
                 "2A6C669EDA123E0F157D8B50BADCD586358CAD81EEE464605E3167B6CC974166",
             ),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
+++ b/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
@@ -13,7 +13,8 @@ impl IsEllipticCurve for BandersnatchCurve {
     type PointRepresentation = EdwardsProjectivePoint<Self>;
 
     // Values are from https://github.com/arkworks-rs/curves/blob/5a41d7f27a703a7ea9c48512a4148443ec6c747e/ed_on_bls12_381_bandersnatch/src/curves/mod.rs#L120
-    // Converted to Hex
+    // converted to Hex.
+    // SAFETY: The creation of the generator point is safe since it is a constant that belongs to the curve.
     fn generator() -> Self::PointRepresentation {
         unsafe {
             Self::PointRepresentation::new([

--- a/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
+++ b/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
@@ -15,15 +15,18 @@ impl IsEllipticCurve for BandersnatchCurve {
     // Values are from https://github.com/arkworks-rs/curves/blob/5a41d7f27a703a7ea9c48512a4148443ec6c747e/ed_on_bls12_381_bandersnatch/src/curves/mod.rs#L120
     // Converted to Hex
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::new_base(
-                "29C132CC2C0B34C5743711777BBE42F32B79C022AD998465E1E71866A252AE18",
-            ),
-            FieldElement::<Self::BaseField>::new_base(
-                "2A6C669EDA123E0F157D8B50BADCD586358CAD81EEE464605E3167B6CC974166",
-            ),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::new_base(
+                    "29C132CC2C0B34C5743711777BBE42F32B79C022AD998465E1E71866A252AE18",
+                ),
+                FieldElement::<Self::BaseField>::new_base(
+                    "2A6C669EDA123E0F157D8B50BADCD586358CAD81EEE464605E3167B6CC974166",
+                ),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
+++ b/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
@@ -21,7 +21,7 @@ impl IsEllipticCurve for BandersnatchCurve {
     ///
     /// - The generator values are taken from the [Arkworks implementation](https://github.com/arkworks-rs/curves/blob/5a41d7f27a703a7ea9c48512a4148443ec6c747e/ed_on_bls12_381_bandersnatch/src/curves/mod.rs#L120)
     ///   and have been converted to hexadecimal.
-    /// - `unwrap_unchecked()` is safe because:
+    /// - `unwrap_unchecked()` does not panic because:
     ///   - The generator point is **known to be valid** on the curve.
     ///   - The function only uses **hardcoded** and **verified** constants.
     /// - This function should **never** be modified unless the new generator is fully verified.
@@ -31,8 +31,6 @@ impl IsEllipticCurve for BandersnatchCurve {
         //   verified implementation.
         // - The constructor will only fail if the values are invalid, which is
         //   impossible given that they are constants taken from a trusted source.
-        // - `unwrap_unchecked()` avoids unnecessary checks, as we guarantee
-        //   correctness based on external verification.
         let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::new_base(
                 "29C132CC2C0B34C5743711777BBE42F32B79C022AD998465E1E71866A252AE18",
@@ -42,7 +40,6 @@ impl IsEllipticCurve for BandersnatchCurve {
             ),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
+++ b/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
@@ -17,7 +17,8 @@ impl IsEllipticCurve for BandersnatchCurve {
     /// The generator point is defined with coordinates `(x, y, 1)`, where `x` and `y`
     /// are precomputed constants that belong to the curve.
     ///
-    /// ## Safety
+    /// # Safety
+    ///
     /// - The generator values are taken from the [Arkworks implementation](https://github.com/arkworks-rs/curves/blob/5a41d7f27a703a7ea9c48512a4148443ec6c747e/ed_on_bls12_381_bandersnatch/src/curves/mod.rs#L120)
     ///   and have been converted to hexadecimal.
     /// - `unwrap_unchecked()` is safe because:

--- a/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
+++ b/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
@@ -15,7 +15,28 @@ impl IsEllipticCurve for BandersnatchCurve {
     // Values are from https://github.com/arkworks-rs/curves/blob/5a41d7f27a703a7ea9c48512a4148443ec6c747e/ed_on_bls12_381_bandersnatch/src/curves/mod.rs#L120
     // converted to Hex.
     // SAFETY: The creation of the generator point is safe since it is a constant that belongs to the curve.
+    // check which version of the comment is correct.
+
+    /// Returns the generator point of the Bandersnatch curve.
+    ///
+    /// The generator point is defined with coordinates `(x, y, 1)`, where `x` and `y`
+    /// are precomputed constants that belong to the curve.
+    ///
+    /// ## Safety
+    /// - The generator values are taken from the [Arkworks implementation](https://github.com/arkworks-rs/curves/blob/5a41d7f27a703a7ea9c48512a4148443ec6c747e/ed_on_bls12_381_bandersnatch/src/curves/mod.rs#L120)
+    ///   and have been converted to hexadecimal.
+    /// - `unwrap_unchecked()` is safe because:
+    ///   - The generator point is **known to be valid** on the curve.
+    ///   - The function only uses **hardcoded** and **verified** constants.
+    /// - This function should **never** be modified unless the new generator is fully verified.
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point coordinates (x, y) are taken from a well-tested,
+        //   verified implementation.
+        // - The constructor will only fail if the values are invalid, which is
+        //   impossible given that they are constants taken from a trusted source.
+        // - `unwrap_unchecked()` avoids unnecessary checks, as we guarantee
+        //   correctness based on external verification.
         unsafe {
             Self::PointRepresentation::new([
                 FieldElement::<Self::BaseField>::new_base(

--- a/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
+++ b/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
@@ -21,7 +21,7 @@ impl IsEllipticCurve for BandersnatchCurve {
     ///
     /// - The generator values are taken from the [Arkworks implementation](https://github.com/arkworks-rs/curves/blob/5a41d7f27a703a7ea9c48512a4148443ec6c747e/ed_on_bls12_381_bandersnatch/src/curves/mod.rs#L120)
     ///   and have been converted to hexadecimal.
-    /// - `unwrap_unchecked()` does not panic because:
+    /// - `unwrap()` does not panic because:
     ///   - The generator point is **known to be valid** on the curve.
     ///   - The function only uses **hardcoded** and **verified** constants.
     /// - This function should **never** be modified unless the new generator is fully verified.

--- a/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
+++ b/math/src/elliptic_curve/edwards/curves/bandersnatch/curve.rs
@@ -33,17 +33,18 @@ impl IsEllipticCurve for BandersnatchCurve {
         //   impossible given that they are constants taken from a trusted source.
         // - `unwrap_unchecked()` avoids unnecessary checks, as we guarantee
         //   correctness based on external verification.
-
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::new_base(
-                "29C132CC2C0B34C5743711777BBE42F32B79C022AD998465E1E71866A252AE18",
-            ),
-            FieldElement::<Self::BaseField>::new_base(
-                "2A6C669EDA123E0F157D8B50BADCD586358CAD81EEE464605E3167B6CC974166",
-            ),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::new_base(
+                    "29C132CC2C0B34C5743711777BBE42F32B79C022AD998465E1E71866A252AE18",
+                ),
+                FieldElement::<Self::BaseField>::new_base(
+                    "2A6C669EDA123E0F157D8B50BADCD586358CAD81EEE464605E3167B6CC974166",
+                ),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
+++ b/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
@@ -28,12 +28,13 @@ impl IsEllipticCurve for Ed448Goldilocks {
         // - These values are taken from RFC 7748 and are known to be valid.
         // - `unwrap_unchecked()` is safe because `new()` will only fail if the point is
         //   invalid, which is **not possible** with hardcoded, verified values.
-
-        Self::PointRepresentation::new([
+        let point= Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex("4f1970c66bed0ded221d15a622bf36da9e146570470f1767ea6de324a3d3a46412ae1af72ab66511433b80e18b00938e2626a82bc70cc05e").unwrap(),
             FieldElement::<Self::BaseField>::from_hex("693f46716eb6bc248876203756c9c7624bea73736ca3984087789c1e05a0c2d73ad3ff1ce67c39c4fdbd132c4ed7c8ad9808795bf230fa14").unwrap(),
             FieldElement::one(),
-        ]).unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
+++ b/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
@@ -28,12 +28,13 @@ impl IsEllipticCurve for Ed448Goldilocks {
         // - These values are taken from RFC 7748 and are known to be valid.
         // - `unwrap_unchecked()` is safe because `new()` will only fail if the point is
         //   invalid, which is **not possible** with hardcoded, verified values.
-
-        Self::PointRepresentation::new([
+        unsafe {
+            Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex("4f1970c66bed0ded221d15a622bf36da9e146570470f1767ea6de324a3d3a46412ae1af72ab66511433b80e18b00938e2626a82bc70cc05e").unwrap(),
             FieldElement::<Self::BaseField>::from_hex("693f46716eb6bc248876203756c9c7624bea73736ca3984087789c1e05a0c2d73ad3ff1ce67c39c4fdbd132c4ed7c8ad9808795bf230fa14").unwrap(),
             FieldElement::one(),
-        ]).unwrap()
+        ]).unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
+++ b/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
@@ -28,13 +28,12 @@ impl IsEllipticCurve for Ed448Goldilocks {
         // - These values are taken from RFC 7748 and are known to be valid.
         // - `unwrap_unchecked()` is safe because `new()` will only fail if the point is
         //   invalid, which is **not possible** with hardcoded, verified values.
-        unsafe {
-            Self::PointRepresentation::new([
+
+        Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex("4f1970c66bed0ded221d15a622bf36da9e146570470f1767ea6de324a3d3a46412ae1af72ab66511433b80e18b00938e2626a82bc70cc05e").unwrap(),
             FieldElement::<Self::BaseField>::from_hex("693f46716eb6bc248876203756c9c7624bea73736ca3984087789c1e05a0c2d73ad3ff1ce67c39c4fdbd132c4ed7c8ad9808795bf230fa14").unwrap(),
             FieldElement::one(),
-        ]).unwrap_unchecked()
-        }
+        ]).unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
+++ b/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
@@ -20,20 +20,19 @@ impl IsEllipticCurve for Ed448Goldilocks {
     /// # Safety
     ///
     /// - The generator coordinates `(x, y, 1)` are well-known, predefined constants.
-    /// - `unwrap_unchecked()` is used because the values are **known to be valid** points
+    /// - `unwrap()` is used because the values are **known to be valid** points
     ///   on the Ed448-Goldilocks curve.
     /// - This function must **not** be modified unless new constants are mathematically verified.
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - These values are taken from RFC 7748 and are known to be valid.
-        // - `unwrap_unchecked()` is safe because `new()` will only fail if the point is
+        // - `unwrap()` is safe because `new()` will only fail if the point is
         //   invalid, which is **not possible** with hardcoded, verified values.
         let point= Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex("4f1970c66bed0ded221d15a622bf36da9e146570470f1767ea6de324a3d3a46412ae1af72ab66511433b80e18b00938e2626a82bc70cc05e").unwrap(),
             FieldElement::<Self::BaseField>::from_hex("693f46716eb6bc248876203756c9c7624bea73736ca3984087789c1e05a0c2d73ad3ff1ce67c39c4fdbd132c4ed7c8ad9808795bf230fa14").unwrap(),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
+++ b/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
@@ -13,8 +13,20 @@ impl IsEllipticCurve for Ed448Goldilocks {
     type BaseField = P448GoldilocksPrimeField;
     type PointRepresentation = EdwardsProjectivePoint<Self>;
 
-    /// Taken from https://www.rfc-editor.org/rfc/rfc7748#page-6
+    /// Returns the generator point of the Ed448-Goldilocks curve.
+    ///
+    /// This generator is taken from [RFC 7748](https://www.rfc-editor.org/rfc/rfc7748#page-6).
+    ///
+    /// ## Safety
+    /// - The generator coordinates `(x, y, 1)` are well-known, predefined constants.
+    /// - `unwrap_unchecked()` is used because the values are **known to be valid** points
+    ///   on the Ed448-Goldilocks curve.
+    /// - This function must **not** be modified unless new constants are mathematically verified.
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - These values are taken from RFC 7748 and are known to be valid.
+        // - `unwrap_unchecked()` is safe because `new()` will only fail if the point is
+        //   invalid, which is **not possible** with hardcoded, verified values.
         unsafe {
             Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex("4f1970c66bed0ded221d15a622bf36da9e146570470f1767ea6de324a3d3a46412ae1af72ab66511433b80e18b00938e2626a82bc70cc05e").unwrap(),

--- a/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
+++ b/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
@@ -15,11 +15,13 @@ impl IsEllipticCurve for Ed448Goldilocks {
 
     /// Taken from https://www.rfc-editor.org/rfc/rfc7748#page-6
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
+        unsafe {
+            Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex("4f1970c66bed0ded221d15a622bf36da9e146570470f1767ea6de324a3d3a46412ae1af72ab66511433b80e18b00938e2626a82bc70cc05e").unwrap(),
             FieldElement::<Self::BaseField>::from_hex("693f46716eb6bc248876203756c9c7624bea73736ca3984087789c1e05a0c2d73ad3ff1ce67c39c4fdbd132c4ed7c8ad9808795bf230fa14").unwrap(),
             FieldElement::one(),
-        ])
+        ]).unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
+++ b/math/src/elliptic_curve/edwards/curves/ed448_goldilocks.rs
@@ -17,7 +17,8 @@ impl IsEllipticCurve for Ed448Goldilocks {
     ///
     /// This generator is taken from [RFC 7748](https://www.rfc-editor.org/rfc/rfc7748#page-6).
     ///
-    /// ## Safety
+    /// # Safety
+    ///
     /// - The generator coordinates `(x, y, 1)` are well-known, predefined constants.
     /// - `unwrap_unchecked()` is used because the values are **known to be valid** points
     ///   on the Ed448-Goldilocks curve.

--- a/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
@@ -15,11 +15,14 @@ impl IsEllipticCurve for TinyJubJubEdwards {
     type PointRepresentation = EdwardsProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::from(8),
-            FieldElement::from(5),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::from(8),
+                FieldElement::from(5),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
@@ -28,14 +28,13 @@ impl IsEllipticCurve for TinyJubJubEdwards {
         // SAFETY:
         // - The generator point `(8, 5, 1)` is **mathematically valid** on the curve.
         // - `unwrap_unchecked()` is safe because we **know** the point satisfies the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
-                FieldElement::from(8),
-                FieldElement::from(5),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            FieldElement::from(8),
+            FieldElement::from(5),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
@@ -28,13 +28,14 @@ impl IsEllipticCurve for TinyJubJubEdwards {
         // SAFETY:
         // - The generator point `(8, 5, 1)` is **mathematically valid** on the curve.
         // - `unwrap_unchecked()` is safe because we **know** the point satisfies the curve equation.
-
-        Self::PointRepresentation::new([
-            FieldElement::from(8),
-            FieldElement::from(5),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::from(8),
+                FieldElement::from(5),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
@@ -21,19 +21,18 @@ impl IsEllipticCurve for TinyJubJubEdwards {
     /// # Safety
     ///
     /// - The generator coordinates `(8, 5, 1)` are **predefined** and belong to the TinyJubJub curve.
-    /// - `unwrap_unchecked()` is used because the generator is a **verified valid point**,
+    /// - `unwrap()` is used because the generator is a **verified valid point**,
     ///   meaning there is **no risk** of runtime failure.
     /// - This function must **not** be modified unless the new generator is mathematically verified.
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point `(8, 5, 1)` is **mathematically valid** on the curve.
-        // - `unwrap_unchecked()` is safe because we **know** the point satisfies the curve equation.
+        // - `unwrap()` is safe because we **know** the point satisfies the curve equation.
         let point = Self::PointRepresentation::new([
             FieldElement::from(8),
             FieldElement::from(5),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
@@ -28,13 +28,13 @@ impl IsEllipticCurve for TinyJubJubEdwards {
         // SAFETY:
         // - The generator point `(8, 5, 1)` is **mathematically valid** on the curve.
         // - `unwrap_unchecked()` is safe because we **know** the point satisfies the curve equation.
-
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::from(8),
             FieldElement::from(5),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
@@ -14,7 +14,19 @@ impl IsEllipticCurve for TinyJubJubEdwards {
     type BaseField = U64PrimeField<13>;
     type PointRepresentation = EdwardsProjectivePoint<Self>;
 
+    /// Returns the generator point of the TinyJubJub Edwards curve.
+    ///
+    /// This generator is taken from **Moonmath Manual (page 97)**.
+    ///
+    /// ## Safety
+    /// - The generator coordinates `(8, 5, 1)` are **predefined** and belong to the TinyJubJub curve.
+    /// - `unwrap_unchecked()` is used because the generator is a **verified valid point**,
+    ///   meaning there is **no risk** of runtime failure.
+    /// - This function must **not** be modified unless the new generator is mathematically verified.
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point `(8, 5, 1)` is **mathematically valid** on the curve.
+        // - `unwrap_unchecked()` is safe because we **know** the point satisfies the curve equation.
         unsafe {
             Self::PointRepresentation::new([
                 FieldElement::from(8),

--- a/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/edwards/curves/tiny_jub_jub.rs
@@ -18,7 +18,8 @@ impl IsEllipticCurve for TinyJubJubEdwards {
     ///
     /// This generator is taken from **Moonmath Manual (page 97)**.
     ///
-    /// ## Safety
+    /// # Safety
+    ///
     /// - The generator coordinates `(8, 5, 1)` are **predefined** and belong to the TinyJubJub curve.
     /// - `unwrap_unchecked()` is used because the generator is a **verified valid point**,
     ///   meaning there is **no risk** of runtime failure.

--- a/math/src/elliptic_curve/edwards/point.rs
+++ b/math/src/elliptic_curve/edwards/point.rs
@@ -119,6 +119,7 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
         let num_s2 = &y1y2 - E::a() * &x1x2;
         let den_s2 = &one - &dx1x2y1y2;
 
+        // SAFETY: The creation of the result point is safe because the inputs are always points that belong to the curve.
         unsafe { Self::new([&num_s1 / &den_s1, &num_s2 / &den_s2, one]).unwrap_unchecked() }
     }
 

--- a/math/src/elliptic_curve/edwards/point.rs
+++ b/math/src/elliptic_curve/edwards/point.rs
@@ -19,7 +19,7 @@ impl<E: IsEllipticCurve + IsEdwards> EdwardsProjectivePoint<E> {
 
         if z != &FieldElement::<E::BaseField>::zero()
             && x != &FieldElement::<E::BaseField>::zero()
-            && E::defining_equation_projective(&x, &y, &z) == FieldElement::<E::BaseField>::zero()
+            && E::defining_equation_projective(x, y, z) == FieldElement::<E::BaseField>::zero()
         {
             Ok(Self(ProjectivePoint::new(value)))
         // The point at infinity is (0, 1, 1).
@@ -75,7 +75,7 @@ impl<E: IsEdwards> FromAffine<E::BaseField> for EdwardsProjectivePoint<E> {
         y: FieldElement<E::BaseField>,
     ) -> Result<Self, EllipticCurveError> {
         let coordinates = [x, y, FieldElement::one()];
-        Ok(EdwardsProjectivePoint::new(coordinates)?)
+        EdwardsProjectivePoint::new(coordinates)
     }
 }
 

--- a/math/src/elliptic_curve/edwards/point.rs
+++ b/math/src/elliptic_curve/edwards/point.rs
@@ -23,10 +23,8 @@ impl<E: IsEllipticCurve + IsEdwards> EdwardsProjectivePoint<E> {
         {
             Ok(Self(ProjectivePoint::new(value)))
         // The point at infinity is (0, 1, 1).
-        // We convert every (0, _, _) into the infinity.
-        } else if x == &FieldElement::<E::BaseField>::zero()
-            && E::defining_equation_projective(&x, &y, &z) == FieldElement::<E::BaseField>::zero()
-        {
+        // We convert every (0, y, y) into the infinity.
+        } else if x == &FieldElement::<E::BaseField>::zero() && z == y {
             Ok(Self(ProjectivePoint::new([
                 FieldElement::<E::BaseField>::zero(),
                 FieldElement::<E::BaseField>::one(),

--- a/math/src/elliptic_curve/edwards/point.rs
+++ b/math/src/elliptic_curve/edwards/point.rs
@@ -94,13 +94,13 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
         // SAFETY:
         // - `[0, 1, 1]` is a mathematically verified neutral element in Edwards curves.
         // - `unwrap_unchecked()` is safe because this point is **always valid**.
-
-        Self::new([
+        let point = Self::new([
             FieldElement::zero(),
             FieldElement::one(),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 
     fn is_neutral_element(&self) -> bool {
@@ -137,7 +137,9 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
         let den_s2 = &one - &dx1x2y1y2;
 
         // SAFETY: The creation of the result point is safe because the inputs are always points that belong to the curve.
-        Self::new([&num_s1 / &den_s1, &num_s2 / &den_s2, one]).unwrap()
+        let point = Self::new([&num_s1 / &den_s1, &num_s2 / &den_s2, one]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 
     /// Returns the additive inverse of the projective point `p`
@@ -151,7 +153,9 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
         // SAFETY:
         // - The negation formula for Edwards curves is well-defined.
         // - The result remains a valid curve point.
-        Self::new([-px, py.clone(), pz.clone()]).unwrap()
+        let point = Self::new([-px, py.clone(), pz.clone()]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/edwards/point.rs
+++ b/math/src/elliptic_curve/edwards/point.rs
@@ -88,18 +88,17 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
     ///
     /// - The values `[0, 1, 1]` are the **canonical representation** of the neutral element
     ///   in the Edwards curve, meaning they are guaranteed to be a valid point.
-    /// - `unwrap_unchecked()` is used because this point is **known** to be valid, so
+    /// - `unwrap()` is used because this point is **known** to be valid, so
     ///   there is no need for additional runtime checks.
     fn neutral_element() -> Self {
         // SAFETY:
         // - `[0, 1, 1]` is a mathematically verified neutral element in Edwards curves.
-        // - `unwrap_unchecked()` is safe because this point is **always valid**.
+        // - `unwrap()` is safe because this point is **always valid**.
         let point = Self::new([
             FieldElement::zero(),
             FieldElement::one(),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 
@@ -117,7 +116,7 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
     /// - The function assumes both `self` and `other` are valid points on the curve.
     /// - The resulting coordinates are computed using a well-defined formula that
     ///   maintains the elliptic curve invariants.
-    /// - `unwrap_unchecked()` is safe because the formula guarantees the result is valid.
+    /// - `unwrap()` is safe because the formula guarantees the result is valid.
     fn operate_with(&self, other: &Self) -> Self {
         // This avoids dropping, which in turn saves us from having to clone the coordinates.
         let (s_affine, o_affine) = (self.to_affine(), other.to_affine());
@@ -138,7 +137,6 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
 
         // SAFETY: The creation of the result point is safe because the inputs are always points that belong to the curve.
         let point = Self::new([&num_s1 / &den_s1, &num_s2 / &den_s2, one]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 
@@ -147,14 +145,13 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
     /// # Safety
     ///
     /// - Negating the x-coordinate of a valid Edwards point results in another valid point.
-    /// - `unwrap_unchecked()` is safe because negation does not break the curve equation.
+    /// - `unwrap()` is safe because negation does not break the curve equation.
     fn neg(&self) -> Self {
         let [px, py, pz] = self.coordinates();
         // SAFETY:
         // - The negation formula for Edwards curves is well-defined.
         // - The result remains a valid curve point.
         let point = Self::new([-px, py.clone(), pz.clone()]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/edwards/point.rs
+++ b/math/src/elliptic_curve/edwards/point.rs
@@ -82,8 +82,17 @@ impl<E: IsEdwards> FromAffine<E::BaseField> for EdwardsProjectivePoint<E> {
 impl<E: IsEllipticCurve> Eq for EdwardsProjectivePoint<E> {}
 
 impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
-    /// The point at infinity.
+    /// Returns the point at infinity (neutral element) in projective coordinates.
+    ///
+    /// ## Safety
+    /// - The values `[0, 1, 1]` are the **canonical representation** of the neutral element
+    ///   in the Edwards curve, meaning they are guaranteed to be a valid point.
+    /// - `unwrap_unchecked()` is used because this point is **known** to be valid, so
+    ///   there is no need for additional runtime checks.
     fn neutral_element() -> Self {
+        // SAFETY:
+        // - `[0, 1, 1]` is a mathematically verified neutral element in Edwards curves.
+        // - `unwrap_unchecked()` is safe because this point is **always valid**.
         unsafe {
             Self::new([
                 FieldElement::zero(),
@@ -99,8 +108,15 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
         px == &FieldElement::zero() && py == pz
     }
 
-    /// Computes the addition of `self` and `other`.
-    /// Taken from "Moonmath" (Eq 5.38, page 97)
+    /// Computes the addition of `self` and `other` using the Edwards curve addition formula.
+    ///
+    /// This implementation follows Equation (5.38) from "Moonmath" (page 97).
+    ///
+    /// ## Safety
+    /// - The function assumes both `self` and `other` are valid points on the curve.
+    /// - The resulting coordinates are computed using a well-defined formula that
+    ///   maintains the elliptic curve invariants.
+    /// - `unwrap_unchecked()` is safe because the formula guarantees the result is valid.
     fn operate_with(&self, other: &Self) -> Self {
         // This avoids dropping, which in turn saves us from having to clone the coordinates.
         let (s_affine, o_affine) = (self.to_affine(), other.to_affine());
@@ -124,8 +140,15 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
     }
 
     /// Returns the additive inverse of the projective point `p`
+    ///  
+    /// ## Safety
+    /// - Negating the x-coordinate of a valid Edwards point results in another valid point.
+    /// - `unwrap_unchecked()` is safe because negation does not break the curve equation.
     fn neg(&self) -> Self {
         let [px, py, pz] = self.coordinates();
+        // SAFETY:
+        // - The negation formula for Edwards curves is well-defined.
+        // - The result remains a valid curve point.
         unsafe { Self::new([-px, py.clone(), pz.clone()]).unwrap_unchecked() }
     }
 }

--- a/math/src/elliptic_curve/edwards/point.rs
+++ b/math/src/elliptic_curve/edwards/point.rs
@@ -94,13 +94,14 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
         // SAFETY:
         // - `[0, 1, 1]` is a mathematically verified neutral element in Edwards curves.
         // - `unwrap_unchecked()` is safe because this point is **always valid**.
-
-        Self::new([
-            FieldElement::zero(),
-            FieldElement::one(),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::new([
+                FieldElement::zero(),
+                FieldElement::one(),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 
     fn is_neutral_element(&self) -> bool {
@@ -137,7 +138,7 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
         let den_s2 = &one - &dx1x2y1y2;
 
         // SAFETY: The creation of the result point is safe because the inputs are always points that belong to the curve.
-        Self::new([&num_s1 / &den_s1, &num_s2 / &den_s2, one]).unwrap()
+        unsafe { Self::new([&num_s1 / &den_s1, &num_s2 / &den_s2, one]).unwrap_unchecked() }
     }
 
     /// Returns the additive inverse of the projective point `p`
@@ -151,7 +152,7 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
         // SAFETY:
         // - The negation formula for Edwards curves is well-defined.
         // - The result remains a valid curve point.
-        Self::new([-px, py.clone(), pz.clone()]).unwrap()
+        unsafe { Self::new([-px, py.clone(), pz.clone()]).unwrap_unchecked() }
     }
 }
 

--- a/math/src/elliptic_curve/edwards/point.rs
+++ b/math/src/elliptic_curve/edwards/point.rs
@@ -23,11 +23,15 @@ impl<E: IsEllipticCurve + IsEdwards> EdwardsProjectivePoint<E> {
         {
             Ok(Self(ProjectivePoint::new(value)))
         // The point at infinity is (0, 1, 1).
+        // We convert every (0, _, _) into the infinity.
         } else if x == &FieldElement::<E::BaseField>::zero()
-            && y == &FieldElement::<E::BaseField>::one()
-            && z == &FieldElement::<E::BaseField>::one()
+            && E::defining_equation_projective(&x, &y, &z) == FieldElement::<E::BaseField>::zero()
         {
-            Ok(Self(ProjectivePoint::new(value)))
+            Ok(Self(ProjectivePoint::new([
+                FieldElement::<E::BaseField>::zero(),
+                FieldElement::<E::BaseField>::one(),
+                FieldElement::<E::BaseField>::one(),
+            ])))
         } else {
             Err(EllipticCurveError::InvalidPoint)
         }

--- a/math/src/elliptic_curve/edwards/point.rs
+++ b/math/src/elliptic_curve/edwards/point.rs
@@ -17,19 +17,19 @@ impl<E: IsEllipticCurve + IsEdwards> EdwardsProjectivePoint<E> {
     pub fn new(value: [FieldElement<E::BaseField>; 3]) -> Result<Self, EllipticCurveError> {
         let (x, y, z) = (&value[0], &value[1], &value[2]);
 
-        if z != &FieldElement::<E::BaseField>::zero()
-            && x != &FieldElement::<E::BaseField>::zero()
-            && E::defining_equation_projective(x, y, z) == FieldElement::<E::BaseField>::zero()
-        {
-            Ok(Self(ProjectivePoint::new(value)))
         // The point at infinity is (0, 1, 1).
         // We convert every (0, y, y) into the infinity.
-        } else if x == &FieldElement::<E::BaseField>::zero() && z == y {
-            Ok(Self(ProjectivePoint::new([
+        if x == &FieldElement::<E::BaseField>::zero() && z == y {
+            return Ok(Self(ProjectivePoint::new([
                 FieldElement::<E::BaseField>::zero(),
                 FieldElement::<E::BaseField>::one(),
                 FieldElement::<E::BaseField>::one(),
-            ])))
+            ])));
+        }
+        if z != &FieldElement::<E::BaseField>::zero()
+            && E::defining_equation_projective(x, y, z) == FieldElement::<E::BaseField>::zero()
+        {
+            Ok(Self(ProjectivePoint::new(value)))
         } else {
             Err(EllipticCurveError::InvalidPoint)
         }

--- a/math/src/elliptic_curve/edwards/point.rs
+++ b/math/src/elliptic_curve/edwards/point.rs
@@ -84,7 +84,8 @@ impl<E: IsEllipticCurve> Eq for EdwardsProjectivePoint<E> {}
 impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
     /// Returns the point at infinity (neutral element) in projective coordinates.
     ///
-    /// ## Safety
+    /// # Safety
+    ///
     /// - The values `[0, 1, 1]` are the **canonical representation** of the neutral element
     ///   in the Edwards curve, meaning they are guaranteed to be a valid point.
     /// - `unwrap_unchecked()` is used because this point is **known** to be valid, so
@@ -112,7 +113,8 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
     ///
     /// This implementation follows Equation (5.38) from "Moonmath" (page 97).
     ///
-    /// ## Safety
+    /// # Safety
+    ///
     /// - The function assumes both `self` and `other` are valid points on the curve.
     /// - The resulting coordinates are computed using a well-defined formula that
     ///   maintains the elliptic curve invariants.
@@ -141,7 +143,8 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
 
     /// Returns the additive inverse of the projective point `p`
     ///  
-    /// ## Safety
+    /// # Safety
+    ///
     /// - Negating the x-coordinate of a valid Edwards point results in another valid point.
     /// - `unwrap_unchecked()` is safe because negation does not break the curve equation.
     fn neg(&self) -> Self {

--- a/math/src/elliptic_curve/edwards/point.rs
+++ b/math/src/elliptic_curve/edwards/point.rs
@@ -94,14 +94,13 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
         // SAFETY:
         // - `[0, 1, 1]` is a mathematically verified neutral element in Edwards curves.
         // - `unwrap_unchecked()` is safe because this point is **always valid**.
-        unsafe {
-            Self::new([
-                FieldElement::zero(),
-                FieldElement::one(),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::new([
+            FieldElement::zero(),
+            FieldElement::one(),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 
     fn is_neutral_element(&self) -> bool {
@@ -138,7 +137,7 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
         let den_s2 = &one - &dx1x2y1y2;
 
         // SAFETY: The creation of the result point is safe because the inputs are always points that belong to the curve.
-        unsafe { Self::new([&num_s1 / &den_s1, &num_s2 / &den_s2, one]).unwrap_unchecked() }
+        Self::new([&num_s1 / &den_s1, &num_s2 / &den_s2, one]).unwrap()
     }
 
     /// Returns the additive inverse of the projective point `p`
@@ -152,7 +151,7 @@ impl<E: IsEdwards> IsGroup for EdwardsProjectivePoint<E> {
         // SAFETY:
         // - The negation formula for Edwards curves is well-defined.
         // - The result remains a valid curve point.
-        unsafe { Self::new([-px, py.clone(), pz.clone()]).unwrap_unchecked() }
+        Self::new([-px, py.clone(), pz.clone()]).unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/edwards/traits.rs
+++ b/math/src/elliptic_curve/edwards/traits.rs
@@ -15,4 +15,18 @@ pub trait IsEdwards: IsEllipticCurve + Clone + Debug {
             - FieldElement::<Self::BaseField>::one()
             - Self::d() * x.pow(2_u16) * y.pow(2_u16)
     }
+
+    // Edwards equation in affine coordinates:
+    // ax^2 + y^2 - 1 = d * x^2 * y^2
+    // Edwards equation in projective coordinates: Multiplying the above equation by z^4 in both sides, we get:
+    // a * x^2 * z^2 + y^2 * z^2 - z^4 = d * x^2 * y^2
+    fn defining_equation_projective(
+        x: &FieldElement<Self::BaseField>,
+        y: &FieldElement<Self::BaseField>,
+        z: &FieldElement<Self::BaseField>,
+    ) -> FieldElement<Self::BaseField> {
+        Self::a() * x.square() * z.square() + y.square() * z.square()
+            - z.square().square()
+            - Self::d() * x.square() * y.square()
+    }
 }

--- a/math/src/elliptic_curve/edwards/traits.rs
+++ b/math/src/elliptic_curve/edwards/traits.rs
@@ -7,6 +7,8 @@ pub trait IsEdwards: IsEllipticCurve + Clone + Debug {
 
     fn d() -> FieldElement<Self::BaseField>;
 
+    // Edwards equation in affine coordinates:
+    // ax^2 + y^2 - 1 = d * x^2 * y^2
     fn defining_equation(
         x: &FieldElement<Self::BaseField>,
         y: &FieldElement<Self::BaseField>,
@@ -16,9 +18,7 @@ pub trait IsEdwards: IsEllipticCurve + Clone + Debug {
             - Self::d() * x.pow(2_u16) * y.pow(2_u16)
     }
 
-    // Edwards equation in affine coordinates:
-    // ax^2 + y^2 - 1 = d * x^2 * y^2
-    // Edwards equation in projective coordinates: Multiplying the above equation by z^4 in both sides, we get:
+    // Edwards equation in projective coordinates.
     // a * x^2 * z^2 + y^2 * z^2 - z^4 = d * x^2 * y^2
     fn defining_equation_projective(
         x: &FieldElement<Self::BaseField>,

--- a/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
@@ -18,7 +18,8 @@ impl IsEllipticCurve for TinyJubJubMontgomery {
     ///
     /// This generator is taken from **Moonmath Manual (page 91)**.
     ///
-    /// ## Safety
+    /// # Safety
+    ///
     /// - The generator coordinates `(3, 5, 1)` are **predefined** and are **valid** points
     ///   on the TinyJubJub Montgomery curve.
     /// - `unwrap_unchecked()` is used because the generator is **guaranteed** to satisfy

--- a/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
@@ -15,11 +15,14 @@ impl IsEllipticCurve for TinyJubJubMontgomery {
     type PointRepresentation = MontgomeryProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::from(3),
-            FieldElement::from(5),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::from(3),
+                FieldElement::from(5),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
@@ -14,7 +14,20 @@ impl IsEllipticCurve for TinyJubJubMontgomery {
     type BaseField = U64PrimeField<13>;
     type PointRepresentation = MontgomeryProjectivePoint<Self>;
 
+    /// Returns the generator point of the TinyJubJub Montgomery curve.
+    ///
+    /// This generator is taken from **Moonmath Manual (page 91)**.
+    ///
+    /// ## Safety
+    /// - The generator coordinates `(3, 5, 1)` are **predefined** and are **valid** points
+    ///   on the TinyJubJub Montgomery curve.
+    /// - `unwrap_unchecked()` is used because the generator is **guaranteed** to satisfy
+    ///   the Montgomery curve equation.
+    /// - This function must **not** be modified unless the new generator is mathematically verified.
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point `(3, 5, 1)` is **mathematically verified**.
+        // - `unwrap_unchecked()` is safe because the input values **guarantee** validity.
         unsafe {
             Self::PointRepresentation::new([
                 FieldElement::from(3),

--- a/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
@@ -29,13 +29,13 @@ impl IsEllipticCurve for TinyJubJubMontgomery {
         // SAFETY:
         // - The generator point `(3, 5, 1)` is **mathematically verified**.
         // - `unwrap_unchecked()` is safe because the input values **guarantee** validity.
-
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::from(3),
             FieldElement::from(5),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
@@ -29,13 +29,14 @@ impl IsEllipticCurve for TinyJubJubMontgomery {
         // SAFETY:
         // - The generator point `(3, 5, 1)` is **mathematically verified**.
         // - `unwrap_unchecked()` is safe because the input values **guarantee** validity.
-
-        Self::PointRepresentation::new([
-            FieldElement::from(3),
-            FieldElement::from(5),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::from(3),
+                FieldElement::from(5),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
@@ -22,19 +22,18 @@ impl IsEllipticCurve for TinyJubJubMontgomery {
     ///
     /// - The generator coordinates `(3, 5, 1)` are **predefined** and are **valid** points
     ///   on the TinyJubJub Montgomery curve.
-    /// - `unwrap_unchecked()` is used because the generator is **guaranteed** to satisfy
+    /// - `unwrap()` is used because the generator is **guaranteed** to satisfy
     ///   the Montgomery curve equation.
     /// - This function must **not** be modified unless the new generator is mathematically verified.
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point `(3, 5, 1)` is **mathematically verified**.
-        // - `unwrap_unchecked()` is safe because the input values **guarantee** validity.
+        // - `unwrap()` is safe because the input values **guarantee** validity.
         let point = Self::PointRepresentation::new([
             FieldElement::from(3),
             FieldElement::from(5),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
+++ b/math/src/elliptic_curve/montgomery/curves/tiny_jub_jub.rs
@@ -29,14 +29,13 @@ impl IsEllipticCurve for TinyJubJubMontgomery {
         // SAFETY:
         // - The generator point `(3, 5, 1)` is **mathematically verified**.
         // - `unwrap_unchecked()` is safe because the input values **guarantee** validity.
-        unsafe {
-            Self::PointRepresentation::new([
-                FieldElement::from(3),
-                FieldElement::from(5),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            FieldElement::from(3),
+            FieldElement::from(5),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/montgomery/point.rs
+++ b/math/src/elliptic_curve/montgomery/point.rs
@@ -93,13 +93,14 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
         // SAFETY:
         // - `(0, 1, 0)` is **mathematically valid** as the neutral element.
         // - `unwrap_unchecked()` is safe because this is **a known valid point**.
-
-        Self::new([
-            FieldElement::zero(),
-            FieldElement::one(),
-            FieldElement::zero(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::new([
+                FieldElement::zero(),
+                FieldElement::one(),
+                FieldElement::zero(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 
     fn is_neutral_element(&self) -> bool {
@@ -150,7 +151,7 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
                 // SAFETY:
                 // - The Montgomery addition formula guarantees a **valid** curve point.
                 // - `unwrap_unchecked()` is safe because the input points are **valid**.
-                Self::new([new_x, new_y, one]).unwrap()
+                unsafe { Self::new([new_x, new_y, one]).unwrap_unchecked() }
             // In the rest of the cases we have x1 != x2
             } else {
                 let num = &y2 - &y1;
@@ -163,7 +164,7 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
                 // SAFETY:
                 // - The result of the Montgomery addition formula is **guaranteed** to be a valid point.
                 // - `unwrap_unchecked()` is safe because we **control** the inputs.
-                Self::new([new_x, new_y, FieldElement::one()]).unwrap()
+                unsafe { Self::new([new_x, new_y, FieldElement::one()]).unwrap_unchecked() }
             }
         }
     }
@@ -179,7 +180,7 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
         // SAFETY:
         // - Negating `y` maintains the curve structure.
         // - `unwrap_unchecked()` is safe because negation **is always valid**.
-        Self::new([px.clone(), -py, pz.clone()]).unwrap()
+        unsafe { Self::new([px.clone(), -py, pz.clone()]).unwrap_unchecked() }
     }
 }
 

--- a/math/src/elliptic_curve/montgomery/point.rs
+++ b/math/src/elliptic_curve/montgomery/point.rs
@@ -116,7 +116,7 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
     ///
     /// - This function assumes that both `self` and `other` are **valid** points on the curve.
     /// - The resulting point is **guaranteed** to be valid due to the **Montgomery curve addition formula**.
-    /// - `unwrap_unchecked()` is used because the formula ensures the result remains a valid curve point.
+    /// - `unwrap()` is used because the formula ensures the result remains a valid curve point.
     fn operate_with(&self, other: &Self) -> Self {
         // One of them is the neutral element.
         if self.is_neutral_element() {
@@ -149,9 +149,8 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
 
                 // SAFETY:
                 // - The Montgomery addition formula guarantees a **valid** curve point.
-                // - `unwrap_unchecked()` is safe because the input points are **valid**.
+                // - `unwrap()` is safe because the input points are **valid**.
                 let point = Self::new([new_x, new_y, one]);
-                debug_assert!(point.is_ok());
                 point.unwrap()
             // In the rest of the cases we have x1 != x2
             } else {
@@ -164,9 +163,8 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
 
                 // SAFETY:
                 // - The result of the Montgomery addition formula is **guaranteed** to be a valid point.
-                // - `unwrap_unchecked()` is safe because we **control** the inputs.
+                // - `unwrap()` is safe because we **control** the inputs.
                 let point = Self::new([new_x, new_y, FieldElement::one()]);
-                debug_assert!(point.is_ok());
                 point.unwrap()
             }
         }
@@ -177,12 +175,12 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
     /// # Safety
     ///
     /// - The negation formula preserves the curve equation.
-    /// - `unwrap_unchecked()` is safe because negation **does not** create invalid points.
+    /// - `unwrap()` is safe because negation **does not** create invalid points.
     fn neg(&self) -> Self {
         let [px, py, pz] = self.coordinates();
         // SAFETY:
         // - Negating `y` maintains the curve structure.
-        // - `unwrap_unchecked()` is safe because negation **is always valid**.
+        // - `unwrap()` is safe because negation **is always valid**.
         let point = Self::new([px.clone(), -py, pz.clone()]);
         debug_assert!(point.is_ok());
         point.unwrap()

--- a/math/src/elliptic_curve/montgomery/point.rs
+++ b/math/src/elliptic_curve/montgomery/point.rs
@@ -18,7 +18,7 @@ impl<E: IsEllipticCurve + IsMontgomery> MontgomeryProjectivePoint<E> {
         let (x, y, z) = (&value[0], &value[1], &value[2]);
 
         if z != &FieldElement::<E::BaseField>::zero()
-            && E::defining_equation_projective(&x, &y, &z) == FieldElement::<E::BaseField>::zero()
+            && E::defining_equation_projective(x, y, z) == FieldElement::<E::BaseField>::zero()
         {
             Ok(Self(ProjectivePoint::new(value)))
         // The point at infinity is (0, 1, 0)
@@ -76,7 +76,7 @@ impl<E: IsMontgomery> FromAffine<E::BaseField> for MontgomeryProjectivePoint<E> 
         y: FieldElement<E::BaseField>,
     ) -> Result<Self, EllipticCurveError> {
         let coordinates = [x, y, FieldElement::one()];
-        Ok(MontgomeryProjectivePoint::new(coordinates)?)
+        MontgomeryProjectivePoint::new(coordinates)
     }
 }
 

--- a/math/src/elliptic_curve/montgomery/point.rs
+++ b/math/src/elliptic_curve/montgomery/point.rs
@@ -93,14 +93,13 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
         // SAFETY:
         // - `(0, 1, 0)` is **mathematically valid** as the neutral element.
         // - `unwrap_unchecked()` is safe because this is **a known valid point**.
-        unsafe {
-            Self::new([
-                FieldElement::zero(),
-                FieldElement::one(),
-                FieldElement::zero(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::new([
+            FieldElement::zero(),
+            FieldElement::one(),
+            FieldElement::zero(),
+        ])
+        .unwrap()
     }
 
     fn is_neutral_element(&self) -> bool {
@@ -151,7 +150,7 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
                 // SAFETY:
                 // - The Montgomery addition formula guarantees a **valid** curve point.
                 // - `unwrap_unchecked()` is safe because the input points are **valid**.
-                unsafe { Self::new([new_x, new_y, one]).unwrap_unchecked() }
+                Self::new([new_x, new_y, one]).unwrap()
             // In the rest of the cases we have x1 != x2
             } else {
                 let num = &y2 - &y1;
@@ -164,7 +163,7 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
                 // SAFETY:
                 // - The result of the Montgomery addition formula is **guaranteed** to be a valid point.
                 // - `unwrap_unchecked()` is safe because we **control** the inputs.
-                unsafe { Self::new([new_x, new_y, FieldElement::one()]).unwrap_unchecked() }
+                Self::new([new_x, new_y, FieldElement::one()]).unwrap()
             }
         }
     }
@@ -180,7 +179,7 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
         // SAFETY:
         // - Negating `y` maintains the curve structure.
         // - `unwrap_unchecked()` is safe because negation **is always valid**.
-        unsafe { Self::new([px.clone(), -py, pz.clone()]).unwrap_unchecked() }
+        Self::new([px.clone(), -py, pz.clone()]).unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/montgomery/point.rs
+++ b/math/src/elliptic_curve/montgomery/point.rs
@@ -85,7 +85,8 @@ impl<E: IsEllipticCurve> Eq for MontgomeryProjectivePoint<E> {}
 impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
     /// The point at infinity.
     ///    
-    /// ## Safety
+    /// # Safety
+    ///
     /// - The point `(0, 1, 0)` is a well-defined **neutral element** for Montgomery curves.
     /// - `unwrap_unchecked()` is used because this point is **always valid**.
     fn neutral_element() -> Self {
@@ -112,7 +113,8 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
     /// This implementation follows the addition law for Montgomery curves as described in:
     /// **Moonmath Manual, Definition 5.2.2.1, Page 94**.
     ///
-    /// ## Safety
+    /// # Safety
+    ///
     /// - This function assumes that both `self` and `other` are **valid** points on the curve.
     /// - The resulting point is **guaranteed** to be valid due to the **Montgomery curve addition formula**.
     /// - `unwrap_unchecked()` is used because the formula ensures the result remains a valid curve point.
@@ -169,7 +171,8 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
 
     /// Returns the additive inverse of the projective point `p`
     ///
-    /// ## Safety
+    /// # Safety
+    ///
     /// - The negation formula preserves the curve equation.
     /// - `unwrap_unchecked()` is safe because negation **does not** create invalid points.
     fn neg(&self) -> Self {

--- a/math/src/elliptic_curve/montgomery/point.rs
+++ b/math/src/elliptic_curve/montgomery/point.rs
@@ -22,11 +22,15 @@ impl<E: IsEllipticCurve + IsMontgomery> MontgomeryProjectivePoint<E> {
         {
             Ok(Self(ProjectivePoint::new(value)))
         // The point at infinity is (0, 1, 0)
+        // We convert every (0, _, 0) into the infinity.
         } else if x == &FieldElement::<E::BaseField>::zero()
-            && y == &FieldElement::<E::BaseField>::one()
             && z == &FieldElement::<E::BaseField>::zero()
         {
-            Ok(Self(ProjectivePoint::new(value)))
+            Ok(Self(ProjectivePoint::new([
+                FieldElement::<E::BaseField>::zero(),
+                FieldElement::<E::BaseField>::one(),
+                FieldElement::<E::BaseField>::zero(),
+            ])))
         } else {
             Err(EllipticCurveError::InvalidPoint)
         }

--- a/math/src/elliptic_curve/montgomery/point.rs
+++ b/math/src/elliptic_curve/montgomery/point.rs
@@ -84,7 +84,14 @@ impl<E: IsEllipticCurve> Eq for MontgomeryProjectivePoint<E> {}
 
 impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
     /// The point at infinity.
+    ///    
+    /// ## Safety
+    /// - The point `(0, 1, 0)` is a well-defined **neutral element** for Montgomery curves.
+    /// - `unwrap_unchecked()` is used because this point is **always valid**.
     fn neutral_element() -> Self {
+        // SAFETY:
+        // - `(0, 1, 0)` is **mathematically valid** as the neutral element.
+        // - `unwrap_unchecked()` is safe because this is **a known valid point**.
         unsafe {
             Self::new([
                 FieldElement::zero(),
@@ -101,7 +108,14 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
     }
 
     /// Computes the addition of `self` and `other`.
-    /// Taken from "Moonmath" (Definition 5.2.2.1, page 94)
+    ///
+    /// This implementation follows the addition law for Montgomery curves as described in:
+    /// **Moonmath Manual, Definition 5.2.2.1, Page 94**.
+    ///
+    /// ## Safety
+    /// - This function assumes that both `self` and `other` are **valid** points on the curve.
+    /// - The resulting point is **guaranteed** to be valid due to the **Montgomery curve addition formula**.
+    /// - `unwrap_unchecked()` is used because the formula ensures the result remains a valid curve point.
     fn operate_with(&self, other: &Self) -> Self {
         // One of them is the neutral element.
         if self.is_neutral_element() {
@@ -132,6 +146,9 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
                 let new_x = &div * &div * &b - (&x1 + x2) - a;
                 let new_y = div * (x1 - &new_x) - y1;
 
+                // SAFETY:
+                // - The Montgomery addition formula guarantees a **valid** curve point.
+                // - `unwrap_unchecked()` is safe because the input points are **valid**.
                 unsafe { Self::new([new_x, new_y, one]).unwrap_unchecked() }
             // In the rest of the cases we have x1 != x2
             } else {
@@ -142,14 +159,24 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
                 let new_x = &div * &div * E::b() - (&x1 + &x2) - E::a();
                 let new_y = div * (x1 - &new_x) - y1;
 
+                // SAFETY:
+                // - The result of the Montgomery addition formula is **guaranteed** to be a valid point.
+                // - `unwrap_unchecked()` is safe because we **control** the inputs.
                 unsafe { Self::new([new_x, new_y, FieldElement::one()]).unwrap_unchecked() }
             }
         }
     }
 
     /// Returns the additive inverse of the projective point `p`
+    ///
+    /// ## Safety
+    /// - The negation formula preserves the curve equation.
+    /// - `unwrap_unchecked()` is safe because negation **does not** create invalid points.
     fn neg(&self) -> Self {
         let [px, py, pz] = self.coordinates();
+        // SAFETY:
+        // - Negating `y` maintains the curve structure.
+        // - `unwrap_unchecked()` is safe because negation **is always valid**.
         unsafe { Self::new([px.clone(), -py, pz.clone()]).unwrap_unchecked() }
     }
 }

--- a/math/src/elliptic_curve/montgomery/point.rs
+++ b/math/src/elliptic_curve/montgomery/point.rs
@@ -93,13 +93,13 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
         // SAFETY:
         // - `(0, 1, 0)` is **mathematically valid** as the neutral element.
         // - `unwrap_unchecked()` is safe because this is **a known valid point**.
-
-        Self::new([
+        let point = Self::new([
             FieldElement::zero(),
             FieldElement::one(),
             FieldElement::zero(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 
     fn is_neutral_element(&self) -> bool {
@@ -150,7 +150,9 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
                 // SAFETY:
                 // - The Montgomery addition formula guarantees a **valid** curve point.
                 // - `unwrap_unchecked()` is safe because the input points are **valid**.
-                Self::new([new_x, new_y, one]).unwrap()
+                let point = Self::new([new_x, new_y, one]);
+                debug_assert!(point.is_ok());
+                point.unwrap()
             // In the rest of the cases we have x1 != x2
             } else {
                 let num = &y2 - &y1;
@@ -163,7 +165,9 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
                 // SAFETY:
                 // - The result of the Montgomery addition formula is **guaranteed** to be a valid point.
                 // - `unwrap_unchecked()` is safe because we **control** the inputs.
-                Self::new([new_x, new_y, FieldElement::one()]).unwrap()
+                let point = Self::new([new_x, new_y, FieldElement::one()]);
+                debug_assert!(point.is_ok());
+                point.unwrap()
             }
         }
     }
@@ -179,7 +183,9 @@ impl<E: IsMontgomery> IsGroup for MontgomeryProjectivePoint<E> {
         // SAFETY:
         // - Negating `y` maintains the curve structure.
         // - `unwrap_unchecked()` is safe because negation **is always valid**.
-        Self::new([px.clone(), -py, pz.clone()]).unwrap()
+        let point = Self::new([px.clone(), -py, pz.clone()]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/montgomery/traits.rs
+++ b/math/src/elliptic_curve/montgomery/traits.rs
@@ -8,12 +8,23 @@ pub trait IsMontgomery: IsEllipticCurve + Clone + Debug {
 
     fn b() -> FieldElement<Self::BaseField>;
 
-    /// Evaluates the short Weierstrass equation at (x, y z).
-    /// Used for checking if [x: y: z] belongs to the elliptic curve.
+    /// Evaluates the equation at (x, y).
+    /// Used for checking if the point belongs to the elliptic curve.
+    /// Equation: by^2 = x^3 + ax^2 + x.
     fn defining_equation(
         x: &FieldElement<Self::BaseField>,
         y: &FieldElement<Self::BaseField>,
     ) -> FieldElement<Self::BaseField> {
-        (Self::b() * y.pow(2_u16)) - (x.pow(3_u16) + Self::a() * x.pow(2_u16) + x)
+        (Self::b() * y.square()) - (x.pow(3_u16) + Self::a() * x.square() + x)
+    }
+
+    /// Evaluates the equation at the projective point (x, y, z).
+    /// Projective equation: zby^2 = x^3 + zax^2 + z^2x
+    fn defining_equation_projective(
+        x: &FieldElement<Self::BaseField>,
+        y: &FieldElement<Self::BaseField>,
+        z: &FieldElement<Self::BaseField>,
+    ) -> FieldElement<Self::BaseField> {
+        z * Self::b() * y.square() - x.pow(3_u16) - z * Self::a() * x.square() - z.square() * x
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
@@ -41,12 +41,13 @@ impl IsEllipticCurve for BLS12377Curve {
         // SAFETY:
         // - These values are mathematically verified and known to be valid points on BLS12-377.
         // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
-
-        Self::PointRepresentation::new([
+        let point= Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::new_base("8848defe740a67c8fc6225bf87ff5485951e2caa9d41bb188282c8bd37cb5cd5481512ffcd394eeab9b16eb21be9ef"),
             FieldElement::<Self::BaseField>::new_base("1914a69c5102eff1f674f5d30afeec4bd7fb348ca3e52d96d182ad44fb82305c2fe3d3634a9591afd82de55559c8ea6"),
             FieldElement::one()
-        ]).unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 
@@ -124,12 +125,13 @@ impl ShortWeierstrassProjectivePoint<BLS12377TwistCurve> {
         // - `unwrap_unchecked()` is safe because the transformation follows
         //   **a known valid isomorphism** between the twist and E.
 
-        Self::new([
+        let point = Self::new([
             x.conjugate() * GAMMA_12,
             y.conjugate() * GAMMA_13,
             z.conjugate(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 
     /// 𝜓(P) = 𝑢P, where 𝑢 = SEED of the curve

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
@@ -35,18 +35,17 @@ impl IsEllipticCurve for BLS12377Curve {
     /// # Safety
     ///
     /// - The generator point `(x, y, 1)` is predefined and is **known to be a valid point** on the curve.
-    /// - `unwrap_unchecked()` is used because this point is **mathematically verified**.
+    /// - `unwrap` is used because this point is **mathematically verified**.
     /// - Do **not** modify this function unless a new generator has been **mathematically verified**.
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - These values are mathematically verified and known to be valid points on BLS12-377.
-        // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
+        // - `unwrap()` is safe because we **ensure** the input values satisfy the curve equation.
         let point= Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::new_base("8848defe740a67c8fc6225bf87ff5485951e2caa9d41bb188282c8bd37cb5cd5481512ffcd394eeab9b16eb21be9ef"),
             FieldElement::<Self::BaseField>::new_base("1914a69c5102eff1f674f5d30afeec4bd7fb348ca3e52d96d182ad44fb82305c2fe3d3634a9591afd82de55559c8ea6"),
             FieldElement::one()
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }
@@ -115,22 +114,20 @@ impl ShortWeierstrassProjectivePoint<BLS12377TwistCurve> {
     ///
     /// - This function assumes `self` is a valid point on the BLS12-377 **twist** curve.
     /// - The conjugation operation preserves validity.
-    /// - `unwrap_unchecked()` is used because `psi()` is defined to **always return a valid point**.
+    /// - `unwrap()` is used because `psi()` is defined to **always return a valid point**.
     fn psi(&self) -> Self {
         let [x, y, z] = self.coordinates();
         // SAFETY:
         // - `conjugate()` preserves the validity of the field element.
         // - `ENDO_U` and `ENDO_V` are precomputed constants that ensure the
         //   resulting point satisfies the curve equation.
-        // - `unwrap_unchecked()` is safe because the transformation follows
+        // - `unwrap()` is safe because the transformation follows
         //   **a known valid isomorphism** between the twist and E.
-
         let point = Self::new([
             x.conjugate() * GAMMA_12,
             y.conjugate() * GAMMA_13,
             z.conjugate(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
@@ -41,12 +41,13 @@ impl IsEllipticCurve for BLS12377Curve {
         // SAFETY:
         // - These values are mathematically verified and known to be valid points on BLS12-377.
         // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
-
-        Self::PointRepresentation::new([
+        unsafe {
+            Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::new_base("8848defe740a67c8fc6225bf87ff5485951e2caa9d41bb188282c8bd37cb5cd5481512ffcd394eeab9b16eb21be9ef"),
             FieldElement::<Self::BaseField>::new_base("1914a69c5102eff1f674f5d30afeec4bd7fb348ca3e52d96d182ad44fb82305c2fe3d3634a9591afd82de55559c8ea6"),
             FieldElement::one()
-        ]).unwrap()
+        ]).unwrap_unchecked()
+        }
     }
 }
 
@@ -123,13 +124,14 @@ impl ShortWeierstrassProjectivePoint<BLS12377TwistCurve> {
         //   resulting point satisfies the curve equation.
         // - `unwrap_unchecked()` is safe because the transformation follows
         //   **a known valid isomorphism** between the twist and E.
-
-        Self::new([
-            x.conjugate() * GAMMA_12,
-            y.conjugate() * GAMMA_13,
-            z.conjugate(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::new([
+                x.conjugate() * GAMMA_12,
+                y.conjugate() * GAMMA_13,
+                z.conjugate(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 
     /// 𝜓(P) = 𝑢P, where 𝑢 = SEED of the curve

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
@@ -32,7 +32,8 @@ impl IsEllipticCurve for BLS12377Curve {
     ///
     /// Generator values are taken from [Neuromancer's BLS12-377 page](https://neuromancer.sk/std/bls/BLS12-377).
     ///
-    /// ## Safety
+    /// # Safety
+    ///
     /// - The generator point `(x, y, 1)` is predefined and is **known to be a valid point** on the curve.
     /// - `unwrap_unchecked()` is used because this point is **mathematically verified**.
     /// - Do **not** modify this function unless a new generator has been **mathematically verified**.
@@ -110,7 +111,8 @@ impl ShortWeierstrassProjectivePoint<BLS12377TwistCurve> {
     /// https://eprint.iacr.org/2022/352.pdf 4.2 (7)
     /// ψ(P) = (ψ_x * conjugate(x), ψ_y * conjugate(y), conjugate(z))
     ///
-    ///  ## Safety
+    /// # Safety
+    ///
     /// - This function assumes `self` is a valid point on the BLS12-377 **twist** curve.
     /// - The conjugation operation preserves validity.
     /// - `unwrap_unchecked()` is used because `psi()` is defined to **always return a valid point**.

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
@@ -30,11 +30,13 @@ impl IsEllipticCurve for BLS12377Curve {
 
     // generator values are taken from https://neuromancer.sk/std/bls/BLS12-377
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
+        unsafe {
+            Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::new_base("8848defe740a67c8fc6225bf87ff5485951e2caa9d41bb188282c8bd37cb5cd5481512ffcd394eeab9b16eb21be9ef"),
             FieldElement::<Self::BaseField>::new_base("1914a69c5102eff1f674f5d30afeec4bd7fb348ca3e52d96d182ad44fb82305c2fe3d3634a9591afd82de55559c8ea6"),
             FieldElement::one()
-        ])
+        ]).unwrap_unchecked()
+        }
     }
 }
 
@@ -99,11 +101,14 @@ impl ShortWeierstrassProjectivePoint<BLS12377TwistCurve> {
     /// ψ(P) = (ψ_x * conjugate(x), ψ_y * conjugate(y), conjugate(z))
     fn psi(&self) -> Self {
         let [x, y, z] = self.coordinates();
-        Self::new([
-            x.conjugate() * GAMMA_12,
-            y.conjugate() * GAMMA_13,
-            z.conjugate(),
-        ])
+        unsafe {
+            Self::new([
+                x.conjugate() * GAMMA_12,
+                y.conjugate() * GAMMA_13,
+                z.conjugate(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 
     /// 𝜓(P) = 𝑢P, where 𝑢 = SEED of the curve
@@ -186,7 +191,7 @@ mod tests {
         let x = FpE::new_base("134e4cc122cb62a06767fb98e86f2d5f77e2a12fefe23bb0c4c31d1bd5348b88d6f5e5dee2b54db4a2146cc9f249eea") * FpE::from(2);
         let y = FpE::new_base("17949c29effee7a9f13f69b1c28eccd78c1ed12b47068836473481ff818856594fd9c1935e3d9e621901a2d500257a2") * FpE::from(2);
         let z = FpE::from(2);
-        let point_2 = ShortWeierstrassProjectivePoint::<BLS12377Curve>::new([x, y, z]);
+        let point_2 = ShortWeierstrassProjectivePoint::<BLS12377Curve>::new([x, y, z]).unwrap();
 
         let first_algorithm_result = point_2.operate_with(&point_1).to_affine();
         let second_algorithm_result = point_2.operate_with_affine(&point_1).to_affine();

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs
@@ -41,13 +41,12 @@ impl IsEllipticCurve for BLS12377Curve {
         // SAFETY:
         // - These values are mathematically verified and known to be valid points on BLS12-377.
         // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
+
+        Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::new_base("8848defe740a67c8fc6225bf87ff5485951e2caa9d41bb188282c8bd37cb5cd5481512ffcd394eeab9b16eb21be9ef"),
             FieldElement::<Self::BaseField>::new_base("1914a69c5102eff1f674f5d30afeec4bd7fb348ca3e52d96d182ad44fb82305c2fe3d3634a9591afd82de55559c8ea6"),
             FieldElement::one()
-        ]).unwrap_unchecked()
-        }
+        ]).unwrap()
     }
 }
 
@@ -124,14 +123,13 @@ impl ShortWeierstrassProjectivePoint<BLS12377TwistCurve> {
         //   resulting point satisfies the curve equation.
         // - `unwrap_unchecked()` is safe because the transformation follows
         //   **a known valid isomorphism** between the twist and E.
-        unsafe {
-            Self::new([
-                x.conjugate() * GAMMA_12,
-                y.conjugate() * GAMMA_13,
-                z.conjugate(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::new([
+            x.conjugate() * GAMMA_12,
+            y.conjugate() * GAMMA_13,
+            z.conjugate(),
+        ])
+        .unwrap()
     }
 
     /// 𝜓(P) = 𝑢P, where 𝑢 = SEED of the curve

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
@@ -164,6 +164,8 @@ fn line(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
             BLS12377TwistCurve::defining_equation_projective(&x_r, &y_r, &z_r),
             Fp2E::zero()
         );
+        // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
+        // satisfy the curve equation. The previous assertion checks that this is indeed the case.
         let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
 
         let l = Fp12E::new([
@@ -196,6 +198,8 @@ fn line(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
             BLS12377TwistCurve::defining_equation_projective(&x_r, &y_r, &z_r),
             Fp2E::zero()
         );
+        // SAFETY: The values `x_r, y_r, z_r` are computed correctly to be on the curve.
+        // The assertion above verifies that the resulting point is valid.
         let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
 
         let l = Fp12E::new([

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
@@ -411,19 +411,21 @@ mod tests {
         assert_eq!(result, FieldElement::one());
     }
 
-    // #[test]
-    // fn ate_pairing_errors_when_one_element_is_not_in_subgroup() {
-    //     // FIX: (1, 1, 1) is not in the curve.
-    //     let p = ShortWeierstrassProjectivePoint::new([
-    //         FieldElement::one(),
-    //         FieldElement::one(),
-    //         FieldElement::one(),
-    //     ])
-    //     .unwrap();
-    //     let q = ShortWeierstrassProjectivePoint::neutral_element();
-    //     let result = BLS12377AtePairing::compute_batch(&[(&p.to_affine(), &q)]);
-    //     assert!(result.is_err())
-    // }
+    #[test]
+    fn ate_pairing_errors_when_one_element_is_not_in_subgroup() {
+        // p = (0, 1, 1) is in the curve but not in the subgroup.
+        // Recall that the BLS 12-377 curve equation is y^2 = x^3 + 1.
+        let p = ShortWeierstrassProjectivePoint::new([
+            FieldElement::zero(),
+            FieldElement::one(),
+            FieldElement::one(),
+        ])
+        .unwrap();
+        let q = ShortWeierstrassProjectivePoint::neutral_element();
+        let result = BLS12377AtePairing::compute_batch(&[(&p.to_affine(), &q)]);
+        assert!(result.is_err())
+    }
+
     #[test]
     fn apply_12_times_frobenius_is_identity() {
         let f = Fp12E::from_coefficients(&[

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
@@ -166,7 +166,7 @@ fn line(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         );
         // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
-        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
+        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
 
         let l = Fp12E::new([
             Fp6E::new([y_p * (-h), Fp2E::zero(), Fp2E::zero()]),
@@ -200,7 +200,7 @@ fn line(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         );
         // SAFETY: The values `x_r, y_r, z_r` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
+        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
 
         let l = Fp12E::new([
             Fp6E::new([y_p * lambda, Fp2E::zero(), Fp2E::zero()]),

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
@@ -160,7 +160,11 @@ fn line(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         let y_r = g.square() - (e_square.double() + e_square);
         let z_r = b * &h;
 
-        let r = G2Point::new([x_r, y_r, z_r]);
+        debug_assert_eq!(
+            BLS12377TwistCurve::defining_equation_projective(&x_r, &y_r, &z_r),
+            Fp2E::zero()
+        );
+        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
 
         let l = Fp12E::new([
             Fp6E::new([y_p * (-h), Fp2E::zero(), Fp2E::zero()]),
@@ -188,7 +192,11 @@ fn line(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         let y_r = &theta * (g - h) - i;
         let z_r = z_t * e;
 
-        let r = G2Point::new([x_r, y_r, z_r]);
+        debug_assert_eq!(
+            BLS12377TwistCurve::defining_equation_projective(&x_r, &y_r, &z_r),
+            Fp2E::zero()
+        );
+        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
 
         let l = Fp12E::new([
             Fp6E::new([y_p * lambda, Fp2E::zero(), Fp2E::zero()]),
@@ -403,17 +411,19 @@ mod tests {
         assert_eq!(result, FieldElement::one());
     }
 
-    #[test]
-    fn ate_pairing_errors_when_one_element_is_not_in_subgroup() {
-        let p = ShortWeierstrassProjectivePoint::new([
-            FieldElement::one(),
-            FieldElement::one(),
-            FieldElement::one(),
-        ]);
-        let q = ShortWeierstrassProjectivePoint::neutral_element();
-        let result = BLS12377AtePairing::compute_batch(&[(&p.to_affine(), &q)]);
-        assert!(result.is_err())
-    }
+    // #[test]
+    // fn ate_pairing_errors_when_one_element_is_not_in_subgroup() {
+    //     // FIX: (1, 1, 1) is not in the curve.
+    //     let p = ShortWeierstrassProjectivePoint::new([
+    //         FieldElement::one(),
+    //         FieldElement::one(),
+    //         FieldElement::one(),
+    //     ])
+    //     .unwrap();
+    //     let q = ShortWeierstrassProjectivePoint::neutral_element();
+    //     let result = BLS12377AtePairing::compute_batch(&[(&p.to_affine(), &q)]);
+    //     assert!(result.is_err())
+    // }
     #[test]
     fn apply_12_times_frobenius_is_identity() {
         let f = Fp12E::from_coefficients(&[

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
@@ -164,10 +164,9 @@ fn line(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
             BLS12377TwistCurve::defining_equation_projective(&x_r, &y_r, &z_r),
             Fp2E::zero()
         );
-        // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
+        // SAFETY: `unwrap()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
         let r = G2Point::new([x_r, y_r, z_r]);
-        debug_assert!(r.is_ok());
 
         let l = Fp12E::new([
             Fp6E::new([y_p * (-h), Fp2E::zero(), Fp2E::zero()]),
@@ -202,7 +201,6 @@ fn line(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         // SAFETY: The values `x_r, y_r, z_r` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
         let r = G2Point::new([x_r, y_r, z_r]);
-        debug_assert!(r.is_ok());
 
         let l = Fp12E::new([
             Fp6E::new([y_p * lambda, Fp2E::zero(), Fp2E::zero()]),

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
@@ -166,7 +166,7 @@ fn line(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         );
         // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
-        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
+        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
 
         let l = Fp12E::new([
             Fp6E::new([y_p * (-h), Fp2E::zero(), Fp2E::zero()]),
@@ -200,7 +200,7 @@ fn line(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         );
         // SAFETY: The values `x_r, y_r, z_r` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
+        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
 
         let l = Fp12E::new([
             Fp6E::new([y_p * lambda, Fp2E::zero(), Fp2E::zero()]),

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
@@ -166,13 +166,14 @@ fn line(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         );
         // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
-        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
+        let r = G2Point::new([x_r, y_r, z_r]);
+        debug_assert!(r.is_ok());
 
         let l = Fp12E::new([
             Fp6E::new([y_p * (-h), Fp2E::zero(), Fp2E::zero()]),
             Fp6E::new([x_p * (j.double() + &j), i, Fp2E::zero()]),
         ]);
-        (r, l)
+        (r.unwrap(), l)
     } else {
         let [x_q, y_q, _] = q.coordinates();
         let [x_t, y_t, z_t] = t.coordinates();
@@ -200,13 +201,14 @@ fn line(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         );
         // SAFETY: The values `x_r, y_r, z_r` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
+        let r = G2Point::new([x_r, y_r, z_r]);
+        debug_assert!(r.is_ok());
 
         let l = Fp12E::new([
             Fp6E::new([y_p * lambda, Fp2E::zero(), Fp2E::zero()]),
             Fp6E::new([x_p * (-theta), j, Fp2E::zero()]),
         ]);
-        (r, l)
+        (r.unwrap(), l)
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/twist.rs
@@ -23,19 +23,20 @@ impl IsEllipticCurve for BLS12377TwistCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
-            FieldElement::new([
-                FieldElement::new(GENERATOR_X_0),
-                FieldElement::new(GENERATOR_X_1),
-            ]),
-            FieldElement::new([
-                FieldElement::new(GENERATOR_Y_0),
-                FieldElement::new(GENERATOR_Y_1),
-            ]),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::new([
+                    FieldElement::new(GENERATOR_X_0),
+                    FieldElement::new(GENERATOR_X_1),
+                ]),
+                FieldElement::new([
+                    FieldElement::new(GENERATOR_Y_0),
+                    FieldElement::new(GENERATOR_Y_1),
+                ]),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/twist.rs
@@ -20,6 +20,9 @@ impl IsEllipticCurve for BLS12377TwistCurve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point is mathematically verified to be a valid point on the curve.
+        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
         unsafe {
             Self::PointRepresentation::new([
                 FieldElement::new([

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/twist.rs
@@ -22,8 +22,7 @@ impl IsEllipticCurve for BLS12377TwistCurve {
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
-        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
+        // - `unwrap()` is safe because the provided coordinates satisfy the curve equation.s
         let point = Self::PointRepresentation::new([
             FieldElement::new([
                 FieldElement::new(GENERATOR_X_0),
@@ -35,7 +34,6 @@ impl IsEllipticCurve for BLS12377TwistCurve {
             ]),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/twist.rs
@@ -24,7 +24,7 @@ impl IsEllipticCurve for BLS12377TwistCurve {
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
 
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::new([
                 FieldElement::new(GENERATOR_X_0),
                 FieldElement::new(GENERATOR_X_1),
@@ -34,8 +34,9 @@ impl IsEllipticCurve for BLS12377TwistCurve {
                 FieldElement::new(GENERATOR_Y_1),
             ]),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/twist.rs
@@ -23,20 +23,19 @@ impl IsEllipticCurve for BLS12377TwistCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
-                FieldElement::new([
-                    FieldElement::new(GENERATOR_X_0),
-                    FieldElement::new(GENERATOR_X_1),
-                ]),
-                FieldElement::new([
-                    FieldElement::new(GENERATOR_Y_0),
-                    FieldElement::new(GENERATOR_Y_1),
-                ]),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            FieldElement::new([
+                FieldElement::new(GENERATOR_X_0),
+                FieldElement::new(GENERATOR_X_1),
+            ]),
+            FieldElement::new([
+                FieldElement::new(GENERATOR_Y_0),
+                FieldElement::new(GENERATOR_Y_1),
+            ]),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/twist.rs
@@ -20,17 +20,20 @@ impl IsEllipticCurve for BLS12377TwistCurve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::new([
-                FieldElement::new(GENERATOR_X_0),
-                FieldElement::new(GENERATOR_X_1),
-            ]),
-            FieldElement::new([
-                FieldElement::new(GENERATOR_Y_0),
-                FieldElement::new(GENERATOR_Y_1),
-            ]),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::new([
+                    FieldElement::new(GENERATOR_X_0),
+                    FieldElement::new(GENERATOR_X_1),
+                ]),
+                FieldElement::new([
+                    FieldElement::new(GENERATOR_Y_0),
+                    FieldElement::new(GENERATOR_Y_1),
+                ]),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
@@ -96,11 +96,14 @@ impl ShortWeierstrassProjectivePoint<BLS12381TwistCurve> {
     /// https://eprint.iacr.org/2022/352.pdf 4.2 (7)
     fn psi(&self) -> Self {
         let [x, y, z] = self.coordinates();
-        Self::new([
-            x.conjugate() * ENDO_U,
-            y.conjugate() * ENDO_V,
-            z.conjugate(),
-        ])
+        unsafe {
+            Self::new([
+                x.conjugate() * ENDO_U,
+                y.conjugate() * ENDO_V,
+                z.conjugate(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 
     /// 𝜓(P) = 𝑢P, where 𝑢 = SEED of the curve
@@ -145,7 +148,10 @@ mod tests {
     ) -> ShortWeierstrassProjectivePoint<BLS12381TwistCurve> {
         let [x, y, z] = p.coordinates();
         // Since power of frobenius map is 2 we apply once as applying twice is inverse
-        ShortWeierstrassProjectivePoint::new([x * ENDO_U_2, y * ENDO_V_2, z.clone()])
+        unsafe {
+            ShortWeierstrassProjectivePoint::new([x * ENDO_U_2, y * ENDO_V_2, z.clone()])
+                .unwrap_unchecked()
+        }
     }
 
     #[allow(clippy::upper_case_acronyms)]

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
@@ -27,11 +27,13 @@ impl IsEllipticCurve for BLS12381Curve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
+        unsafe {
+            Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::new_base("17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"),
             FieldElement::<Self::BaseField>::new_base("8b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1"),
             FieldElement::one()
-        ])
+        ]).unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
@@ -36,12 +36,13 @@ impl IsEllipticCurve for BLS12381Curve {
         // SAFETY:
         // - These values are mathematically verified and known to be valid points on BLS12-381.
         // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
-
-        Self::PointRepresentation::new([
+        unsafe {
+            Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::new_base("17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"),
             FieldElement::<Self::BaseField>::new_base("8b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1"),
             FieldElement::one()
-        ]).unwrap()
+        ]).unwrap_unchecked()
+        }
     }
 }
 
@@ -110,19 +111,20 @@ impl ShortWeierstrassProjectivePoint<BLS12381TwistCurve> {
     /// - `unwrap_unchecked()` is used because `psi()` is defined to **always return a valid point**.
     fn psi(&self) -> Self {
         let [x, y, z] = self.coordinates();
-
-        // SAFETY:
-        // - `conjugate()` preserves the validity of the field element.
-        // - `ENDO_U` and `ENDO_V` are precomputed constants that ensure the
-        //   resulting point satisfies the curve equation.
-        // - `unwrap_unchecked()` is safe because the transformation follows
-        //   **a known valid isomorphism** between the twist and E.
-        Self::new([
-            x.conjugate() * ENDO_U,
-            y.conjugate() * ENDO_V,
-            z.conjugate(),
-        ])
-        .unwrap()
+        unsafe {
+            // SAFETY:
+            // - `conjugate()` preserves the validity of the field element.
+            // - `ENDO_U` and `ENDO_V` are precomputed constants that ensure the
+            //   resulting point satisfies the curve equation.
+            // - `unwrap_unchecked()` is safe because the transformation follows
+            //   **a known valid isomorphism** between the twist and E.
+            Self::new([
+                x.conjugate() * ENDO_U,
+                y.conjugate() * ENDO_V,
+                z.conjugate(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 
     /// 𝜓(P) = 𝑢P, where 𝑢 = SEED of the curve
@@ -173,11 +175,13 @@ mod tests {
     ) -> ShortWeierstrassProjectivePoint<BLS12381TwistCurve> {
         let [x, y, z] = p.coordinates();
         // Since power of frobenius map is 2 we apply once as applying twice is inverse
-
-        // SAFETY:
-        // - `ENDO_U_2` and `ENDO_V_2` are known valid constants.
-        // - `unwrap_unchecked()` is safe because the transformation preserves curve validity.
-        ShortWeierstrassProjectivePoint::new([x * ENDO_U_2, y * ENDO_V_2, z.clone()]).unwrap()
+        unsafe {
+            // SAFETY:
+            // - `ENDO_U_2` and `ENDO_V_2` are known valid constants.
+            // - `unwrap_unchecked()` is safe because the transformation preserves curve validity.
+            ShortWeierstrassProjectivePoint::new([x * ENDO_U_2, y * ENDO_V_2, z.clone()])
+                .unwrap_unchecked()
+        }
     }
 
     #[allow(clippy::upper_case_acronyms)]

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
@@ -28,7 +28,8 @@ impl IsEllipticCurve for BLS12381Curve {
 
     /// Returns the generator point of the BLS12-381 curve.
     ///
-    /// ## Safety
+    /// # Safety
+    ///
     /// - The generator point is mathematically verified to be a valid point on the curve.
     /// - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
     fn generator() -> Self::PointRepresentation {
@@ -103,7 +104,8 @@ impl ShortWeierstrassProjectivePoint<BLS12381TwistCurve> {
     /// and 𝜓 satisifies minmal equation 𝑋² + 𝑡𝑋 + 𝑞 = 𝑂
     /// https://eprint.iacr.org/2022/352.pdf 4.2 (7)
     ///
-    ///  ## Safety
+    /// # Safety
+    ///
     /// - This function assumes `self` is a valid point on the BLS12-381 **twist** curve.
     /// - The conjugation operation preserves validity.
     /// - `unwrap_unchecked()` is used because `psi()` is defined to **always return a valid point**.

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
@@ -37,11 +37,13 @@ impl IsEllipticCurve for BLS12381Curve {
         // - These values are mathematically verified and known to be valid points on BLS12-381.
         // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
 
-        Self::PointRepresentation::new([
+        let point= Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::new_base("17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"),
             FieldElement::<Self::BaseField>::new_base("8b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1"),
             FieldElement::one()
-        ]).unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 
@@ -110,19 +112,19 @@ impl ShortWeierstrassProjectivePoint<BLS12381TwistCurve> {
     /// - `unwrap_unchecked()` is used because `psi()` is defined to **always return a valid point**.
     fn psi(&self) -> Self {
         let [x, y, z] = self.coordinates();
-
         // SAFETY:
         // - `conjugate()` preserves the validity of the field element.
         // - `ENDO_U` and `ENDO_V` are precomputed constants that ensure the
         //   resulting point satisfies the curve equation.
         // - `unwrap_unchecked()` is safe because the transformation follows
         //   **a known valid isomorphism** between the twist and E.
-        Self::new([
+        let point = Self::new([
             x.conjugate() * ENDO_U,
             y.conjugate() * ENDO_V,
             z.conjugate(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 
     /// 𝜓(P) = 𝑢P, where 𝑢 = SEED of the curve

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
@@ -36,13 +36,12 @@ impl IsEllipticCurve for BLS12381Curve {
         // SAFETY:
         // - These values are mathematically verified and known to be valid points on BLS12-381.
         // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
+
+        Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::new_base("17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"),
             FieldElement::<Self::BaseField>::new_base("8b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1"),
             FieldElement::one()
-        ]).unwrap_unchecked()
-        }
+        ]).unwrap()
     }
 }
 
@@ -111,20 +110,19 @@ impl ShortWeierstrassProjectivePoint<BLS12381TwistCurve> {
     /// - `unwrap_unchecked()` is used because `psi()` is defined to **always return a valid point**.
     fn psi(&self) -> Self {
         let [x, y, z] = self.coordinates();
-        unsafe {
-            // SAFETY:
-            // - `conjugate()` preserves the validity of the field element.
-            // - `ENDO_U` and `ENDO_V` are precomputed constants that ensure the
-            //   resulting point satisfies the curve equation.
-            // - `unwrap_unchecked()` is safe because the transformation follows
-            //   **a known valid isomorphism** between the twist and E.
-            Self::new([
-                x.conjugate() * ENDO_U,
-                y.conjugate() * ENDO_V,
-                z.conjugate(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        // SAFETY:
+        // - `conjugate()` preserves the validity of the field element.
+        // - `ENDO_U` and `ENDO_V` are precomputed constants that ensure the
+        //   resulting point satisfies the curve equation.
+        // - `unwrap_unchecked()` is safe because the transformation follows
+        //   **a known valid isomorphism** between the twist and E.
+        Self::new([
+            x.conjugate() * ENDO_U,
+            y.conjugate() * ENDO_V,
+            z.conjugate(),
+        ])
+        .unwrap()
     }
 
     /// 𝜓(P) = 𝑢P, where 𝑢 = SEED of the curve
@@ -175,13 +173,11 @@ mod tests {
     ) -> ShortWeierstrassProjectivePoint<BLS12381TwistCurve> {
         let [x, y, z] = p.coordinates();
         // Since power of frobenius map is 2 we apply once as applying twice is inverse
-        unsafe {
-            // SAFETY:
-            // - `ENDO_U_2` and `ENDO_V_2` are known valid constants.
-            // - `unwrap_unchecked()` is safe because the transformation preserves curve validity.
-            ShortWeierstrassProjectivePoint::new([x * ENDO_U_2, y * ENDO_V_2, z.clone()])
-                .unwrap_unchecked()
-        }
+
+        // SAFETY:
+        // - `ENDO_U_2` and `ENDO_V_2` are known valid constants.
+        // - `unwrap_unchecked()` is safe because the transformation preserves curve validity.
+        ShortWeierstrassProjectivePoint::new([x * ENDO_U_2, y * ENDO_V_2, z.clone()]).unwrap()
     }
 
     #[allow(clippy::upper_case_acronyms)]

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/curve.rs
@@ -31,18 +31,16 @@ impl IsEllipticCurve for BLS12381Curve {
     /// # Safety
     ///
     /// - The generator point is mathematically verified to be a valid point on the curve.
-    /// - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+    /// - `unwrap()` is safe because the provided coordinates satisfy the curve equation.
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - These values are mathematically verified and known to be valid points on BLS12-381.
-        // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
-
+        // - `unwrap()` is safe because we **ensure** the input values satisfy the curve equation.
         let point= Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::new_base("17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"),
             FieldElement::<Self::BaseField>::new_base("8b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1"),
             FieldElement::one()
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }
@@ -109,21 +107,20 @@ impl ShortWeierstrassProjectivePoint<BLS12381TwistCurve> {
     ///
     /// - This function assumes `self` is a valid point on the BLS12-381 **twist** curve.
     /// - The conjugation operation preserves validity.
-    /// - `unwrap_unchecked()` is used because `psi()` is defined to **always return a valid point**.
+    /// - `unwrap()` is used because `psi()` is defined to **always return a valid point**.
     fn psi(&self) -> Self {
         let [x, y, z] = self.coordinates();
         // SAFETY:
         // - `conjugate()` preserves the validity of the field element.
         // - `ENDO_U` and `ENDO_V` are precomputed constants that ensure the
         //   resulting point satisfies the curve equation.
-        // - `unwrap_unchecked()` is safe because the transformation follows
+        // - `unwrap()` is safe because the transformation follows
         //   **a known valid isomorphism** between the twist and E.
         let point = Self::new([
             x.conjugate() * ENDO_U,
             y.conjugate() * ENDO_V,
             z.conjugate(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 
@@ -169,7 +166,7 @@ mod tests {
     ///
     /// - This function assumes `p` is a valid point on the BLS12-381 twist curve.
     /// - The transformation involves multiplying the x and y coordinates by known constants.
-    /// - `unwrap_unchecked()` is used because the resulting point remains valid under the curve equations.
+    /// - `unwrap()` is used because the resulting point remains valid under the curve equations.
     fn psi_square(
         p: &ShortWeierstrassProjectivePoint<BLS12381TwistCurve>,
     ) -> ShortWeierstrassProjectivePoint<BLS12381TwistCurve> {
@@ -178,7 +175,7 @@ mod tests {
 
         // SAFETY:
         // - `ENDO_U_2` and `ENDO_V_2` are known valid constants.
-        // - `unwrap_unchecked()` is safe because the transformation preserves curve validity.
+        // - `unwrap()` is safe because the transformation preserves curve validity.
         ShortWeierstrassProjectivePoint::new([x * ENDO_U_2, y * ENDO_V_2, z.clone()]).unwrap()
     }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -447,21 +447,21 @@ mod tests {
         assert_eq!(result, FieldElement::one());
     }
 
-    // #[test]
-    // fn ate_pairing_errors_when_one_element_is_not_in_subgroup() {
-    //     // FIX: (1, 1, 1) is not in the curve
-    //     // y^2 * z = x^3 + a * x * z^2 + b * z^3
-    //     // 1 * 1 = 1 + a * 1 + b * 1
-    //     let p = ShortWeierstrassProjectivePoint::new([
-    //         FieldElement::one(),
-    //         FieldElement::one(),
-    //         FieldElement::one(),
-    //     ])
-    //     .unwrap();
-    //     let q = ShortWeierstrassProjectivePoint::neutral_element();
-    //     let result = BLS12381AtePairing::compute_batch(&[(&p.to_affine(), &q)]);
-    //     assert!(result.is_err())
-    // }
+    #[test]
+    fn ate_pairing_errors_when_one_element_is_not_in_subgroup() {
+        // p = (0, 2, 1) is in the curve but not in the subgroup.
+        // Recall that the BLS 12-381 curve equation is y^2 = x^3 + 4.
+        let p = ShortWeierstrassProjectivePoint::new([
+            FieldElement::zero(),
+            FieldElement::from(2),
+            FieldElement::one(),
+        ])
+        .unwrap();
+        let q = ShortWeierstrassProjectivePoint::neutral_element();
+        let result = BLS12381AtePairing::compute_batch(&[(&p.to_affine(), &q)]);
+        assert!(result.is_err())
+    }
+
     #[test]
     fn apply_12_times_frobenius_is_identity() {
         let f = Fp12E::from_coefficients(&[

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -447,17 +447,21 @@ mod tests {
         assert_eq!(result, FieldElement::one());
     }
 
-    #[test]
-    fn ate_pairing_errors_when_one_element_is_not_in_subgroup() {
-        let p = ShortWeierstrassProjectivePoint::new([
-            FieldElement::one(),
-            FieldElement::one(),
-            FieldElement::one(),
-        ]);
-        let q = ShortWeierstrassProjectivePoint::neutral_element();
-        let result = BLS12381AtePairing::compute_batch(&[(&p.to_affine(), &q)]);
-        assert!(result.is_err())
-    }
+    // #[test]
+    // fn ate_pairing_errors_when_one_element_is_not_in_subgroup() {
+    //     // FIX: (1, 1, 1) is not in the curve
+    //     // y^2 * z = x^3 + a * x * z^2 + b * z^3
+    //     // 1 * 1 = 1 + a * 1 + b * 1
+    //     let p = ShortWeierstrassProjectivePoint::new([
+    //         FieldElement::one(),
+    //         FieldElement::one(),
+    //         FieldElement::one(),
+    //     ])
+    //     .unwrap();
+    //     let q = ShortWeierstrassProjectivePoint::neutral_element();
+    //     let result = BLS12381AtePairing::compute_batch(&[(&p.to_affine(), &q)]);
+    //     assert!(result.is_err())
+    // }
     #[test]
     fn apply_12_times_frobenius_is_identity() {
         let f = Fp12E::from_coefficients(&[

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -23,6 +23,9 @@ impl IsEllipticCurve for BLS12381TwistCurve {
 
     fn generator() -> Self::PointRepresentation {
         unsafe {
+            // SAFETY:
+            // - The generator point is mathematically verified to be a valid point on the curve.
+            // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
             Self::PointRepresentation::new([
                 FieldElement::new([
                     FieldElement::new(GENERATOR_X_0),

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -24,7 +24,7 @@ impl IsEllipticCurve for BLS12381TwistCurve {
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
-        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+        // - `unwrap()` is safe because the provided coordinates satisfy the curve equation.
         let point = Self::PointRepresentation::new([
             FieldElement::new([
                 FieldElement::new(GENERATOR_X_0),
@@ -36,7 +36,6 @@ impl IsEllipticCurve for BLS12381TwistCurve {
             ]),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -25,7 +25,7 @@ impl IsEllipticCurve for BLS12381TwistCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::new([
                 FieldElement::new(GENERATOR_X_0),
                 FieldElement::new(GENERATOR_X_1),
@@ -35,8 +35,9 @@ impl IsEllipticCurve for BLS12381TwistCurve {
                 FieldElement::new(GENERATOR_Y_1),
             ]),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -22,23 +22,21 @@ impl IsEllipticCurve for BLS12381TwistCurve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        unsafe {
-            // SAFETY:
-            // - The generator point is mathematically verified to be a valid point on the curve.
-            // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-            Self::PointRepresentation::new([
-                FieldElement::new([
-                    FieldElement::new(GENERATOR_X_0),
-                    FieldElement::new(GENERATOR_X_1),
-                ]),
-                FieldElement::new([
-                    FieldElement::new(GENERATOR_Y_0),
-                    FieldElement::new(GENERATOR_Y_1),
-                ]),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+        // SAFETY:
+        // - The generator point is mathematically verified to be a valid point on the curve.
+        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+        Self::PointRepresentation::new([
+            FieldElement::new([
+                FieldElement::new(GENERATOR_X_0),
+                FieldElement::new(GENERATOR_X_1),
+            ]),
+            FieldElement::new([
+                FieldElement::new(GENERATOR_Y_0),
+                FieldElement::new(GENERATOR_Y_1),
+            ]),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -22,17 +22,20 @@ impl IsEllipticCurve for BLS12381TwistCurve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::new([
-                FieldElement::new(GENERATOR_X_0),
-                FieldElement::new(GENERATOR_X_1),
-            ]),
-            FieldElement::new([
-                FieldElement::new(GENERATOR_Y_0),
-                FieldElement::new(GENERATOR_Y_1),
-            ]),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::new([
+                    FieldElement::new(GENERATOR_X_0),
+                    FieldElement::new(GENERATOR_X_1),
+                ]),
+                FieldElement::new([
+                    FieldElement::new(GENERATOR_Y_0),
+                    FieldElement::new(GENERATOR_Y_1),
+                ]),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/twist.rs
@@ -22,21 +22,23 @@ impl IsEllipticCurve for BLS12381TwistCurve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        // SAFETY:
-        // - The generator point is mathematically verified to be a valid point on the curve.
-        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-        Self::PointRepresentation::new([
-            FieldElement::new([
-                FieldElement::new(GENERATOR_X_0),
-                FieldElement::new(GENERATOR_X_1),
-            ]),
-            FieldElement::new([
-                FieldElement::new(GENERATOR_Y_0),
-                FieldElement::new(GENERATOR_Y_1),
-            ]),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            // SAFETY:
+            // - The generator point is mathematically verified to be a valid point on the curve.
+            // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+            Self::PointRepresentation::new([
+                FieldElement::new([
+                    FieldElement::new(GENERATOR_X_0),
+                    FieldElement::new(GENERATOR_X_1),
+                ]),
+                FieldElement::new([
+                    FieldElement::new(GENERATOR_Y_0),
+                    FieldElement::new(GENERATOR_Y_1),
+                ]),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
@@ -21,11 +21,14 @@ impl IsEllipticCurve for BN254Curve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::one(),
-            FieldElement::<Self::BaseField>::from(2),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::one(),
+                FieldElement::<Self::BaseField>::from(2),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 
@@ -52,11 +55,14 @@ impl ShortWeierstrassProjectivePoint<BN254TwistCurve> {
     /// See https://hackmd.io/@Wimet/ry7z1Xj-2#Subgroup-Checks.
     pub fn phi(&self) -> Self {
         let [x, y, z] = self.coordinates();
-        Self::new([
-            x.conjugate() * GAMMA_12,
-            y.conjugate() * GAMMA_13,
-            z.conjugate(),
-        ])
+        unsafe {
+            Self::new([
+                x.conjugate() * GAMMA_12,
+                y.conjugate() * GAMMA_13,
+                z.conjugate(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 
     // Checks if a G2 point is in the subgroup of the twisted curve.
@@ -279,7 +285,8 @@ mod tests {
                 )),
             ]),
             Fp2E::one(),
-        ]);
+        ])
+        .unwrap();
         assert!(!q.is_in_subgroup())
     }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
@@ -62,6 +62,7 @@ impl ShortWeierstrassProjectivePoint<BN254TwistCurve> {
     /// We also use phi at the last lines of the Miller Loop of the pairing.
     /// phi(q) = (x^p, y^p, z^p), where (x, y, z) are the projective coordinates of q.
     /// See https://hackmd.io/@Wimet/ry7z1Xj-2#Subgroup-Checks.
+    ///
     /// # Safety
     ///
     /// - The function assumes `self` is a valid point on the BN254 twist curve.

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
@@ -27,15 +27,17 @@ impl IsEllipticCurve for BN254Curve {
     /// - The generator point is mathematically verified to be a valid point on the curve.
     /// - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
     fn generator() -> Self::PointRepresentation {
-        // SAFETY:
-        // - The generator coordinates `(1, 2, 1)` are **predefined** and belong to the BN254 curve.
-        // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::one(),
-            FieldElement::<Self::BaseField>::from(2),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            // SAFETY:
+            // - The generator coordinates `(1, 2, 1)` are **predefined** and belong to the BN254 curve.
+            // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::one(),
+                FieldElement::<Self::BaseField>::from(2),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 
@@ -67,17 +69,18 @@ impl ShortWeierstrassProjectivePoint<BN254TwistCurve> {
     /// - The transformation follows a known isomorphism and preserves validity.
     pub fn phi(&self) -> Self {
         let [x, y, z] = self.coordinates();
-
-        // SAFETY:
-        // - `conjugate()` preserves the validity of the field element.
-        // - `unwrap_unchecked()` is safe because the transformation follows
-        //   **a known valid isomorphism** between the twist and E.
-        Self::new([
-            x.conjugate() * GAMMA_12,
-            y.conjugate() * GAMMA_13,
-            z.conjugate(),
-        ])
-        .unwrap()
+        unsafe {
+            // SAFETY:
+            // - `conjugate()` preserves the validity of the field element.
+            // - `unwrap_unchecked()` is safe because the transformation follows
+            //   **a known valid isomorphism** between the twist and E.
+            Self::new([
+                x.conjugate() * GAMMA_12,
+                y.conjugate() * GAMMA_13,
+                z.conjugate(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 
     // Checks if a G2 point is in the subgroup of the twisted curve.

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
@@ -20,8 +20,17 @@ impl IsEllipticCurve for BN254Curve {
     type BaseField = BN254PrimeField;
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
+    /// Returns the generator point of the BN254 curve.
+    ///
+    /// # Safety
+    ///
+    /// - The generator point is mathematically verified to be a valid point on the curve.
+    /// - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
     fn generator() -> Self::PointRepresentation {
         unsafe {
+            // SAFETY:
+            // - The generator coordinates `(1, 2, 1)` are **predefined** and belong to the BN254 curve.
+            // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
             Self::PointRepresentation::new([
                 FieldElement::<Self::BaseField>::one(),
                 FieldElement::<Self::BaseField>::from(2),
@@ -53,9 +62,17 @@ impl ShortWeierstrassProjectivePoint<BN254TwistCurve> {
     /// We also use phi at the last lines of the Miller Loop of the pairing.
     /// phi(q) = (x^p, y^p, z^p), where (x, y, z) are the projective coordinates of q.
     /// See https://hackmd.io/@Wimet/ry7z1Xj-2#Subgroup-Checks.
+    /// # Safety
+    ///
+    /// - The function assumes `self` is a valid point on the BN254 twist curve.
+    /// - The transformation follows a known isomorphism and preserves validity.
     pub fn phi(&self) -> Self {
         let [x, y, z] = self.coordinates();
         unsafe {
+            // SAFETY:
+            // - `conjugate()` preserves the validity of the field element.
+            // - `unwrap_unchecked()` is safe because the transformation follows
+            //   **a known valid isomorphism** between the twist and E.
             Self::new([
                 x.conjugate() * GAMMA_12,
                 y.conjugate() * GAMMA_13,

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
@@ -25,17 +25,16 @@ impl IsEllipticCurve for BN254Curve {
     /// # Safety
     ///
     /// - The generator point is mathematically verified to be a valid point on the curve.
-    /// - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+    /// - `unwrap()` is safe because the provided coordinates satisfy the curve equation.
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator coordinates `(1, 2, 1)` are **predefined** and belong to the BN254 curve.
-        // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
+        // - `unwrap()` is safe because we **ensure** the input values satisfy the curve equation.
         let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::one(),
             FieldElement::<Self::BaseField>::from(2),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }
@@ -70,14 +69,13 @@ impl ShortWeierstrassProjectivePoint<BN254TwistCurve> {
         let [x, y, z] = self.coordinates();
         // SAFETY:
         // - `conjugate()` preserves the validity of the field element.
-        // - `unwrap_unchecked()` is safe because the transformation follows
+        // - `unwrap()` is safe because the transformation follows
         //   **a known valid isomorphism** between the twist and E.
         let point = Self::new([
             x.conjugate() * GAMMA_12,
             y.conjugate() * GAMMA_13,
             z.conjugate(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
@@ -30,12 +30,13 @@ impl IsEllipticCurve for BN254Curve {
         // SAFETY:
         // - The generator coordinates `(1, 2, 1)` are **predefined** and belong to the BN254 curve.
         // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::one(),
             FieldElement::<Self::BaseField>::from(2),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 
@@ -67,17 +68,17 @@ impl ShortWeierstrassProjectivePoint<BN254TwistCurve> {
     /// - The transformation follows a known isomorphism and preserves validity.
     pub fn phi(&self) -> Self {
         let [x, y, z] = self.coordinates();
-
         // SAFETY:
         // - `conjugate()` preserves the validity of the field element.
         // - `unwrap_unchecked()` is safe because the transformation follows
         //   **a known valid isomorphism** between the twist and E.
-        Self::new([
+        let point = Self::new([
             x.conjugate() * GAMMA_12,
             y.conjugate() * GAMMA_13,
             z.conjugate(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 
     // Checks if a G2 point is in the subgroup of the twisted curve.

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/curve.rs
@@ -27,17 +27,15 @@ impl IsEllipticCurve for BN254Curve {
     /// - The generator point is mathematically verified to be a valid point on the curve.
     /// - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
     fn generator() -> Self::PointRepresentation {
-        unsafe {
-            // SAFETY:
-            // - The generator coordinates `(1, 2, 1)` are **predefined** and belong to the BN254 curve.
-            // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
-            Self::PointRepresentation::new([
-                FieldElement::<Self::BaseField>::one(),
-                FieldElement::<Self::BaseField>::from(2),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+        // SAFETY:
+        // - The generator coordinates `(1, 2, 1)` are **predefined** and belong to the BN254 curve.
+        // - `unwrap_unchecked()` is safe because we **ensure** the input values satisfy the curve equation.
+        Self::PointRepresentation::new([
+            FieldElement::<Self::BaseField>::one(),
+            FieldElement::<Self::BaseField>::from(2),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 
@@ -69,18 +67,17 @@ impl ShortWeierstrassProjectivePoint<BN254TwistCurve> {
     /// - The transformation follows a known isomorphism and preserves validity.
     pub fn phi(&self) -> Self {
         let [x, y, z] = self.coordinates();
-        unsafe {
-            // SAFETY:
-            // - `conjugate()` preserves the validity of the field element.
-            // - `unwrap_unchecked()` is safe because the transformation follows
-            //   **a known valid isomorphism** between the twist and E.
-            Self::new([
-                x.conjugate() * GAMMA_12,
-                y.conjugate() * GAMMA_13,
-                z.conjugate(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        // SAFETY:
+        // - `conjugate()` preserves the validity of the field element.
+        // - `unwrap_unchecked()` is safe because the transformation follows
+        //   **a known valid isomorphism** between the twist and E.
+        Self::new([
+            x.conjugate() * GAMMA_12,
+            y.conjugate() * GAMMA_13,
+            z.conjugate(),
+        ])
+        .unwrap()
     }
 
     // Checks if a G2 point is in the subgroup of the twisted curve.

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
@@ -310,7 +310,7 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         );
         // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
-        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
+        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
 
         let l = Fp12E::new([
             Fp6E::new([y_p * (-h), Fp2E::zero(), Fp2E::zero()]),
@@ -345,7 +345,7 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
 
         // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
-        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
+        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
 
         let l = Fp12E::new([
             Fp6E::new([y_p * lambda, Fp2E::zero(), Fp2E::zero()]),

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
@@ -304,6 +304,12 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         let y_r = g.square() - (e_square.double() + e_square);
         let z_r = b * &h;
 
+        debug_assert_eq!(
+            BN254TwistCurve::defining_equation_projective(&x_r, &y_r, &z_r),
+            Fp2E::zero()
+        );
+        // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
+        // satisfy the curve equation. The previous assertion checks that this is indeed the case.
         let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
 
         let l = Fp12E::new([
@@ -332,6 +338,13 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         let y_r = &theta * (g - h) - i;
         let z_r = z_t * e;
 
+        debug_assert_eq!(
+            BN254TwistCurve::defining_equation_projective(&x_r, &y_r, &z_r),
+            Fp2E::zero()
+        );
+
+        // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
+        // satisfy the curve equation. The previous assertion checks that this is indeed the case.
         let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
 
         let l = Fp12E::new([

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
@@ -304,7 +304,7 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         let y_r = g.square() - (e_square.double() + e_square);
         let z_r = b * &h;
 
-        let r = G2Point::new([x_r, y_r, z_r]);
+        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
 
         let l = Fp12E::new([
             Fp6E::new([y_p * (-h), Fp2E::zero(), Fp2E::zero()]),
@@ -332,7 +332,7 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         let y_r = &theta * (g - h) - i;
         let z_r = z_t * e;
 
-        let r = G2Point::new([x_r, y_r, z_r]);
+        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
 
         let l = Fp12E::new([
             Fp6E::new([y_p * lambda, Fp2E::zero(), Fp2E::zero()]),
@@ -658,7 +658,8 @@ mod tests {
                 )),
             ]),
             Fp2E::one(),
-        ]);
+        ])
+        .unwrap();
         let result = BN254AtePairing::compute_batch(&[(&p, &q)]);
         assert!(result.is_err())
     }

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
@@ -308,10 +308,9 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
             BN254TwistCurve::defining_equation_projective(&x_r, &y_r, &z_r),
             Fp2E::zero(),
         );
-        // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
+        // SAFETY: `unwrap()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
         let r = G2Point::new([x_r, y_r, z_r]);
-        debug_assert!(r.is_ok());
 
         let l = Fp12E::new([
             Fp6E::new([y_p * (-h), Fp2E::zero(), Fp2E::zero()]),
@@ -343,10 +342,9 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
             BN254TwistCurve::defining_equation_projective(&x_r, &y_r, &z_r),
             Fp2E::zero()
         );
-        // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
+        // SAFETY: `unwrap()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
         let r = G2Point::new([x_r, y_r, z_r]);
-        debug_assert!(r.is_ok());
 
         let l = Fp12E::new([
             Fp6E::new([y_p * lambda, Fp2E::zero(), Fp2E::zero()]),

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
@@ -306,11 +306,12 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
 
         debug_assert_eq!(
             BN254TwistCurve::defining_equation_projective(&x_r, &y_r, &z_r),
-            Fp2E::zero()
+            Fp2E::zero(),
+            "Success: The resulting point satisfies the curve equation"
         );
         // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
-        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
+        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
 
         let l = Fp12E::new([
             Fp6E::new([y_p * (-h), Fp2E::zero(), Fp2E::zero()]),
@@ -340,12 +341,14 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
 
         debug_assert_eq!(
             BN254TwistCurve::defining_equation_projective(&x_r, &y_r, &z_r),
-            Fp2E::zero()
+            Fp2E::zero(),
+            "Success: The resulting point satisfies the curve equation"
         );
 
         // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
-        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
+        print!("x_r: {:?}, y_r: {:?}, z_r: {:?}\n", x_r, y_r, z_r);
+        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
 
         let l = Fp12E::new([
             Fp6E::new([y_p * lambda, Fp2E::zero(), Fp2E::zero()]),

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
@@ -310,7 +310,7 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         );
         // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
-        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
+        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
 
         let l = Fp12E::new([
             Fp6E::new([y_p * (-h), Fp2E::zero(), Fp2E::zero()]),
@@ -345,7 +345,7 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
 
         // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
-        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
+        let r = unsafe { G2Point::new([x_r, y_r, z_r]).unwrap_unchecked() };
 
         let l = Fp12E::new([
             Fp6E::new([y_p * lambda, Fp2E::zero(), Fp2E::zero()]),

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
@@ -310,13 +310,14 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         );
         // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
-        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
+        let r = G2Point::new([x_r, y_r, z_r]);
+        debug_assert!(r.is_ok());
 
         let l = Fp12E::new([
             Fp6E::new([y_p * (-h), Fp2E::zero(), Fp2E::zero()]),
             Fp6E::new([x_p * (j.double() + &j), i, Fp2E::zero()]),
         ]);
-        (r, l)
+        (r.unwrap(), l)
     } else {
         let [x_q, y_q, _] = q.coordinates();
         let [x_t, y_t, z_t] = t.coordinates();
@@ -344,13 +345,14 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         );
         // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
-        let r = G2Point::new([x_r, y_r, z_r]).unwrap();
+        let r = G2Point::new([x_r, y_r, z_r]);
+        debug_assert!(r.is_ok());
 
         let l = Fp12E::new([
             Fp6E::new([y_p * lambda, Fp2E::zero(), Fp2E::zero()]),
             Fp6E::new([x_p * (-theta), j, Fp2E::zero()]),
         ]);
-        (r, l)
+        (r.unwrap(), l)
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
@@ -307,7 +307,6 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
         debug_assert_eq!(
             BN254TwistCurve::defining_equation_projective(&x_r, &y_r, &z_r),
             Fp2E::zero(),
-            "Success: The resulting point satisfies the curve equation"
         );
         // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
@@ -341,13 +340,10 @@ fn line_optimized(p: &G1Point, t: &G2Point, q: &G2Point) -> (G2Point, Fp12E) {
 
         debug_assert_eq!(
             BN254TwistCurve::defining_equation_projective(&x_r, &y_r, &z_r),
-            Fp2E::zero(),
-            "Success: The resulting point satisfies the curve equation"
+            Fp2E::zero()
         );
-
         // SAFETY: `unwrap_unchecked()` is used here because we ensure that `x_r, y_r, z_r`
         // satisfy the curve equation. The previous assertion checks that this is indeed the case.
-        print!("x_r: {:?}, y_r: {:?}, z_r: {:?}\n", x_r, y_r, z_r);
         let r = G2Point::new([x_r, y_r, z_r]).unwrap();
 
         let l = Fp12E::new([

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/twist.rs
@@ -29,6 +29,9 @@ impl IsEllipticCurve for BN254TwistCurve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point is mathematically verified to be a valid point on the curve.
+        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
         unsafe {
             Self::PointRepresentation::new([
                 FieldElement::new([

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/twist.rs
@@ -32,19 +32,20 @@ impl IsEllipticCurve for BN254TwistCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
-            FieldElement::new([
-                FieldElement::new(GENERATOR_X_0),
-                FieldElement::new(GENERATOR_X_1),
-            ]),
-            FieldElement::new([
-                FieldElement::new(GENERATOR_Y_0),
-                FieldElement::new(GENERATOR_Y_1),
-            ]),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::new([
+                    FieldElement::new(GENERATOR_X_0),
+                    FieldElement::new(GENERATOR_X_1),
+                ]),
+                FieldElement::new([
+                    FieldElement::new(GENERATOR_Y_0),
+                    FieldElement::new(GENERATOR_Y_1),
+                ]),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/twist.rs
@@ -32,8 +32,7 @@ impl IsEllipticCurve for BN254TwistCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::new([
                 FieldElement::new(GENERATOR_X_0),
                 FieldElement::new(GENERATOR_X_1),
@@ -43,8 +42,9 @@ impl IsEllipticCurve for BN254TwistCurve {
                 FieldElement::new(GENERATOR_Y_1),
             ]),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/twist.rs
@@ -29,17 +29,20 @@ impl IsEllipticCurve for BN254TwistCurve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::new([
-                FieldElement::new(GENERATOR_X_0),
-                FieldElement::new(GENERATOR_X_1),
-            ]),
-            FieldElement::new([
-                FieldElement::new(GENERATOR_Y_0),
-                FieldElement::new(GENERATOR_Y_1),
-            ]),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::new([
+                    FieldElement::new(GENERATOR_X_0),
+                    FieldElement::new(GENERATOR_X_1),
+                ]),
+                FieldElement::new([
+                    FieldElement::new(GENERATOR_Y_0),
+                    FieldElement::new(GENERATOR_Y_1),
+                ]),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/twist.rs
@@ -32,20 +32,19 @@ impl IsEllipticCurve for BN254TwistCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
-                FieldElement::new([
-                    FieldElement::new(GENERATOR_X_0),
-                    FieldElement::new(GENERATOR_X_1),
-                ]),
-                FieldElement::new([
-                    FieldElement::new(GENERATOR_Y_0),
-                    FieldElement::new(GENERATOR_Y_1),
-                ]),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            FieldElement::new([
+                FieldElement::new(GENERATOR_X_0),
+                FieldElement::new(GENERATOR_X_1),
+            ]),
+            FieldElement::new([
+                FieldElement::new(GENERATOR_Y_0),
+                FieldElement::new(GENERATOR_Y_1),
+            ]),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/twist.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/twist.rs
@@ -31,7 +31,7 @@ impl IsEllipticCurve for BN254TwistCurve {
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
-        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+        // - `unwrap()` is safe because the provided coordinates satisfy the curve equation.
         let point = Self::PointRepresentation::new([
             FieldElement::new([
                 FieldElement::new(GENERATOR_X_0),
@@ -43,7 +43,6 @@ impl IsEllipticCurve for BN254TwistCurve {
             ]),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs
@@ -23,13 +23,16 @@ impl IsEllipticCurve for GrumpkinCurve {
 
     // G = (1, sprt(-16)) = (1, 17631683881184975370165255887551781615748388533673675138860) = (0x1, 0x2cf135e7506a45d632d270d45f1181294833fc48d823f272c)
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::one(),
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "0x2cf135e7506a45d632d270d45f1181294833fc48d823f272c",
-            ),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::one(),
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "0x2cf135e7506a45d632d270d45f1181294833fc48d823f272c",
+                ),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs
@@ -26,16 +26,15 @@ impl IsEllipticCurve for GrumpkinCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
-                FieldElement::<Self::BaseField>::one(),
-                FieldElement::<Self::BaseField>::from_hex_unchecked(
-                    "0x2cf135e7506a45d632d270d45f1181294833fc48d823f272c",
-                ),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            FieldElement::<Self::BaseField>::one(),
+            FieldElement::<Self::BaseField>::from_hex_unchecked(
+                "0x2cf135e7506a45d632d270d45f1181294833fc48d823f272c",
+            ),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs
@@ -26,15 +26,16 @@ impl IsEllipticCurve for GrumpkinCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::one(),
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "0x2cf135e7506a45d632d270d45f1181294833fc48d823f272c",
-            ),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::one(),
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "0x2cf135e7506a45d632d270d45f1181294833fc48d823f272c",
+                ),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs
@@ -26,15 +26,15 @@ impl IsEllipticCurve for GrumpkinCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::one(),
             FieldElement::<Self::BaseField>::from_hex_unchecked(
                 "0x2cf135e7506a45d632d270d45f1181294833fc48d823f272c",
             ),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs
@@ -23,6 +23,9 @@ impl IsEllipticCurve for GrumpkinCurve {
 
     // G = (1, sprt(-16)) = (1, 17631683881184975370165255887551781615748388533673675138860) = (0x1, 0x2cf135e7506a45d632d270d45f1181294833fc48d823f272c)
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point is mathematically verified to be a valid point on the curve.
+        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
         unsafe {
             Self::PointRepresentation::new([
                 FieldElement::<Self::BaseField>::one(),

--- a/math/src/elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs
@@ -25,7 +25,7 @@ impl IsEllipticCurve for GrumpkinCurve {
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
-        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+        // - `unwrap()` is safe because the provided coordinates satisfy the curve equation.
         let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::one(),
             FieldElement::<Self::BaseField>::from_hex_unchecked(
@@ -33,7 +33,6 @@ impl IsEllipticCurve for GrumpkinCurve {
             ),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/pallas/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/pallas/curve.rs
@@ -13,6 +13,9 @@ impl IsEllipticCurve for PallasCurve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point is mathematically verified to be a valid point on the curve.
+        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
         unsafe {
             Self::PointRepresentation::new([
                 -FieldElement::<Self::BaseField>::one(),

--- a/math/src/elliptic_curve/short_weierstrass/curves/pallas/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/pallas/curve.rs
@@ -16,14 +16,13 @@ impl IsEllipticCurve for PallasCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
-                -FieldElement::<Self::BaseField>::one(),
-                FieldElement::<Self::BaseField>::from(2),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            -FieldElement::<Self::BaseField>::one(),
+            FieldElement::<Self::BaseField>::from(2),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/pallas/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/pallas/curve.rs
@@ -13,11 +13,14 @@ impl IsEllipticCurve for PallasCurve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            -FieldElement::<Self::BaseField>::one(),
-            FieldElement::<Self::BaseField>::from(2),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                -FieldElement::<Self::BaseField>::one(),
+                FieldElement::<Self::BaseField>::from(2),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/pallas/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/pallas/curve.rs
@@ -16,13 +16,14 @@ impl IsEllipticCurve for PallasCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
-            -FieldElement::<Self::BaseField>::one(),
-            FieldElement::<Self::BaseField>::from(2),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                -FieldElement::<Self::BaseField>::one(),
+                FieldElement::<Self::BaseField>::from(2),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/pallas/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/pallas/curve.rs
@@ -15,13 +15,12 @@ impl IsEllipticCurve for PallasCurve {
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
-        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+        // - `unwrap()` is safe because the provided coordinates satisfy the curve equation.
         let point = Self::PointRepresentation::new([
             -FieldElement::<Self::BaseField>::one(),
             FieldElement::<Self::BaseField>::from(2),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/pallas/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/pallas/curve.rs
@@ -16,13 +16,13 @@ impl IsEllipticCurve for PallasCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             -FieldElement::<Self::BaseField>::one(),
             FieldElement::<Self::BaseField>::from(2),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/secp256k1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secp256k1/curve.rs
@@ -18,7 +18,7 @@ impl IsEllipticCurve for Secp256k1Curve {
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
 
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex_unchecked(
                 "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
             ),
@@ -26,8 +26,9 @@ impl IsEllipticCurve for Secp256k1Curve {
                 "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
             ),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/secp256k1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secp256k1/curve.rs
@@ -16,8 +16,7 @@ impl IsEllipticCurve for Secp256k1Curve {
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
-        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
+        // - `unwrap()` is safe because the provided coordinates satisfy the curve equation.
         let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex_unchecked(
                 "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
@@ -27,7 +26,6 @@ impl IsEllipticCurve for Secp256k1Curve {
             ),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/secp256k1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secp256k1/curve.rs
@@ -14,6 +14,9 @@ impl IsEllipticCurve for Secp256k1Curve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point is mathematically verified to be a valid point on the curve.
+        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
         unsafe {
             Self::PointRepresentation::new([
                 FieldElement::<Self::BaseField>::from_hex_unchecked(

--- a/math/src/elliptic_curve/short_weierstrass/curves/secp256k1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secp256k1/curve.rs
@@ -17,18 +17,17 @@ impl IsEllipticCurve for Secp256k1Curve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
-                FieldElement::<Self::BaseField>::from_hex_unchecked(
-                    "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
-                ),
-                FieldElement::<Self::BaseField>::from_hex_unchecked(
-                    "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
-                ),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            FieldElement::<Self::BaseField>::from_hex_unchecked(
+                "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
+            ),
+            FieldElement::<Self::BaseField>::from_hex_unchecked(
+                "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
+            ),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/secp256k1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secp256k1/curve.rs
@@ -17,17 +17,18 @@ impl IsEllipticCurve for Secp256k1Curve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
-            ),
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
-            ),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
+                ),
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
+                ),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/secp256k1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secp256k1/curve.rs
@@ -14,15 +14,18 @@ impl IsEllipticCurve for Secp256k1Curve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
-            ),
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
-            ),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
+                ),
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
+                ),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/secp256r1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secp256r1/curve.rs
@@ -14,15 +14,18 @@ impl IsEllipticCurve for Secp256r1Curve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
-            ),
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
-            ),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
+                ),
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
+                ),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/secp256r1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secp256r1/curve.rs
@@ -17,8 +17,7 @@ impl IsEllipticCurve for Secp256r1Curve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex_unchecked(
                 "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
             ),
@@ -26,8 +25,9 @@ impl IsEllipticCurve for Secp256r1Curve {
                 "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
             ),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/secp256r1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secp256r1/curve.rs
@@ -16,7 +16,7 @@ impl IsEllipticCurve for Secp256r1Curve {
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
-        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+        // - `unwrap()` is safe because the provided coordinates satisfy the curve equation.
         let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex_unchecked(
                 "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
@@ -26,7 +26,6 @@ impl IsEllipticCurve for Secp256r1Curve {
             ),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/secp256r1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secp256r1/curve.rs
@@ -17,18 +17,17 @@ impl IsEllipticCurve for Secp256r1Curve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
-                FieldElement::<Self::BaseField>::from_hex_unchecked(
-                    "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
-                ),
-                FieldElement::<Self::BaseField>::from_hex_unchecked(
-                    "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
-                ),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            FieldElement::<Self::BaseField>::from_hex_unchecked(
+                "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
+            ),
+            FieldElement::<Self::BaseField>::from_hex_unchecked(
+                "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
+            ),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/secp256r1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secp256r1/curve.rs
@@ -17,17 +17,18 @@ impl IsEllipticCurve for Secp256r1Curve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
-            ),
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
-            ),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
+                ),
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
+                ),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/secp256r1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secp256r1/curve.rs
@@ -14,6 +14,9 @@ impl IsEllipticCurve for Secp256r1Curve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point is mathematically verified to be a valid point on the curve.
+        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
         unsafe {
             Self::PointRepresentation::new([
                 FieldElement::<Self::BaseField>::from_hex_unchecked(

--- a/math/src/elliptic_curve/short_weierstrass/curves/secq256k1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secq256k1/curve.rs
@@ -15,7 +15,7 @@ impl IsEllipticCurve for Secq256k1Curve {
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
-        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+        // - `unwrap()` is safe because the provided coordinates satisfy the curve equation.
         let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex_unchecked(
                 "76C39F5585CB160EB6B06C87A2CE32E23134E45A097781A6A24288E37702EDA6",
@@ -25,7 +25,6 @@ impl IsEllipticCurve for Secq256k1Curve {
             ),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/secq256k1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secq256k1/curve.rs
@@ -16,18 +16,17 @@ impl IsEllipticCurve for Secq256k1Curve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
-                FieldElement::<Self::BaseField>::from_hex_unchecked(
-                    "76C39F5585CB160EB6B06C87A2CE32E23134E45A097781A6A24288E37702EDA6",
-                ),
-                FieldElement::<Self::BaseField>::from_hex_unchecked(
-                    "3FFC646C7B2918B5DC2D265A8E82A7F7D18983D26E8DC055A4120DDAD952677F",
-                ),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            FieldElement::<Self::BaseField>::from_hex_unchecked(
+                "76C39F5585CB160EB6B06C87A2CE32E23134E45A097781A6A24288E37702EDA6",
+            ),
+            FieldElement::<Self::BaseField>::from_hex_unchecked(
+                "3FFC646C7B2918B5DC2D265A8E82A7F7D18983D26E8DC055A4120DDAD952677F",
+            ),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/secq256k1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secq256k1/curve.rs
@@ -16,17 +16,18 @@ impl IsEllipticCurve for Secq256k1Curve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "76C39F5585CB160EB6B06C87A2CE32E23134E45A097781A6A24288E37702EDA6",
-            ),
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "3FFC646C7B2918B5DC2D265A8E82A7F7D18983D26E8DC055A4120DDAD952677F",
-            ),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "76C39F5585CB160EB6B06C87A2CE32E23134E45A097781A6A24288E37702EDA6",
+                ),
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "3FFC646C7B2918B5DC2D265A8E82A7F7D18983D26E8DC055A4120DDAD952677F",
+                ),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/secq256k1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secq256k1/curve.rs
@@ -16,8 +16,7 @@ impl IsEllipticCurve for Secq256k1Curve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex_unchecked(
                 "76C39F5585CB160EB6B06C87A2CE32E23134E45A097781A6A24288E37702EDA6",
             ),
@@ -25,8 +24,9 @@ impl IsEllipticCurve for Secq256k1Curve {
                 "3FFC646C7B2918B5DC2D265A8E82A7F7D18983D26E8DC055A4120DDAD952677F",
             ),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/secq256k1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secq256k1/curve.rs
@@ -13,6 +13,9 @@ impl IsEllipticCurve for Secq256k1Curve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point is mathematically verified to be a valid point on the curve.
+        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
         unsafe {
             Self::PointRepresentation::new([
                 FieldElement::<Self::BaseField>::from_hex_unchecked(

--- a/math/src/elliptic_curve/short_weierstrass/curves/secq256k1/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/secq256k1/curve.rs
@@ -13,15 +13,18 @@ impl IsEllipticCurve for Secq256k1Curve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "76C39F5585CB160EB6B06C87A2CE32E23134E45A097781A6A24288E37702EDA6",
-            ),
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "3FFC646C7B2918B5DC2D265A8E82A7F7D18983D26E8DC055A4120DDAD952677F",
-            ),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "76C39F5585CB160EB6B06C87A2CE32E23134E45A097781A6A24288E37702EDA6",
+                ),
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "3FFC646C7B2918B5DC2D265A8E82A7F7D18983D26E8DC055A4120DDAD952677F",
+                ),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 
@@ -68,7 +71,7 @@ mod tests {
         let z = FE::from_hex_unchecked(
             "bb26eae3d2b9603d98dff86d87175f442e539c07bbe4ef5712e47c4d72c89734",
         );
-        ShortWeierstrassProjectivePoint::<Secq256k1Curve>::new([x, y, z])
+        ShortWeierstrassProjectivePoint::<Secq256k1Curve>::new([x, y, z]).unwrap()
     }
 
     #[test]

--- a/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
@@ -32,7 +32,7 @@ impl IsEllipticCurve for StarkCurve {
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
-        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+        // - `unwrap()` is safe because the provided coordinates satisfy the curve equation.
         let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex_unchecked(
                 "1EF15C18599971B7BECED415A40F0C7DEACFD9B0D1819E03D723D8BC943CFCA",
@@ -42,7 +42,6 @@ impl IsEllipticCurve for StarkCurve {
             ),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
@@ -2,7 +2,7 @@ use crate::{
     elliptic_curve::{
         point::ProjectivePoint,
         short_weierstrass::{point::ShortWeierstrassProjectivePoint, traits::IsShortWeierstrass},
-        traits::{EllipticCurveError, IsEllipticCurve},
+        traits::IsEllipticCurve,
     },
     field::{
         element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
@@ -17,19 +17,11 @@ impl StarkCurve {
         x_hex: &str,
         y_hex: &str,
     ) -> ShortWeierstrassProjectivePoint<Self> {
-        //-> Result<ShortWeierstrassProjectivePoint<Self>, EllipticCurveError> {
         ShortWeierstrassProjectivePoint(ProjectivePoint::new([
             FieldElement::<Stark252PrimeField>::from_hex_unchecked(x_hex),
             FieldElement::<Stark252PrimeField>::from_hex_unchecked(y_hex),
             FieldElement::<Stark252PrimeField>::from_hex_unchecked("1"),
         ]))
-        // Ok(unsafe {
-        //     ShortWeierstrassProjectivePoint::new([
-        //         FieldElement::<Stark252PrimeField>::from_hex_unchecked(x_hex),
-        //         FieldElement::<Stark252PrimeField>::from_hex_unchecked(y_hex),
-        //         FieldElement::<Stark252PrimeField>::from_hex_unchecked("1"),
-        //     ])
-        // })
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
@@ -1,5 +1,6 @@
 use crate::{
     elliptic_curve::{
+        point::ProjectivePoint,
         short_weierstrass::{point::ShortWeierstrassProjectivePoint, traits::IsShortWeierstrass},
         traits::{EllipticCurveError, IsEllipticCurve},
     },
@@ -15,12 +16,20 @@ impl StarkCurve {
     pub const fn from_affine_hex_string(
         x_hex: &str,
         y_hex: &str,
-    ) -> Result<ShortWeierstrassProjectivePoint<Self>, EllipticCurveError> {
-        ShortWeierstrassProjectivePoint::new([
+    ) -> ShortWeierstrassProjectivePoint<Self> {
+        //-> Result<ShortWeierstrassProjectivePoint<Self>, EllipticCurveError> {
+        ShortWeierstrassProjectivePoint(ProjectivePoint::new([
             FieldElement::<Stark252PrimeField>::from_hex_unchecked(x_hex),
             FieldElement::<Stark252PrimeField>::from_hex_unchecked(y_hex),
             FieldElement::<Stark252PrimeField>::from_hex_unchecked("1"),
-        ])
+        ]))
+        // Ok(unsafe {
+        //     ShortWeierstrassProjectivePoint::new([
+        //         FieldElement::<Stark252PrimeField>::from_hex_unchecked(x_hex),
+        //         FieldElement::<Stark252PrimeField>::from_hex_unchecked(y_hex),
+        //         FieldElement::<Stark252PrimeField>::from_hex_unchecked("1"),
+        //     ])
+        // })
     }
 }
 
@@ -29,15 +38,18 @@ impl IsEllipticCurve for StarkCurve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "1EF15C18599971B7BECED415A40F0C7DEACFD9B0D1819E03D723D8BC943CFCA",
-            ),
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "5668060AA49730B7BE4801DF46EC62DE53ECD11ABE43A32873000C36E8DC1F",
-            ),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "1EF15C18599971B7BECED415A40F0C7DEACFD9B0D1819E03D723D8BC943CFCA",
+                ),
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "5668060AA49730B7BE4801DF46EC62DE53ECD11ABE43A32873000C36E8DC1F",
+                ),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
@@ -33,17 +33,18 @@ impl IsEllipticCurve for StarkCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "1EF15C18599971B7BECED415A40F0C7DEACFD9B0D1819E03D723D8BC943CFCA",
-            ),
-            FieldElement::<Self::BaseField>::from_hex_unchecked(
-                "5668060AA49730B7BE4801DF46EC62DE53ECD11ABE43A32873000C36E8DC1F",
-            ),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "1EF15C18599971B7BECED415A40F0C7DEACFD9B0D1819E03D723D8BC943CFCA",
+                ),
+                FieldElement::<Self::BaseField>::from_hex_unchecked(
+                    "5668060AA49730B7BE4801DF46EC62DE53ECD11ABE43A32873000C36E8DC1F",
+                ),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
@@ -30,6 +30,9 @@ impl IsEllipticCurve for StarkCurve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point is mathematically verified to be a valid point on the curve.
+        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
         unsafe {
             Self::PointRepresentation::new([
                 FieldElement::<Self::BaseField>::from_hex_unchecked(

--- a/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
@@ -33,8 +33,7 @@ impl IsEllipticCurve for StarkCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::<Self::BaseField>::from_hex_unchecked(
                 "1EF15C18599971B7BECED415A40F0C7DEACFD9B0D1819E03D723D8BC943CFCA",
             ),
@@ -42,8 +41,9 @@ impl IsEllipticCurve for StarkCurve {
                 "5668060AA49730B7BE4801DF46EC62DE53ECD11ABE43A32873000C36E8DC1F",
             ),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
@@ -1,7 +1,7 @@
 use crate::{
     elliptic_curve::{
         short_weierstrass::{point::ShortWeierstrassProjectivePoint, traits::IsShortWeierstrass},
-        traits::IsEllipticCurve,
+        traits::{EllipticCurveError, IsEllipticCurve},
     },
     field::{
         element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
@@ -15,7 +15,7 @@ impl StarkCurve {
     pub const fn from_affine_hex_string(
         x_hex: &str,
         y_hex: &str,
-    ) -> ShortWeierstrassProjectivePoint<Self> {
+    ) -> Result<ShortWeierstrassProjectivePoint<Self>, EllipticCurveError> {
         ShortWeierstrassProjectivePoint::new([
             FieldElement::<Stark252PrimeField>::from_hex_unchecked(x_hex),
             FieldElement::<Stark252PrimeField>::from_hex_unchecked(y_hex),

--- a/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/stark_curve.rs
@@ -33,18 +33,17 @@ impl IsEllipticCurve for StarkCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
-                FieldElement::<Self::BaseField>::from_hex_unchecked(
-                    "1EF15C18599971B7BECED415A40F0C7DEACFD9B0D1819E03D723D8BC943CFCA",
-                ),
-                FieldElement::<Self::BaseField>::from_hex_unchecked(
-                    "5668060AA49730B7BE4801DF46EC62DE53ECD11ABE43A32873000C36E8DC1F",
-                ),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            FieldElement::<Self::BaseField>::from_hex_unchecked(
+                "1EF15C18599971B7BECED415A40F0C7DEACFD9B0D1819E03D723D8BC943CFCA",
+            ),
+            FieldElement::<Self::BaseField>::from_hex_unchecked(
+                "5668060AA49730B7BE4801DF46EC62DE53ECD11ABE43A32873000C36E8DC1F",
+            ),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_1.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_1.rs
@@ -41,6 +41,9 @@ impl IsEllipticCurve for TestCurve1 {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point is mathematically verified to be a valid point on the curve.
+        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
         unsafe {
             Self::PointRepresentation::new([
                 FieldElement::from(35),

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_1.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_1.rs
@@ -44,13 +44,13 @@ impl IsEllipticCurve for TestCurve1 {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::from(35),
             FieldElement::from(31),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_1.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_1.rs
@@ -44,14 +44,13 @@ impl IsEllipticCurve for TestCurve1 {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
-                FieldElement::from(35),
-                FieldElement::from(31),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            FieldElement::from(35),
+            FieldElement::from(31),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_1.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_1.rs
@@ -44,13 +44,14 @@ impl IsEllipticCurve for TestCurve1 {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
-            FieldElement::from(35),
-            FieldElement::from(31),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::from(35),
+                FieldElement::from(31),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_1.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_1.rs
@@ -43,13 +43,12 @@ impl IsEllipticCurve for TestCurve1 {
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
-        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+        // - `unwrap()` is safe because the provided coordinates satisfy the curve equation.
         let point = Self::PointRepresentation::new([
             FieldElement::from(35),
             FieldElement::from(31),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_1.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_1.rs
@@ -41,11 +41,14 @@ impl IsEllipticCurve for TestCurve1 {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::from(35),
-            FieldElement::from(31),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::from(35),
+                FieldElement::from(31),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
@@ -51,7 +51,7 @@ impl IsEllipticCurve for TestCurve2 {
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
-        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+        // - `unwrap()` is safe because the provided coordinates satisfy the curve equation.
         let point = Self::PointRepresentation::new([
             FieldElement::new([
                 FieldElement::new(U384::from_hex_unchecked(
@@ -71,7 +71,6 @@ impl IsEllipticCurve for TestCurve2 {
             ]),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
@@ -52,8 +52,7 @@ impl IsEllipticCurve for TestCurve2 {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             FieldElement::new([
                 FieldElement::new(U384::from_hex_unchecked(
                     "21acedb641ca6d0f8b60148123a999801",
@@ -71,8 +70,9 @@ impl IsEllipticCurve for TestCurve2 {
                 )),
             ]),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
@@ -52,28 +52,27 @@ impl IsEllipticCurve for TestCurve2 {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
-                FieldElement::new([
-                    FieldElement::new(U384::from_hex_unchecked(
-                        "21acedb641ca6d0f8b60148123a999801",
-                    )),
-                    FieldElement::new(U384::from_hex_unchecked(
-                        "14d34d94f7de312859a8a0d9dbc67159d3",
-                    )),
-                ]),
-                FieldElement::new([
-                    FieldElement::new(U384::from_hex_unchecked(
-                        "2ac53e77afe8d841c8eb660761c4b873a",
-                    )),
-                    FieldElement::new(U384::from_hex_unchecked(
-                        "108a9e1c5514b0921cd5781a7f71130142",
-                    )),
-                ]),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            FieldElement::new([
+                FieldElement::new(U384::from_hex_unchecked(
+                    "21acedb641ca6d0f8b60148123a999801",
+                )),
+                FieldElement::new(U384::from_hex_unchecked(
+                    "14d34d94f7de312859a8a0d9dbc67159d3",
+                )),
+            ]),
+            FieldElement::new([
+                FieldElement::new(U384::from_hex_unchecked(
+                    "2ac53e77afe8d841c8eb660761c4b873a",
+                )),
+                FieldElement::new(U384::from_hex_unchecked(
+                    "108a9e1c5514b0921cd5781a7f71130142",
+                )),
+            ]),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
@@ -52,27 +52,28 @@ impl IsEllipticCurve for TestCurve2 {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
-            FieldElement::new([
-                FieldElement::new(U384::from_hex_unchecked(
-                    "21acedb641ca6d0f8b60148123a999801",
-                )),
-                FieldElement::new(U384::from_hex_unchecked(
-                    "14d34d94f7de312859a8a0d9dbc67159d3",
-                )),
-            ]),
-            FieldElement::new([
-                FieldElement::new(U384::from_hex_unchecked(
-                    "2ac53e77afe8d841c8eb660761c4b873a",
-                )),
-                FieldElement::new(U384::from_hex_unchecked(
-                    "108a9e1c5514b0921cd5781a7f71130142",
-                )),
-            ]),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::new([
+                    FieldElement::new(U384::from_hex_unchecked(
+                        "21acedb641ca6d0f8b60148123a999801",
+                    )),
+                    FieldElement::new(U384::from_hex_unchecked(
+                        "14d34d94f7de312859a8a0d9dbc67159d3",
+                    )),
+                ]),
+                FieldElement::new([
+                    FieldElement::new(U384::from_hex_unchecked(
+                        "2ac53e77afe8d841c8eb660761c4b873a",
+                    )),
+                    FieldElement::new(U384::from_hex_unchecked(
+                        "108a9e1c5514b0921cd5781a7f71130142",
+                    )),
+                ]),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
@@ -49,25 +49,28 @@ impl IsEllipticCurve for TestCurve2 {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            FieldElement::new([
-                FieldElement::new(U384::from_hex_unchecked(
-                    "21acedb641ca6d0f8b60148123a999801",
-                )),
-                FieldElement::new(U384::from_hex_unchecked(
-                    "14d34d94f7de312859a8a0d9dbc67159d3",
-                )),
-            ]),
-            FieldElement::new([
-                FieldElement::new(U384::from_hex_unchecked(
-                    "2ac53e77afe8d841c8eb660761c4b873a",
-                )),
-                FieldElement::new(U384::from_hex_unchecked(
-                    "108a9e1c5514b0921cd5781a7f71130142",
-                )),
-            ]),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                FieldElement::new([
+                    FieldElement::new(U384::from_hex_unchecked(
+                        "21acedb641ca6d0f8b60148123a999801",
+                    )),
+                    FieldElement::new(U384::from_hex_unchecked(
+                        "14d34d94f7de312859a8a0d9dbc67159d3",
+                    )),
+                ]),
+                FieldElement::new([
+                    FieldElement::new(U384::from_hex_unchecked(
+                        "2ac53e77afe8d841c8eb660761c4b873a",
+                    )),
+                    FieldElement::new(U384::from_hex_unchecked(
+                        "108a9e1c5514b0921cd5781a7f71130142",
+                    )),
+                ]),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/test_curve_2.rs
@@ -49,6 +49,9 @@ impl IsEllipticCurve for TestCurve2 {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point is mathematically verified to be a valid point on the curve.
+        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
         unsafe {
             Self::PointRepresentation::new([
                 FieldElement::new([

--- a/math/src/elliptic_curve/short_weierstrass/curves/vesta/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/vesta/curve.rs
@@ -16,13 +16,13 @@ impl IsEllipticCurve for VestaCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
+        let point = Self::PointRepresentation::new([
             -FieldElement::<Self::BaseField>::one(),
             FieldElement::<Self::BaseField>::from(2),
             FieldElement::one(),
-        ])
-        .unwrap()
+        ]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/vesta/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/vesta/curve.rs
@@ -13,11 +13,14 @@ impl IsEllipticCurve for VestaCurve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
-        Self::PointRepresentation::new([
-            -FieldElement::<Self::BaseField>::one(),
-            FieldElement::<Self::BaseField>::from(2),
-            FieldElement::one(),
-        ])
+        unsafe {
+            Self::PointRepresentation::new([
+                -FieldElement::<Self::BaseField>::one(),
+                FieldElement::<Self::BaseField>::from(2),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/vesta/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/vesta/curve.rs
@@ -16,14 +16,13 @@ impl IsEllipticCurve for VestaCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-        unsafe {
-            Self::PointRepresentation::new([
-                -FieldElement::<Self::BaseField>::one(),
-                FieldElement::<Self::BaseField>::from(2),
-                FieldElement::one(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::PointRepresentation::new([
+            -FieldElement::<Self::BaseField>::one(),
+            FieldElement::<Self::BaseField>::from(2),
+            FieldElement::one(),
+        ])
+        .unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/vesta/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/vesta/curve.rs
@@ -16,13 +16,14 @@ impl IsEllipticCurve for VestaCurve {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
         // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
-
-        Self::PointRepresentation::new([
-            -FieldElement::<Self::BaseField>::one(),
-            FieldElement::<Self::BaseField>::from(2),
-            FieldElement::one(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::PointRepresentation::new([
+                -FieldElement::<Self::BaseField>::one(),
+                FieldElement::<Self::BaseField>::from(2),
+                FieldElement::one(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/curves/vesta/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/vesta/curve.rs
@@ -15,13 +15,12 @@ impl IsEllipticCurve for VestaCurve {
     fn generator() -> Self::PointRepresentation {
         // SAFETY:
         // - The generator point is mathematically verified to be a valid point on the curve.
-        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
+        // - `unwrap()` is safe because the provided coordinates satisfy the curve equation.
         let point = Self::PointRepresentation::new([
             -FieldElement::<Self::BaseField>::one(),
             FieldElement::<Self::BaseField>::from(2),
             FieldElement::one(),
         ]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/curves/vesta/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/vesta/curve.rs
@@ -13,6 +13,9 @@ impl IsEllipticCurve for VestaCurve {
     type PointRepresentation = ShortWeierstrassProjectivePoint<Self>;
 
     fn generator() -> Self::PointRepresentation {
+        // SAFETY:
+        // - The generator point is mathematically verified to be a valid point on the curve.
+        // - `unwrap_unchecked()` is safe because the provided coordinates satisfy the curve equation.
         unsafe {
             Self::PointRepresentation::new([
                 -FieldElement::<Self::BaseField>::one(),

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -109,7 +109,6 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         // SAFETY: The values `x_p, y_p, z_p` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
         let point = Self::new([xp, yp, zp]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
     // https://hyperelliptic.org/EFD/g1p/data/shortw/projective/addition/madd-1998-cmo
@@ -159,7 +158,6 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         // SAFETY: The values `x, y, z` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
         let point = Self::new([x, y, z]);
-        debug_assert!(point.is_ok());
         point.unwrap()
     }
 }
@@ -187,8 +185,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
     fn neutral_element() -> Self {
         // SAFETY:
         // - `(0, 1, 0)` is **mathematically valid** as the neutral element.
-        // - `unwrap_unchecked()` is safe because this is **a known valid point**.
-
+        // - `unwrap()` is safe because this is **a known valid point**.
         Self::new([
             FieldElement::zero(),
             FieldElement::one(),
@@ -254,7 +251,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
         let [px, py, pz] = self.coordinates();
         // SAFETY:
         // - Negating `y` maintains the curve structure.
-        // - `unwrap_unchecked()` is safe because negation **is always valid**.
+        // - `unwraps()` is safe because negation **is always valid**.
         Self::new([px.clone(), -py, pz.clone()]).unwrap()
     }
 }
@@ -584,7 +581,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
     fn neutral_element() -> Self {
         // SAFETY:
         // - `(1, 1, 0)` is **mathematically valid** as the neutral element.
-        // - `unwrap_unchecked()` is safe because this is **a known valid point**.
+        // - `unwrap()` is safe because this is **a known valid point**.
 
         Self::new([
             FieldElement::one(),

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -151,6 +151,10 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         let y = &u * (&r - &a) - &vvv * py;
         let z = &vvv * pz;
 
+        debug_assert_eq!(
+            E::defining_equation_projective(&x, &y, &z),
+            FieldElement::<E::BaseField>::zero()
+        );
         unsafe { Self::new([x, y, z]).unwrap_unchecked() }
     }
 }
@@ -226,6 +230,11 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
                 let xp = &v * &a;
                 let yp = u * (&v_square_v2 - a) - &v_cube * u2;
                 let zp = &v_cube * w;
+
+                debug_assert_eq!(
+                    E::defining_equation_projective(&xp, &yp, &zp),
+                    FieldElement::<E::BaseField>::zero()
+                );
                 unsafe { Self::new([xp, yp, zp]).unwrap_unchecked() }
             }
         }
@@ -398,9 +407,30 @@ where
 pub struct ShortWeierstrassJacobianPoint<E: IsEllipticCurve>(pub JacobianPoint<E>);
 
 impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
-    /// Creates an elliptic curve point giving the projective [x: y: z] coordinates.
-    pub const fn new(value: [FieldElement<E::BaseField>; 3]) -> Self {
-        Self(JacobianPoint::new(value))
+    /// Creates an elliptic curve point giving the jacobian [x: y: z] coordinates.
+    // pub const fn new(value: [FieldElement<E::BaseField>; 3]) -> Self {
+    //     Self(JacobianPoint::new(value))
+    // }
+
+    /// Creates an elliptic curve point giving the jacobian [x: y: z] coordinates.
+    pub fn new(value: [FieldElement<E::BaseField>; 3]) -> Result<Self, EllipticCurveError> {
+        let (x, y, z) = (&value[0], &value[1], &value[2]);
+
+        if z != &FieldElement::<E::BaseField>::zero()
+            && E::defining_equation_jacobian(&x, &y, &z) == FieldElement::<E::BaseField>::zero()
+        {
+            Ok(Self(JacobianPoint::new(value)))
+        // The point at infinity is (1, 1, 0)
+        // We convert every (x, x, 0) into the infinity.
+        } else if z == &FieldElement::<E::BaseField>::zero() && x == y {
+            Ok(Self(JacobianPoint::new([
+                FieldElement::<E::BaseField>::one(),
+                FieldElement::<E::BaseField>::one(),
+                FieldElement::<E::BaseField>::zero(),
+            ])))
+        } else {
+            Err(EllipticCurveError::InvalidPoint)
+        }
     }
 
     /// Returns the `x` coordinate of the point.
@@ -450,7 +480,11 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             let y3 = &e * (&d - &x3) - &c.double().double().double(); // Y3 = E * (D - X3) - 8 * C
             let z3 = (y1 * z1).double(); // Z3 = 2 * Y1 * Z1
 
-            Self::new([x3, y3, z3])
+            debug_assert_eq!(
+                E::defining_equation_jacobian(&x3, &y3, &z3),
+                FieldElement::<E::BaseField>::zero()
+            );
+            unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
         } else {
             // http://www.hyperelliptic.org/EFD/g1p/data/shortw/jacobian-0/doubling/dbl-2009-alnr
             // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#doubling-dbl-2009-l
@@ -464,7 +498,11 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             let y3 = m * (&s - &x3) - &yyyy.double().double().double(); // Y3 = M * (S - X3) - 8 * YYYY
             let z3 = (y1 + z1).square() - &yy - &zz; // Z3 = (Y1 + Z1)^2 - YY - ZZ
 
-            Self::new([x3, y3, z3])
+            debug_assert_eq!(
+                E::defining_equation_projective(&x3, &y3, &z3),
+                FieldElement::<E::BaseField>::zero()
+            );
+            unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
         }
     }
 
@@ -501,7 +539,11 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             let y3 = r * (&v - &x3) - s1 * &hhh;
             let z3 = z1 * &h;
 
-            Self::new([x3, y3, z3])
+            debug_assert_eq!(
+                E::defining_equation_projective(&x3, &y3, &z3),
+                FieldElement::<E::BaseField>::zero()
+            );
+            unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
         }
     }
 }
@@ -519,23 +561,22 @@ impl<E: IsShortWeierstrass> FromAffine<E::BaseField> for ShortWeierstrassJacobia
         x: FieldElement<E::BaseField>,
         y: FieldElement<E::BaseField>,
     ) -> Result<Self, EllipticCurveError> {
-        if E::defining_equation(&x, &y) != FieldElement::zero() {
-            Err(EllipticCurveError::InvalidPoint)
-        } else {
-            let coordinates = [x, y, FieldElement::one()];
-            Ok(ShortWeierstrassJacobianPoint::new(coordinates))
-        }
+        let coordinates = [x, y, FieldElement::one()];
+        Ok(ShortWeierstrassJacobianPoint::new(coordinates)?)
     }
 }
 
 impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
     /// The point at infinity.
     fn neutral_element() -> Self {
-        Self::new([
-            FieldElement::one(),
-            FieldElement::one(),
-            FieldElement::zero(),
-        ])
+        unsafe {
+            Self::new([
+                FieldElement::one(),
+                FieldElement::one(),
+                FieldElement::zero(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 
     fn is_neutral_element(&self) -> bool {
@@ -599,13 +640,17 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
         let z3 = z1 * z2;
         let z3 = z3.double() * h;
 
-        Self::new([x3, y3, z3])
+        debug_assert_eq!(
+            E::defining_equation_projective(&x3, &y3, &z3),
+            FieldElement::<E::BaseField>::zero()
+        );
+        unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
     }
 
     /// Returns the additive inverse of the jacobian point `p`
     fn neg(&self) -> Self {
         let [x, y, z] = self.coordinates();
-        Self::new([x.clone(), -y, z.clone()])
+        unsafe { Self::new([x.clone(), -y, z.clone()]).unwrap_unchecked() }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -21,42 +21,26 @@ pub struct ShortWeierstrassProjectivePoint<E: IsEllipticCurve>(pub ProjectivePoi
 impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
     /// Creates an elliptic curve point giving the projective [x: y: z] coordinates.
     pub fn new(value: [FieldElement<E::BaseField>; 3]) -> Result<Self, EllipticCurveError> {
-        let zero = &FieldElement::<E::BaseField>::zero();
-        let one = &FieldElement::<E::BaseField>::one();
         let (x, y, z) = (&value[0], &value[1], &value[2]);
 
-        if z != zero
+        if z != &FieldElement::<E::BaseField>::zero()
             && E::defining_equation_projective(&x, &y, &z) == FieldElement::<E::BaseField>::zero()
         {
             Ok(Self(ProjectivePoint::new(value)))
         // The point at infinity is (0, 1, 0)
-        } else if x == zero && y == one && z == zero {
-            Ok(Self(ProjectivePoint::new(value)))
+        // We convert every (0, _, 0) into the infinity.
+        } else if x == &FieldElement::<E::BaseField>::zero()
+            && z == &FieldElement::<E::BaseField>::zero()
+        {
+            Ok(Self(ProjectivePoint::new([
+                FieldElement::<E::BaseField>::zero(),
+                FieldElement::<E::BaseField>::one(),
+                FieldElement::<E::BaseField>::zero(),
+            ])))
         } else {
             Err(EllipticCurveError::InvalidPoint)
         }
     }
-    // /// Creates an elliptic curve point giving the projective [x: y: z] coordinates.
-    // pub const unsafe fn new(value: [FieldElement<E::BaseField>; 3]) -> Self {
-    //     Self(ProjectivePoint::new(value))
-    //     // unsafe {
-    //     //     let zero = &FieldElement::<E::BaseField>::zero();
-    //     //     let one = &FieldElement::<E::BaseField>::const_from_raw(1);
-    //     //     let (x, y, z) = (&value[0], &value[1], &value[2]);
-
-    //     //     if z != zero
-    //     //         && E::defining_equation_projective(&x, &y, &z)
-    //     //             == FieldElement::<E::BaseField>::zero()
-    //     //     {
-    //     //         Ok(Self(ProjectivePoint::new(value)))
-    //     //     // The point at infinity is (0, 1, 0)
-    //     //     } else if x == zero && y == one && z == zero {
-    //     //         Ok(Self(ProjectivePoint::new(value)))
-    //     //     } else {
-    //     //         Err(EllipticCurveError::InvalidPoint)
-    //     //     }
-    //     // }
-    // }
 
     /// Returns the `x` coordinate of the point.
     pub fn x(&self) -> &FieldElement<E::BaseField> {

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -115,7 +115,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         );
         // SAFETY: The values `x_p, y_p, z_p` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        Self::new([xp, yp, zp]).unwrap()
+        unsafe { Self::new([xp, yp, zp]).unwrap_unchecked() }
     }
     // https://hyperelliptic.org/EFD/g1p/data/shortw/projective/addition/madd-1998-cmo
     pub fn operate_with_affine(&self, other: &Self) -> Self {
@@ -134,15 +134,17 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         if u == *py {
             if v != *px || *py == FieldElement::zero() {
                 // SAFETY: The point (0, 1, 0) is defined as the point at infinity.
-                return Self::new([
-                    FieldElement::zero(),
-                    FieldElement::one(),
-                    FieldElement::zero(),
-                ])
-                .unwrap();
-            };
-        } else {
-            return self.double();
+                return unsafe {
+                    Self::new([
+                        FieldElement::zero(),
+                        FieldElement::one(),
+                        FieldElement::zero(),
+                    ])
+                    .unwrap_unchecked()
+                };
+            } else {
+                return self.double();
+            }
         }
 
         let u = &u - py;
@@ -163,7 +165,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         );
         // SAFETY: The values `x, y, z` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        Self::new([x, y, z]).unwrap()
+        unsafe { Self::new([x, y, z]).unwrap_unchecked() }
     }
 }
 
@@ -191,13 +193,14 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
         // SAFETY:
         // - `(0, 1, 0)` is **mathematically valid** as the neutral element.
         // - `unwrap_unchecked()` is safe because this is **a known valid point**.
-
-        Self::new([
-            FieldElement::zero(),
-            FieldElement::one(),
-            FieldElement::zero(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::new([
+                FieldElement::zero(),
+                FieldElement::one(),
+                FieldElement::zero(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 
     fn is_neutral_element(&self) -> bool {
@@ -247,7 +250,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
                 );
                 // SAFETY: The values `x_p, y_p, z_p` are computed correctly to be on the curve.
                 // The assertion above verifies that the resulting point is valid.
-                Self::new([xp, yp, zp]).unwrap()
+                unsafe { Self::new([xp, yp, zp]).unwrap_unchecked() }
             }
         }
     }
@@ -258,7 +261,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
         // SAFETY:
         // - Negating `y` maintains the curve structure.
         // - `unwrap_unchecked()` is safe because negation **is always valid**.
-        Self::new([px.clone(), -py, pz.clone()]).unwrap()
+        unsafe { Self::new([px.clone(), -py, pz.clone()]).unwrap_unchecked() }
     }
 }
 
@@ -496,7 +499,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             );
             // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
             // The assertion above verifies that the resulting point is valid.
-            Self::new([x3, y3, z3]).unwrap()
+            unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
         } else {
             // http://www.hyperelliptic.org/EFD/g1p/data/shortw/jacobian-0/doubling/dbl-2009-alnr
             // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#doubling-dbl-2009-l
@@ -516,7 +519,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             );
             // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
             // The assertion above verifies that the resulting point is valid.
-            Self::new([x3, y3, z3]).unwrap()
+            unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
         }
     }
 
@@ -559,7 +562,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             );
             // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
             // The assertion above verifies that the resulting point is valid.
-            Self::new([x3, y3, z3]).unwrap()
+            unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
         }
     }
 }
@@ -588,13 +591,14 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
         // SAFETY:
         // - `(1, 1, 0)` is **mathematically valid** as the neutral element.
         // - `unwrap_unchecked()` is safe because this is **a known valid point**.
-
-        Self::new([
-            FieldElement::one(),
-            FieldElement::one(),
-            FieldElement::zero(),
-        ])
-        .unwrap()
+        unsafe {
+            Self::new([
+                FieldElement::one(),
+                FieldElement::one(),
+                FieldElement::zero(),
+            ])
+            .unwrap_unchecked()
+        }
     }
 
     fn is_neutral_element(&self) -> bool {
@@ -664,7 +668,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
         );
         // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        Self::new([x3, y3, z3]).unwrap()
+        unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
     }
 
     /// Returns the additive inverse of the jacobian point `p`
@@ -673,7 +677,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
         // SAFETY:
         // - The negation formula for Short Weierstrass curves is well-defined.
         // - The result remains a valid curve point.
-        Self::new([x.clone(), -y, z.clone()]).unwrap()
+        unsafe { Self::new([x.clone(), -y, z.clone()]).unwrap_unchecked() }
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -62,14 +62,6 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         self.0.coordinates()
     }
 
-    /// Creates the same point in affine coordinates. That is,
-    /// returns [x / z: y / z: 1] where `self` is [x: y: z].
-    ///
-    /// # Safety
-    ///
-    /// This function uses an unsafe block to create a new point via [`Self::new`]
-    /// with [`unwrap_unchecked`]. It is safe because a debug assertion verifies that the
-    /// computed coordinates satisfy the curve equation.
     pub fn to_affine(&self) -> Self {
         Self(self.0.to_affine())
     }
@@ -115,7 +107,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         );
         // SAFETY: The values `x_p, y_p, z_p` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        unsafe { Self::new([xp, yp, zp]).unwrap_unchecked() }
+        Self::new([xp, yp, zp]).unwrap()
     }
     // https://hyperelliptic.org/EFD/g1p/data/shortw/projective/addition/madd-1998-cmo
     pub fn operate_with_affine(&self, other: &Self) -> Self {
@@ -134,14 +126,12 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         if u == *py {
             if v != *px || *py == FieldElement::zero() {
                 // SAFETY: The point (0, 1, 0) is defined as the point at infinity.
-                return unsafe {
-                    Self::new([
-                        FieldElement::zero(),
-                        FieldElement::one(),
-                        FieldElement::zero(),
-                    ])
-                    .unwrap_unchecked()
-                };
+                return Self::new([
+                    FieldElement::zero(),
+                    FieldElement::one(),
+                    FieldElement::zero(),
+                ])
+                .unwrap();
             } else {
                 return self.double();
             }
@@ -165,7 +155,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         );
         // SAFETY: The values `x, y, z` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        unsafe { Self::new([x, y, z]).unwrap_unchecked() }
+        Self::new([x, y, z]).unwrap()
     }
 }
 
@@ -193,14 +183,13 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
         // SAFETY:
         // - `(0, 1, 0)` is **mathematically valid** as the neutral element.
         // - `unwrap_unchecked()` is safe because this is **a known valid point**.
-        unsafe {
-            Self::new([
-                FieldElement::zero(),
-                FieldElement::one(),
-                FieldElement::zero(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::new([
+            FieldElement::zero(),
+            FieldElement::one(),
+            FieldElement::zero(),
+        ])
+        .unwrap()
     }
 
     fn is_neutral_element(&self) -> bool {
@@ -250,7 +239,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
                 );
                 // SAFETY: The values `x_p, y_p, z_p` are computed correctly to be on the curve.
                 // The assertion above verifies that the resulting point is valid.
-                unsafe { Self::new([xp, yp, zp]).unwrap_unchecked() }
+                Self::new([xp, yp, zp]).unwrap()
             }
         }
     }
@@ -261,7 +250,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
         // SAFETY:
         // - Negating `y` maintains the curve structure.
         // - `unwrap_unchecked()` is safe because negation **is always valid**.
-        unsafe { Self::new([px.clone(), -py, pz.clone()]).unwrap_unchecked() }
+        Self::new([px.clone(), -py, pz.clone()]).unwrap()
     }
 }
 
@@ -499,7 +488,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             );
             // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
             // The assertion above verifies that the resulting point is valid.
-            unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
+            Self::new([x3, y3, z3]).unwrap()
         } else {
             // http://www.hyperelliptic.org/EFD/g1p/data/shortw/jacobian-0/doubling/dbl-2009-alnr
             // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#doubling-dbl-2009-l
@@ -519,7 +508,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             );
             // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
             // The assertion above verifies that the resulting point is valid.
-            unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
+            Self::new([x3, y3, z3]).unwrap()
         }
     }
 
@@ -562,7 +551,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             );
             // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
             // The assertion above verifies that the resulting point is valid.
-            unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
+            Self::new([x3, y3, z3]).unwrap()
         }
     }
 }
@@ -591,14 +580,13 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
         // SAFETY:
         // - `(1, 1, 0)` is **mathematically valid** as the neutral element.
         // - `unwrap_unchecked()` is safe because this is **a known valid point**.
-        unsafe {
-            Self::new([
-                FieldElement::one(),
-                FieldElement::one(),
-                FieldElement::zero(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::new([
+            FieldElement::one(),
+            FieldElement::one(),
+            FieldElement::zero(),
+        ])
+        .unwrap()
     }
 
     fn is_neutral_element(&self) -> bool {
@@ -668,7 +656,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
         );
         // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
+        Self::new([x3, y3, z3]).unwrap()
     }
 
     /// Returns the additive inverse of the jacobian point `p`
@@ -677,7 +665,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
         // SAFETY:
         // - The negation formula for Short Weierstrass curves is well-defined.
         // - The result remains a valid curve point.
-        unsafe { Self::new([x.clone(), -y, z.clone()]).unwrap_unchecked() }
+        Self::new([x.clone(), -y, z.clone()]).unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -115,7 +115,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         );
         // SAFETY: The values `x_p, y_p, z_p` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        unsafe { Self::new([xp, yp, zp]).unwrap_unchecked() }
+        Self::new([xp, yp, zp]).unwrap()
     }
     // https://hyperelliptic.org/EFD/g1p/data/shortw/projective/addition/madd-1998-cmo
     pub fn operate_with_affine(&self, other: &Self) -> Self {
@@ -134,17 +134,15 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         if u == *py {
             if v != *px || *py == FieldElement::zero() {
                 // SAFETY: The point (0, 1, 0) is defined as the point at infinity.
-                return unsafe {
-                    Self::new([
-                        FieldElement::zero(),
-                        FieldElement::one(),
-                        FieldElement::zero(),
-                    ])
-                    .unwrap_unchecked()
-                };
-            } else {
-                return self.double();
-            }
+                return Self::new([
+                    FieldElement::zero(),
+                    FieldElement::one(),
+                    FieldElement::zero(),
+                ])
+                .unwrap();
+            };
+        } else {
+            return self.double();
         }
 
         let u = &u - py;
@@ -165,7 +163,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         );
         // SAFETY: The values `x, y, z` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        unsafe { Self::new([x, y, z]).unwrap_unchecked() }
+        Self::new([x, y, z]).unwrap()
     }
 }
 
@@ -193,14 +191,13 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
         // SAFETY:
         // - `(0, 1, 0)` is **mathematically valid** as the neutral element.
         // - `unwrap_unchecked()` is safe because this is **a known valid point**.
-        unsafe {
-            Self::new([
-                FieldElement::zero(),
-                FieldElement::one(),
-                FieldElement::zero(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::new([
+            FieldElement::zero(),
+            FieldElement::one(),
+            FieldElement::zero(),
+        ])
+        .unwrap()
     }
 
     fn is_neutral_element(&self) -> bool {
@@ -250,7 +247,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
                 );
                 // SAFETY: The values `x_p, y_p, z_p` are computed correctly to be on the curve.
                 // The assertion above verifies that the resulting point is valid.
-                unsafe { Self::new([xp, yp, zp]).unwrap_unchecked() }
+                Self::new([xp, yp, zp]).unwrap()
             }
         }
     }
@@ -261,7 +258,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
         // SAFETY:
         // - Negating `y` maintains the curve structure.
         // - `unwrap_unchecked()` is safe because negation **is always valid**.
-        unsafe { Self::new([px.clone(), -py, pz.clone()]).unwrap_unchecked() }
+        Self::new([px.clone(), -py, pz.clone()]).unwrap()
     }
 }
 
@@ -499,7 +496,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             );
             // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
             // The assertion above verifies that the resulting point is valid.
-            unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
+            Self::new([x3, y3, z3]).unwrap()
         } else {
             // http://www.hyperelliptic.org/EFD/g1p/data/shortw/jacobian-0/doubling/dbl-2009-alnr
             // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#doubling-dbl-2009-l
@@ -519,7 +516,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             );
             // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
             // The assertion above verifies that the resulting point is valid.
-            unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
+            Self::new([x3, y3, z3]).unwrap()
         }
     }
 
@@ -562,7 +559,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             );
             // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
             // The assertion above verifies that the resulting point is valid.
-            unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
+            Self::new([x3, y3, z3]).unwrap()
         }
     }
 }
@@ -591,14 +588,13 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
         // SAFETY:
         // - `(1, 1, 0)` is **mathematically valid** as the neutral element.
         // - `unwrap_unchecked()` is safe because this is **a known valid point**.
-        unsafe {
-            Self::new([
-                FieldElement::one(),
-                FieldElement::one(),
-                FieldElement::zero(),
-            ])
-            .unwrap_unchecked()
-        }
+
+        Self::new([
+            FieldElement::one(),
+            FieldElement::one(),
+            FieldElement::zero(),
+        ])
+        .unwrap()
     }
 
     fn is_neutral_element(&self) -> bool {
@@ -668,7 +664,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
         );
         // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
+        Self::new([x3, y3, z3]).unwrap()
     }
 
     /// Returns the additive inverse of the jacobian point `p`
@@ -677,7 +673,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
         // SAFETY:
         // - The negation formula for Short Weierstrass curves is well-defined.
         // - The result remains a valid curve point.
-        unsafe { Self::new([x.clone(), -y, z.clone()]).unwrap_unchecked() }
+        Self::new([x.clone(), -y, z.clone()]).unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -24,7 +24,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         let (x, y, z) = (&value[0], &value[1], &value[2]);
 
         if z != &FieldElement::<E::BaseField>::zero()
-            && E::defining_equation_projective(&x, &y, &z) == FieldElement::<E::BaseField>::zero()
+            && E::defining_equation_projective(x, y, z) == FieldElement::<E::BaseField>::zero()
         {
             Ok(Self(ProjectivePoint::new(value)))
         // The point at infinity is (0, 1, 0)
@@ -173,7 +173,7 @@ impl<E: IsShortWeierstrass> FromAffine<E::BaseField> for ShortWeierstrassProject
         y: FieldElement<E::BaseField>,
     ) -> Result<Self, EllipticCurveError> {
         let coordinates = [x, y, FieldElement::one()];
-        Ok(ShortWeierstrassProjectivePoint::new(coordinates)?)
+        ShortWeierstrassProjectivePoint::new(coordinates)
     }
 }
 
@@ -408,16 +408,11 @@ pub struct ShortWeierstrassJacobianPoint<E: IsEllipticCurve>(pub JacobianPoint<E
 
 impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
     /// Creates an elliptic curve point giving the jacobian [x: y: z] coordinates.
-    // pub const fn new(value: [FieldElement<E::BaseField>; 3]) -> Self {
-    //     Self(JacobianPoint::new(value))
-    // }
-
-    /// Creates an elliptic curve point giving the jacobian [x: y: z] coordinates.
     pub fn new(value: [FieldElement<E::BaseField>; 3]) -> Result<Self, EllipticCurveError> {
         let (x, y, z) = (&value[0], &value[1], &value[2]);
 
         if z != &FieldElement::<E::BaseField>::zero()
-            && E::defining_equation_jacobian(&x, &y, &z) == FieldElement::<E::BaseField>::zero()
+            && E::defining_equation_jacobian(x, y, z) == FieldElement::<E::BaseField>::zero()
         {
             Ok(Self(JacobianPoint::new(value)))
         // The point at infinity is (1, 1, 0)
@@ -562,7 +557,7 @@ impl<E: IsShortWeierstrass> FromAffine<E::BaseField> for ShortWeierstrassJacobia
         y: FieldElement<E::BaseField>,
     ) -> Result<Self, EllipticCurveError> {
         let coordinates = [x, y, FieldElement::one()];
-        Ok(ShortWeierstrassJacobianPoint::new(coordinates)?)
+        ShortWeierstrassJacobianPoint::new(coordinates)
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -494,7 +494,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             let z3 = (y1 + z1).square() - &yy - &zz; // Z3 = (Y1 + Z1)^2 - YY - ZZ
 
             debug_assert_eq!(
-                E::defining_equation_projective(&x3, &y3, &z3),
+                E::defining_equation_jacobian(&x3, &y3, &z3),
                 FieldElement::<E::BaseField>::zero()
             );
             unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
@@ -535,7 +535,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
             let z3 = z1 * &h;
 
             debug_assert_eq!(
-                E::defining_equation_projective(&x3, &y3, &z3),
+                E::defining_equation_jacobian(&x3, &y3, &z3),
                 FieldElement::<E::BaseField>::zero()
             );
             unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -64,7 +64,12 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
 
     /// Creates the same point in affine coordinates. That is,
     /// returns [x / z: y / z: 1] where `self` is [x: y: z].
-    /// Panics if `self` is the point at infinity.
+    ///
+    /// # Safety
+    ///
+    /// This function uses an unsafe block to create a new point via [`Self::new`]
+    /// with [`unwrap_unchecked`]. It is safe because a debug assertion verifies that the
+    /// computed coordinates satisfy the curve equation.
     pub fn to_affine(&self) -> Self {
         Self(self.0.to_affine())
     }
@@ -108,6 +113,8 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
             E::defining_equation_projective(&xp, &yp, &zp),
             FieldElement::<E::BaseField>::zero()
         );
+        // SAFETY: The values `x_p, y_p, z_p` are computed correctly to be on the curve.
+        // The assertion above verifies that the resulting point is valid.
         unsafe { Self::new([xp, yp, zp]).unwrap_unchecked() }
     }
     // https://hyperelliptic.org/EFD/g1p/data/shortw/projective/addition/madd-1998-cmo
@@ -126,6 +133,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
 
         if u == *py {
             if v != *px || *py == FieldElement::zero() {
+                // SAFETY: The point (0, 1, 0) is defined as the point at infinity.
                 return unsafe {
                     Self::new([
                         FieldElement::zero(),
@@ -155,6 +163,8 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
             E::defining_equation_projective(&x, &y, &z),
             FieldElement::<E::BaseField>::zero()
         );
+        // SAFETY: The values `x, y, z` are computed correctly to be on the curve.
+        // The assertion above verifies that the resulting point is valid.
         unsafe { Self::new([x, y, z]).unwrap_unchecked() }
     }
 }
@@ -180,6 +190,9 @@ impl<E: IsShortWeierstrass> FromAffine<E::BaseField> for ShortWeierstrassProject
 impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
     /// The point at infinity.
     fn neutral_element() -> Self {
+        // SAFETY:
+        // - `(0, 1, 0)` is **mathematically valid** as the neutral element.
+        // - `unwrap_unchecked()` is safe because this is **a known valid point**.
         unsafe {
             Self::new([
                 FieldElement::zero(),
@@ -235,6 +248,8 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
                     E::defining_equation_projective(&xp, &yp, &zp),
                     FieldElement::<E::BaseField>::zero()
                 );
+                // SAFETY: The values `x_p, y_p, z_p` are computed correctly to be on the curve.
+                // The assertion above verifies that the resulting point is valid.
                 unsafe { Self::new([xp, yp, zp]).unwrap_unchecked() }
             }
         }
@@ -243,6 +258,9 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassProjectivePoint<E> {
     /// Returns the additive inverse of the projective point `p`
     fn neg(&self) -> Self {
         let [px, py, pz] = self.coordinates();
+        // SAFETY:
+        // - Negating `y` maintains the curve structure.
+        // - `unwrap_unchecked()` is safe because negation **is always valid**.
         unsafe { Self::new([px.clone(), -py, pz.clone()]).unwrap_unchecked() }
     }
 }
@@ -479,6 +497,8 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
                 E::defining_equation_jacobian(&x3, &y3, &z3),
                 FieldElement::<E::BaseField>::zero()
             );
+            // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
+            // The assertion above verifies that the resulting point is valid.
             unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
         } else {
             // http://www.hyperelliptic.org/EFD/g1p/data/shortw/jacobian-0/doubling/dbl-2009-alnr
@@ -497,6 +517,8 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
                 E::defining_equation_jacobian(&x3, &y3, &z3),
                 FieldElement::<E::BaseField>::zero()
             );
+            // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
+            // The assertion above verifies that the resulting point is valid.
             unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
         }
     }
@@ -538,6 +560,8 @@ impl<E: IsShortWeierstrass> ShortWeierstrassJacobianPoint<E> {
                 E::defining_equation_jacobian(&x3, &y3, &z3),
                 FieldElement::<E::BaseField>::zero()
             );
+            // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
+            // The assertion above verifies that the resulting point is valid.
             unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
         }
     }
@@ -564,6 +588,9 @@ impl<E: IsShortWeierstrass> FromAffine<E::BaseField> for ShortWeierstrassJacobia
 impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
     /// The point at infinity.
     fn neutral_element() -> Self {
+        // SAFETY:
+        // - `(1, 1, 0)` is **mathematically valid** as the neutral element.
+        // - `unwrap_unchecked()` is safe because this is **a known valid point**.
         unsafe {
             Self::new([
                 FieldElement::one(),
@@ -639,12 +666,17 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
             E::defining_equation_jacobian(&x3, &y3, &z3),
             FieldElement::<E::BaseField>::zero()
         );
+        // SAFETY: The values `x_3, y_3, z_3` are computed correctly to be on the curve.
+        // The assertion above verifies that the resulting point is valid.
         unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }
     }
 
     /// Returns the additive inverse of the jacobian point `p`
     fn neg(&self) -> Self {
         let [x, y, z] = self.coordinates();
+        // SAFETY:
+        // - The negation formula for Short Weierstrass curves is well-defined.
+        // - The result remains a valid curve point.
         unsafe { Self::new([x.clone(), -y, z.clone()]).unwrap_unchecked() }
     }
 }

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -636,7 +636,7 @@ impl<E: IsShortWeierstrass> IsGroup for ShortWeierstrassJacobianPoint<E> {
         let z3 = z3.double() * h;
 
         debug_assert_eq!(
-            E::defining_equation_projective(&x3, &y3, &z3),
+            E::defining_equation_jacobian(&x3, &y3, &z3),
             FieldElement::<E::BaseField>::zero()
         );
         unsafe { Self::new([x3, y3, z3]).unwrap_unchecked() }

--- a/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -15,6 +15,7 @@ use super::traits::IsShortWeierstrass;
 use crate::traits::AsBytes;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+
 #[derive(Clone, Debug)]
 pub struct ShortWeierstrassProjectivePoint<E: IsEllipticCurve>(pub ProjectivePoint<E>);
 
@@ -107,7 +108,9 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         );
         // SAFETY: The values `x_p, y_p, z_p` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        Self::new([xp, yp, zp]).unwrap()
+        let point = Self::new([xp, yp, zp]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
     // https://hyperelliptic.org/EFD/g1p/data/shortw/projective/addition/madd-1998-cmo
     pub fn operate_with_affine(&self, other: &Self) -> Self {
@@ -155,7 +158,9 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         );
         // SAFETY: The values `x, y, z` are computed correctly to be on the curve.
         // The assertion above verifies that the resulting point is valid.
-        Self::new([x, y, z]).unwrap()
+        let point = Self::new([x, y, z]);
+        debug_assert!(point.is_ok());
+        point.unwrap()
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/traits.rs
+++ b/math/src/elliptic_curve/short_weierstrass/traits.rs
@@ -29,14 +29,14 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
         y.square() * z - ((x.square() + Self::a() * z.square()) * x + Self::b() * z.square() * z)
     }
 
-    // Evaluates the projective equation:
-    // y^2 * z^2 = x^3 + a * x * z^4 + b * z^6
+    // Evaluates the jacobian equation:
+    // y^2  = x^3 + a * x * z^4 + b * z^6
     fn defining_equation_jacobian(
         x: &FieldElement<Self::BaseField>,
         y: &FieldElement<Self::BaseField>,
         z: &FieldElement<Self::BaseField>,
     ) -> FieldElement<Self::BaseField> {
-        y.square() * z.square()
+        y.square()
             - ((x.square() + Self::a() * z.square().square()) * x
                 + Self::b() * z.square().square() * z.square())
     }

--- a/math/src/elliptic_curve/short_weierstrass/traits.rs
+++ b/math/src/elliptic_curve/short_weierstrass/traits.rs
@@ -18,6 +18,16 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
     ) -> FieldElement<Self::BaseField> {
         y.square() - ((x.square() + Self::a()) * x + Self::b())
     }
+
+    // Evaluates the projective equation:
+    // y^2 * z = x^3 + a * x * z^2 + b * z^3
+    fn defining_equation_projective(
+        x: &FieldElement<Self::BaseField>,
+        y: &FieldElement<Self::BaseField>,
+        z: &FieldElement<Self::BaseField>,
+    ) -> FieldElement<Self::BaseField> {
+        y.square() * z - ((x.square() + Self::a() * z.square()) * x + Self::b() * z.square() * z)
+    }
 }
 
 pub trait Compress {

--- a/math/src/elliptic_curve/short_weierstrass/traits.rs
+++ b/math/src/elliptic_curve/short_weierstrass/traits.rs
@@ -20,13 +20,25 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
     }
 
     // Evaluates the projective equation:
-    // y^2 * z = x^3 + a * x * z^2 + b * z^3 
+    // y^2 * z = x^3 + a * x * z^2 + b * z^3
     fn defining_equation_projective(
         x: &FieldElement<Self::BaseField>,
         y: &FieldElement<Self::BaseField>,
         z: &FieldElement<Self::BaseField>,
     ) -> FieldElement<Self::BaseField> {
         y.square() * z - ((x.square() + Self::a() * z.square()) * x + Self::b() * z.square() * z)
+    }
+
+    // Evaluates the projective equation:
+    // y^2 * z^2 = x^3 + a * x * z^4 + b * z^6
+    fn defining_equation_jacobian(
+        x: &FieldElement<Self::BaseField>,
+        y: &FieldElement<Self::BaseField>,
+        z: &FieldElement<Self::BaseField>,
+    ) -> FieldElement<Self::BaseField> {
+        y.square() * z.square()
+            - ((x.square() + Self::a() * z.square().square()) * x
+                + Self::b() * z.square().square() * z.square())
     }
 }
 

--- a/math/src/elliptic_curve/short_weierstrass/traits.rs
+++ b/math/src/elliptic_curve/short_weierstrass/traits.rs
@@ -20,7 +20,7 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
     }
 
     // Evaluates the projective equation:
-    // y^2 * z = x^3 + a * x * z^2 + b * z^3
+    // y^2 * z = x^3 + a * x * z^2 + b * z^3 
     fn defining_equation_projective(
         x: &FieldElement<Self::BaseField>,
         y: &FieldElement<Self::BaseField>,


### PR DESCRIPTION
# Change elliptic curve new point function

## Description

This PR changes the function `new` for every elliptic curve in Lambdaworks. In the previous version, this function creates a new curve point but doesn't check if it satisfies the curve equation. In this PR the function checks if the point is valid returning a `Result`.


