### PR TITLE
docs: corrected typo in the word "illustration"

### DIFF
--- a/docs/src/starks/under_the_hood.md
+++ b/docs/src/starks/under_the_hood.md
@@ -2,7 +2,7 @@
 
 In this section we go over how a few things in the `prove` and `verify` functions are implemented. If you just need to *use* the prover, then you probably don't need to read this. If you're going through the code to try to understand it, read on.
 
-We will once again use the fibonacci example as an ilustration. Recall from the `recap` that the main steps for the prover and verifier are the following:
+We will once again use the fibonacci example as an illustration. Recall from the `recap` that the main steps for the prover and verifier are the following:
 
 ### Prover side
 


### PR DESCRIPTION
# TITLE

## Description

Noticed a small typo—"illustration" was missing an "l."

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
