### PR TITLE
CI: migrate workflows to checkout v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -95,7 +95,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Fetch coverage data
         uses: actions/cache/restore@v4
         with:
@@ -150,7 +150,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
@@ -168,7 +168,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: install GCC/GMP
         run: |

--- a/.github/workflows/criterion_benchs.yml
+++ b/.github/workflows/criterion_benchs.yml
@@ -21,7 +21,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run benchmark
         run: |
           cargo bench --no-fail-fast --bench "criterion_fft" \
@@ -46,7 +46,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install GCC/GMP
         run: |
           brew install gcc

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1

--- a/.github/workflows/iai_benchs_main.yml
+++ b/.github/workflows/iai_benchs_main.yml
@@ -18,7 +18,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: stable
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
       with:
         shared-key: ${{ runner.os }}-benchmark-build-cache

--- a/.github/workflows/iai_benchs_pr.yml
+++ b/.github/workflows/iai_benchs_pr.yml
@@ -32,7 +32,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: stable
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: ${{ steps.cache-iai-results.outputs.cache-hit != 'true' }}
       with:
         ref: ${{ github.event.pull_request.base.sha }}
@@ -64,7 +64,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: stable
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
       with:
         shared-key: ${{ runner.os }}-iai-benchmark-cache


### PR DESCRIPTION
Bumps checkout to v4 for future-proofing against Node 20 runner updates. Workflows compile the same.