### PR TITLE
docs: Fix broken link to STARKs documentation

### DIFF
--- a/crates/provers/README.md
+++ b/crates/provers/README.md
@@ -6,7 +6,7 @@ This folder contains the different provers currently supported by lambdaworks:
 - [Groth 16](./groth16/)
 - [Plonk](./plonk/)
 - [STARKs](./stark/)
-- [Cairo](https://github.com/lambdaclass/lambdaworks/tree/a591186e6c4dd53301b03b4ddd69369abe99f960/provers/cairo) - This is only for learning purposes and no longer supported. The [docs](../docs/src/starks/) still contain information that could be useful to understand and learn how Cairo works.
+- [Cairo](https://github.com/lambdaclass/lambdaworks/tree/a591186e6c4dd53301b03b4ddd69369abe99f960/provers/cairo) - This is only for learning purposes and no longer supported. The [docs](../../docs/src/starks/) still contain information that could be useful to understand and learn how Cairo works.
 
 The reference papers for each of the provers is given below:
 - [Groth 16](https://eprint.iacr.org/2016/260)


### PR DESCRIPTION
## Description

update path to STARKs documentation in provers README

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [x] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
