### PR TITLE
refactor: remove `Default` contraint in merkle tree trait

### DIFF
--- a/crates/crypto/src/merkle_tree/traits.rs
+++ b/crates/crypto/src/merkle_tree/traits.rs
@@ -5,7 +5,7 @@ use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 /// A backend for Merkle trees. This defines raw `Data` from which the Merkle
 /// tree is built from. It also defines the `Node` type and the hash function
 /// used to build parent nodes from children nodes.
-pub trait IsMerkleTreeBackend: Default {
+pub trait IsMerkleTreeBackend {
     type Node: PartialEq + Eq + Clone + Sync + Send;
     type Data: Sync + Send;
 


### PR DESCRIPTION
# Remove `Default` contraint in `IsMerkleTreeBackend` 

## Description

Previously, the `IsMerkleTreeBackend` trait required types to implement the `Default` trait. However, `Default` is no longer used in the current Merkle tree construction logic.

Requiring `Default` can be unnecessarily restrictive, especially in codebases where implementing it is non-trivial. This change simplifies the trait by removing the Default constraint, making it easier to implement custom backends.

## Type of change

- [x] Refactor

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
