### PR TITLE
fix(coset): shl overflow when getting the points

### DIFF
--- a/crates/math/src/circle/cosets.rs
+++ b/crates/math/src/circle/cosets.rs
@@ -58,11 +58,11 @@ impl Coset {
     pub fn get_coset_points(coset: &Self) -> Vec<CirclePoint<Mersenne31Field>> {
         // g_n the generator of the subgroup of order n.
         let generator_n = CirclePoint::get_generator_of_subgroup(coset.log_2_size);
-        let size: u32 = 1 << coset.log_2_size;
+        let size: usize = 1 << coset.log_2_size;
         core::iter::successors(Some(coset.shift.clone()), move |prev| {
             Some(prev + &generator_n)
         })
-        .take(size as usize)
+        .take(size)
         .collect()
     }
 }

--- a/crates/math/src/circle/cosets.rs
+++ b/crates/math/src/circle/cosets.rs
@@ -58,11 +58,11 @@ impl Coset {
     pub fn get_coset_points(coset: &Self) -> Vec<CirclePoint<Mersenne31Field>> {
         // g_n the generator of the subgroup of order n.
         let generator_n = CirclePoint::get_generator_of_subgroup(coset.log_2_size);
-        let size: u8 = 1 << coset.log_2_size;
+        let size: u32 = 1 << coset.log_2_size;
         core::iter::successors(Some(coset.shift.clone()), move |prev| {
             Some(prev + &generator_n)
         })
-        .take(size.into())
+        .take(size as usize)
         .collect()
     }
 }

--- a/crates/math/src/circle/polynomial.rs
+++ b/crates/math/src/circle/polynomial.rs
@@ -297,4 +297,14 @@ mod tests {
 
         assert_eq!(coeff, new_coeff);
     }
+
+    #[test]
+    fn evaluate_and_interpolate_2_pow_20_other_points() {
+        let coeff: Vec<FieldElement<Mersenne31Field>> =
+            (0..2_u32.pow(20)).map(|i| FE::from(&i)).collect();
+        let evals = evaluate_cfft(coeff.clone());
+        let new_coeff = interpolate_cfft(evals);
+
+        assert_eq!(coeff, new_coeff);
+    }
 }

--- a/crates/math/src/circle/twiddles.rs
+++ b/crates/math/src/circle/twiddles.rs
@@ -63,7 +63,7 @@ mod tests {
 
     #[test]
     fn evaluation_twiddles_vectors_length_is_correct() {
-        let domain = Coset::new_standard(3);
+        let domain = Coset::new_standard(20);
         let config = TwiddlesConfig::Evaluation;
         let twiddles = get_twiddles(domain, config);
         for i in 0..twiddles.len() - 1 {
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn interpolation_twiddles_vectors_length_is_correct() {
-        let domain = Coset::new_standard(3);
+        let domain = Coset::new_standard(20);
         let config = TwiddlesConfig::Interpolation;
         let twiddles = get_twiddles(domain, config);
         for i in 0..twiddles.len() - 1 {


### PR DESCRIPTION
For higher degree polynomials the twiddles weren't computed correctly because computing the coset size would overflow. Fixed that by switching to u32 and added tests for higher degree polynomials