### PR TITLE
Add extension degree const to isField trait

### DIFF
--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/field_extension.rs
@@ -29,6 +29,9 @@ pub struct Degree2ExtensionField;
 
 impl IsField for Degree2ExtensionField {
     type BaseType = [FieldElement<BLS12377PrimeField>; 2];
+
+    const EXTENSION_DEGREE: usize = 2;
+
     /// Returns the component wise addition of `a` and `b`
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         [&a[0] + &b[0], &a[1] + &b[1]]

--- a/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs
@@ -30,6 +30,8 @@ pub struct Degree2ExtensionField;
 impl IsField for Degree2ExtensionField {
     type BaseType = [FieldElement<BLS12381PrimeField>; 2];
 
+    const EXTENSION_DEGREE: usize = 2;
+
     /// Returns the component wise addition of `a` and `b`
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         [&a[0] + &b[0], &a[1] + &b[1]]

--- a/math/src/elliptic_curve/short_weierstrass/curves/bn_254/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bn_254/field_extension.rs
@@ -35,6 +35,8 @@ type Fp2E = FieldElement<Degree2ExtensionField>;
 impl IsField for Degree2ExtensionField {
     type BaseType = [FieldElement<BN254PrimeField>; 2];
 
+    const EXTENSION_DEGREE: usize = 2;
+
     /// Returns the component wise addition of `a` and `b`
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         [&a[0] + &b[0], &a[1] + &b[1]]

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -62,6 +62,8 @@ where
 {
     type BaseType = [FieldElement<F>; 3];
 
+    const EXTENSION_DEGREE: usize = 3;
+
     /// Returns the component wise addition of `a` and `b`
     fn add(a: &[FieldElement<F>; 3], b: &[FieldElement<F>; 3]) -> [FieldElement<F>; 3] {
         [&a[0] + &b[0], &a[1] + &b[1], &a[2] + &b[2]]

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -75,6 +75,8 @@ where
 {
     type BaseType = [FieldElement<F>; 2];
 
+    const EXTENSION_DEGREE: usize = 2;
+
     /// Returns the component wise addition of `a` and `b`
     fn add(a: &[FieldElement<F>; 2], b: &[FieldElement<F>; 2]) -> [FieldElement<F>; 2] {
         [&a[0] + &b[0], &a[1] + &b[1]]

--- a/math/src/field/fields/fft_friendly/quartic_babybear.rs
+++ b/math/src/field/fields/fft_friendly/quartic_babybear.rs
@@ -22,6 +22,8 @@ pub struct Degree4BabyBearExtensionField;
 impl IsField for Degree4BabyBearExtensionField {
     type BaseType = [FieldElement<Babybear31PrimeField>; 4];
 
+    const EXTENSION_DEGREE: usize = 4;
+
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         [&a[0] + &b[0], &a[1] + &b[1], &a[2] + &b[2], &a[3] + &b[3]]
     }

--- a/math/src/field/fields/fft_friendly/quartic_babybear_u32.rs
+++ b/math/src/field/fields/fft_friendly/quartic_babybear_u32.rs
@@ -26,6 +26,8 @@ pub struct Degree4BabyBearU32ExtensionField;
 impl IsField for Degree4BabyBearU32ExtensionField {
     type BaseType = [FieldElement<Babybear31PrimeField>; 4];
 
+    const EXTENSION_DEGREE: usize = 4;
+
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         [a[0] + b[0], a[1] + b[1], a[2] + b[2], a[3] + b[3]]
     }

--- a/math/src/field/fields/mersenne31/extensions.rs
+++ b/math/src/field/fields/mersenne31/extensions.rs
@@ -27,6 +27,8 @@ impl IsField for Degree2ExtensionField {
     //Element representation: a[0] = real part, a[1] = imaginary part
     type BaseType = [FpE; 2];
 
+    const EXTENSION_DEGREE: usize = 2;
+
     /// Returns the component wise addition of `a` and `b`
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         [a[0] + b[0], a[1] + b[1]]
@@ -148,6 +150,8 @@ impl Degree4ExtensionField {
 
 impl IsField for Degree4ExtensionField {
     type BaseType = [Fp2E; 2];
+
+    const EXTENSION_DEGREE: usize = 4;
 
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         [&a[0] + &b[0], &a[1] + &b[1]]

--- a/math/src/field/fields/mersenne31/field.rs
+++ b/math/src/field/fields/mersenne31/field.rs
@@ -75,6 +75,8 @@ pub const MERSENNE_31_PRIME_FIELD_ORDER: u32 = (1 << 31) - 1;
 impl IsField for Mersenne31Field {
     type BaseType = u32;
 
+    const EXTENSION_DEGREE: usize = 1;
+
     /// Returns the sum of `a` and `b`.
     fn add(a: &u32, b: &u32) -> u32 {
         // We are using that if a and b are field elements of Mersenne31, then

--- a/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -117,6 +117,8 @@ where
 {
     type BaseType = UnsignedInteger<NUM_LIMBS>;
 
+    const EXTENSION_DEGREE: usize = 1;
+
     #[inline(always)]
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         let (sum, overflow) = UnsignedInteger::add(a, b);

--- a/math/src/field/fields/p448_goldilocks_prime_field.rs
+++ b/math/src/field/fields/p448_goldilocks_prime_field.rs
@@ -51,6 +51,8 @@ impl ByteConversion for U56x8 {
 impl IsField for P448GoldilocksPrimeField {
     type BaseType = U56x8;
 
+    const EXTENSION_DEGREE: usize = 1;
+
     fn add(a: &U56x8, b: &U56x8) -> U56x8 {
         let mut limbs = [0u64; 8];
         for (i, limb) in limbs.iter_mut().enumerate() {

--- a/math/src/field/fields/u32_montgomery_backend_prime_field.rs
+++ b/math/src/field/fields/u32_montgomery_backend_prime_field.rs
@@ -90,6 +90,8 @@ impl<const MODULUS: u32> U32MontgomeryBackendPrimeField<MODULUS> {
 impl<const MODULUS: u32> IsField for U32MontgomeryBackendPrimeField<MODULUS> {
     type BaseType = u32;
 
+    const EXTENSION_DEGREE: usize = 1;
+
     #[inline(always)]
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
         let mut sum = a + b;

--- a/math/src/field/fields/u64_goldilocks_field.rs
+++ b/math/src/field/fields/u64_goldilocks_field.rs
@@ -55,6 +55,8 @@ impl ByteConversion for u64 {
 impl IsField for Goldilocks64Field {
     type BaseType = u64;
 
+    const EXTENSION_DEGREE: usize = 1;
+
     fn add(a: &u64, b: &u64) -> u64 {
         let (sum, over) = a.overflowing_add(*b);
         let (mut sum, over) = sum.overflowing_add(u64::from(over) * Self::NEG_ORDER);

--- a/math/src/field/fields/u64_prime_field.rs
+++ b/math/src/field/fields/u64_prime_field.rs
@@ -23,6 +23,8 @@ impl IsFFTField for F17 {
 impl<const MODULUS: u64> IsField for U64PrimeField<MODULUS> {
     type BaseType = u64;
 
+    const EXTENSION_DEGREE: usize = 1;
+
     fn add(a: &u64, b: &u64) -> u64 {
         ((*a as u128 + *b as u128) % MODULUS as u128) as u64
     }

--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -41,6 +41,8 @@ impl ByteConversion for u32 {
 impl<const MODULUS: u32> IsField for U32Field<MODULUS> {
     type BaseType = u32;
 
+    const EXTENSION_DEGREE: usize = 1;
+    
     fn add(a: &u32, b: &u32) -> u32 {
         ((*a as u128 + *b as u128) % MODULUS as u128) as u32
     }

--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -42,7 +42,7 @@ impl<const MODULUS: u32> IsField for U32Field<MODULUS> {
     type BaseType = u32;
 
     const EXTENSION_DEGREE: usize = 1;
-    
+
     fn add(a: &u32, b: &u32) -> u32 {
         ((*a as u128 + *b as u128) % MODULUS as u128) as u32
     }

--- a/math/src/field/test_fields/u64_test_field.rs
+++ b/math/src/field/test_fields/u64_test_field.rs
@@ -14,6 +14,8 @@ pub struct U64Field<const MODULUS: u64>;
 impl<const MODULUS: u64> IsField for U64Field<MODULUS> {
     type BaseType = u64;
 
+    const EXTENSION_DEGREE: usize = 1;
+
     fn add(a: &u64, b: &u64) -> u64 {
         ((*a as u128 + *b as u128) % MODULUS as u128) as u64
     }

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -103,6 +103,8 @@ pub trait IsField: Debug + Clone {
     #[cfg(not(feature = "lambdaworks-serde-binary"))]
     type BaseType: Clone + Debug + Unpin + Default;
 
+    const EXTENSION_DEGREE: usize;
+
     /// Returns the sum of `a` and `b`.
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType;
 

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -103,6 +103,7 @@ pub trait IsField: Debug + Clone {
     #[cfg(not(feature = "lambdaworks-serde-binary"))]
     type BaseType: Clone + Debug + Unpin + Default;
 
+    // Defines the degree of an extension; set to 1 when it is not an extension.
     const EXTENSION_DEGREE: usize;
 
     /// Returns the sum of `a` and `b`.


### PR DESCRIPTION
This PR adds a constant to the `isField` trait to determine the degree of an extension. In cases where it is not an extension, we define it as degree 1.
