### PR TITLE
Remove feature serde binary for field element base type

### DIFF
--- a/math/src/circle/cosets.rs
+++ b/math/src/circle/cosets.rs
@@ -1,6 +1,7 @@
 extern crate alloc;
 use crate::circle::point::CirclePoint;
 use crate::field::fields::mersenne31::field::Mersenne31Field;
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 /// Given g_n, a generator of the subgroup of size n of the circle, i.e. <g_n>,

--- a/math/src/circle/polynomial.rs
+++ b/math/src/circle/polynomial.rs
@@ -9,6 +9,7 @@ use crate::{
     fft::cpu::bit_reversing::in_place_bit_reverse_permute,
     field::{element::FieldElement, fields::mersenne31::field::Mersenne31Field},
 };
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 /// Given the 2^n coefficients of a two-variables polynomial of degree 2^n - 1 in the basis {1, y, x, xy, 2xˆ2 -1, 2xˆ2y-y, 2xˆ3-x, 2xˆ3y-xy,...}

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -1,6 +1,7 @@
 use crate::errors::CreationError;
 use crate::field::errors::FieldError;
 use crate::field::traits::IsField;
+#[cfg(feature = "lambdaworks-serde-binary")]
 use crate::traits::ByteConversion;
 use crate::unsigned_integer::element::UnsignedInteger;
 use crate::unsigned_integer::montgomery::MontgomeryAlgorithms;

--- a/math/src/field/element.rs
+++ b/math/src/field/element.rs
@@ -1,7 +1,6 @@
 use crate::errors::CreationError;
 use crate::field::errors::FieldError;
 use crate::field::traits::IsField;
-#[cfg(feature = "lambdaworks-serde-binary")]
 use crate::traits::ByteConversion;
 use crate::unsigned_integer::element::UnsignedInteger;
 use crate::unsigned_integer::montgomery::MontgomeryAlgorithms;

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -1,7 +1,6 @@
 use crate::field::element::FieldElement;
 use crate::field::errors::FieldError;
 use crate::field::traits::{IsField, IsSubFieldOf};
-#[cfg(feature = "lambdaworks-serde-binary")]
 use crate::traits::ByteConversion;
 use core::fmt::Debug;
 use core::marker::PhantomData;

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -24,7 +24,6 @@ pub trait HasCubicNonResidue<F: IsField> {
     fn residue() -> FieldElement<F>;
 }
 
-#[cfg(feature = "lambdaworks-serde-binary")]
 impl<F> ByteConversion for [FieldElement<F>; 3]
 where
     F: IsField,

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -1,7 +1,6 @@
 use crate::field::element::FieldElement;
 use crate::field::errors::FieldError;
 use crate::field::traits::{IsField, IsSubFieldOf};
-#[cfg(feature = "lambdaworks-serde-binary")]
 use crate::traits::ByteConversion;
 use core::fmt::Debug;
 use core::marker::PhantomData;

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -37,7 +37,6 @@ where
     }
 }
 
-#[cfg(feature = "lambdaworks-serde-binary")]
 impl<F> ByteConversion for [FieldElement<F>; 2]
 where
     F: IsField,

--- a/math/src/field/fields/fft_friendly/quartic_babybear.rs
+++ b/math/src/field/fields/fft_friendly/quartic_babybear.rs
@@ -5,7 +5,6 @@ use crate::field::{
     traits::{IsFFTField, IsField, IsSubFieldOf},
 };
 
-#[cfg(feature = "lambdaworks-serde-binary")]
 use crate::traits::ByteConversion;
 
 #[cfg(all(feature = "lambdaworks-serde-binary", feature = "alloc"))]

--- a/math/src/field/fields/fft_friendly/quartic_babybear.rs
+++ b/math/src/field/fields/fft_friendly/quartic_babybear.rs
@@ -7,7 +7,7 @@ use crate::field::{
 
 use crate::traits::ByteConversion;
 
-#[cfg(all(feature = "lambdaworks-serde-binary", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use crate::traits::AsBytes;
 
 /// We are implementig the extension of Baby Bear of degree 4 using the irreducible polynomial x^4 + 11.
@@ -219,7 +219,6 @@ impl IsSubFieldOf<Degree4BabyBearExtensionField> for Babybear31PrimeField {
     }
 }
 
-#[cfg(feature = "lambdaworks-serde-binary")]
 impl ByteConversion for [FieldElement<Babybear31PrimeField>; 4] {
     #[cfg(feature = "alloc")]
     fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {
@@ -268,8 +267,8 @@ impl ByteConversion for [FieldElement<Babybear31PrimeField>; 4] {
     }
 }
 
-#[cfg(feature = "lambdaworks-serde-binary")]
 impl ByteConversion for FieldElement<Degree4BabyBearExtensionField> {
+    #[cfg(feature = "alloc")]
     fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {
         let mut byte_slice = ByteConversion::to_bytes_be(&self.value()[0]);
         byte_slice.extend(ByteConversion::to_bytes_be(&self.value()[1]));
@@ -278,6 +277,7 @@ impl ByteConversion for FieldElement<Degree4BabyBearExtensionField> {
         byte_slice
     }
 
+    #[cfg(feature = "alloc")]
     fn to_bytes_le(&self) -> alloc::vec::Vec<u8> {
         let mut byte_slice = ByteConversion::to_bytes_le(&self.value()[0]);
         byte_slice.extend(ByteConversion::to_bytes_le(&self.value()[1]));
@@ -313,7 +313,6 @@ impl ByteConversion for FieldElement<Degree4BabyBearExtensionField> {
     }
 }
 
-#[cfg(feature = "lambdaworks-serde-binary")]
 #[cfg(feature = "alloc")]
 impl AsBytes for FieldElement<Degree4BabyBearExtensionField> {
     fn as_bytes(&self) -> alloc::vec::Vec<u8> {

--- a/math/src/field/fields/fft_friendly/quartic_babybear_u32.rs
+++ b/math/src/field/fields/fft_friendly/quartic_babybear_u32.rs
@@ -5,10 +5,9 @@ use crate::field::{
     traits::{IsFFTField, IsField, IsSubFieldOf},
 };
 
-#[cfg(all(feature = "lambdaworks-serde-binary", feature = "alloc"))]
 use crate::traits::ByteConversion;
 
-#[cfg(all(feature = "lambdaworks-serde-binary", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use crate::traits::AsBytes;
 
 /// We are implementig the extension of Baby Bear of degree 4 using the irreducible polynomial x^4 + 11.
@@ -221,7 +220,6 @@ impl IsSubFieldOf<Degree4BabyBearU32ExtensionField> for Babybear31PrimeField {
     }
 }
 
-#[cfg(feature = "lambdaworks-serde-binary")]
 impl ByteConversion for [FieldElement<Babybear31PrimeField>; 4] {
     #[cfg(feature = "alloc")]
     fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {
@@ -269,8 +267,7 @@ impl ByteConversion for [FieldElement<Babybear31PrimeField>; 4] {
         Ok([x0, x1, x2, x3])
     }
 }
-#[cfg(feature = "lambdaworks-serde-binary")]
-#[cfg(feature = "alloc")]
+
 impl ByteConversion for FieldElement<Degree4BabyBearU32ExtensionField> {
     #[cfg(feature = "alloc")]
     fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {
@@ -316,7 +313,6 @@ impl ByteConversion for FieldElement<Degree4BabyBearU32ExtensionField> {
     }
 }
 
-#[cfg(feature = "lambdaworks-serde-binary")]
 #[cfg(feature = "alloc")]
 impl AsBytes for FieldElement<Degree4BabyBearU32ExtensionField> {
     fn as_bytes(&self) -> alloc::vec::Vec<u8> {
@@ -461,28 +457,28 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "alloc", feature = "lambdaworks-serde-binary"))]
+    #[cfg(feature = "alloc")]
     fn to_bytes_from_bytes_be_is_the_identity() {
         let x = Fp4E::new([FpE::from(2), FpE::from(4), FpE::from(6), FpE::from(8)]);
         assert_eq!(Fp4E::from_bytes_be(&x.to_bytes_be()).unwrap(), x);
     }
 
     #[test]
-    #[cfg(all(feature = "alloc", feature = "lambdaworks-serde-binary"))]
+    #[cfg(feature = "alloc")]
     fn from_bytes_to_bytes_be_is_the_identity() {
         let bytes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         assert_eq!(Fp4E::from_bytes_be(&bytes).unwrap().to_bytes_be(), bytes);
     }
 
     #[test]
-    #[cfg(all(feature = "alloc", feature = "lambdaworks-serde-binary"))]
+    #[cfg(feature = "alloc")]
     fn to_bytes_from_bytes_le_is_the_identity() {
         let x = Fp4E::new([FpE::from(2), FpE::from(4), FpE::from(6), FpE::from(8)]);
         assert_eq!(Fp4E::from_bytes_le(&x.to_bytes_le()).unwrap(), x);
     }
 
     #[test]
-    #[cfg(all(feature = "alloc", feature = "lambdaworks-serde-binary"))]
+    #[cfg(feature = "alloc")]
     fn from_bytes_to_bytes_le_is_the_identity() {
         let bytes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         assert_eq!(Fp4E::from_bytes_le(&bytes).unwrap().to_bytes_le(), bytes);

--- a/math/src/field/fields/p448_goldilocks_prime_field.rs
+++ b/math/src/field/fields/p448_goldilocks_prime_field.rs
@@ -20,7 +20,6 @@ pub struct U56x8 {
     limbs: [u64; 8],
 }
 
-#[cfg(feature = "lambdaworks-serde-binary")]
 impl ByteConversion for U56x8 {
     #[cfg(feature = "alloc")]
     fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {

--- a/math/src/field/fields/p448_goldilocks_prime_field.rs
+++ b/math/src/field/fields/p448_goldilocks_prime_field.rs
@@ -1,7 +1,6 @@
 use crate::errors::CreationError;
 use crate::field::errors::FieldError;
 use crate::field::traits::{IsField, IsPrimeField};
-#[cfg(feature = "lambdaworks-serde-binary")]
 use crate::traits::ByteConversion;
 use crate::unsigned_integer::element::UnsignedInteger;
 

--- a/math/src/field/fields/u64_goldilocks_field.rs
+++ b/math/src/field/fields/u64_goldilocks_field.rs
@@ -1,6 +1,5 @@
 use core::fmt::{self, Display};
 
-#[cfg(feature = "lambdaworks-serde-binary")]
 use crate::traits::ByteConversion;
 use crate::{
     errors::CreationError,

--- a/math/src/field/fields/u64_goldilocks_field.rs
+++ b/math/src/field/fields/u64_goldilocks_field.rs
@@ -21,7 +21,6 @@ impl Goldilocks64Field {
     pub const NEG_ORDER: u64 = Self::ORDER.wrapping_neg();
 }
 
-#[cfg(feature = "lambdaworks-serde-binary")]
 impl ByteConversion for u64 {
     #[cfg(feature = "alloc")]
     fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {

--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -10,7 +10,6 @@ use crate::traits::ByteConversion;
 
 pub struct U32Field<const MODULUS: u32>;
 
-#[cfg(feature = "lambdaworks-serde-binary")]
 impl ByteConversion for u32 {
     #[cfg(feature = "alloc")]
     fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {

--- a/math/src/field/test_fields/u32_test_field.rs
+++ b/math/src/field/test_fields/u32_test_field.rs
@@ -4,7 +4,6 @@ use crate::{
     field::traits::{IsFFTField, IsField, IsPrimeField},
 };
 
-#[cfg(feature = "lambdaworks-serde-binary")]
 use crate::traits::ByteConversion;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -1,5 +1,4 @@
 use super::{element::FieldElement, errors::FieldError};
-#[cfg(feature = "lambdaworks-serde-binary")]
 use crate::traits::ByteConversion;
 use crate::{errors::CreationError, unsigned_integer::traits::IsUnsignedInteger};
 use core::fmt::Debug;
@@ -98,10 +97,7 @@ pub trait IsFFTField: IsField {
 pub trait IsField: Debug + Clone {
     /// The underlying base type for representing elements from the field.
     // TODO: Relax Unpin for non cuda usage
-    #[cfg(feature = "lambdaworks-serde-binary")]
     type BaseType: Clone + Debug + Unpin + ByteConversion + Default;
-    #[cfg(not(feature = "lambdaworks-serde-binary"))]
-    type BaseType: Clone + Debug + Unpin + Default;
 
     /// Returns the sum of `a` and `b`.
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType;


### PR DESCRIPTION
# Remove feature serde binary for field element base type

## Description

In this PR we remove the flag serde binary so that the `BaseType` of a field element can implement `ByteConversion` without that feature.
