### PR TITLE
Refactor: Clap attribute macros from #[clap(...)] to #[arg(...)] and #[command(...)] in v4.x

### DIFF
--- a/examples/merkle-tree-cli/src/commands.rs
+++ b/examples/merkle-tree-cli/src/commands.rs
@@ -3,17 +3,17 @@ use clap::{Args, Parser, Subcommand};
 #[derive(Parser, Debug)]
 #[command(author = "Lambdaworks", version, about)]
 pub struct MerkleArgs {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub entity: MerkleEntity,
 }
 
 #[derive(Subcommand, Debug)]
 pub enum MerkleEntity {
-    #[clap(about = "Generate a merkle tree")]
+    #[command(about = "Generate a merkle tree")]
     GenerateTree(GenerateTreeArgs),
-    #[clap(about = "Generate a merkle proof")]
+    #[command(about = "Generate a merkle proof")]
     GenerateProof(GenerateProofArgs),
-    #[clap(about = "Verify a merkle proof")]
+    #[command(about = "Verify a merkle proof")]
     VerifyProof(VerifyArgs),
 }
 


### PR DESCRIPTION
## Description

This PR updates deprecated #[clap(...)] attributes to their modern equivalents in clap 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.

I ran cargo check --features clap/deprecated after making the changes, and the previous clap deprecation warnings are no longer present.

![image](https://github.com/user-attachments/assets/a5405f0e-e688-45e3-9056-a4fbf4f97c58)

Fixes #982 

## Type of change

- [X] Optimization

## Checklist
- [X] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [X] This change is an Optimization
  - [ ] Benchmarks added/run



