### PR TITLE
Corrected typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Below is a list of examples to understand lambdaworks and learn what you can bui
 - [Pohlig-Hellman algorithm](./examples/pohlig-hellman-attack/)
 - [Naive RSA](./examples/rsa/)
 - [Naive Schnorr signatures](./examples/schnorr-signature/)
-- [Using Circom with lambdaworks's Groth16](./examples/prove-verify-circom/circom_lambdaworks_tutorial.md)
+- [Using Circom with lambdaworks's Growth16](./examples/prove-verify-circom/circom_lambdaworks_tutorial.md)
 - [Proving Fibonacci using Circom and lambdaworks](./examples/prove-verify-circom/circom_lambdaworks_tutorial.md)
 
-- You can use Circom to generate circuits and use lambdaworks's capabilities to prove the execution with [Groth16](./crates/provers/groth16/README.md).
+- You can use Circom to generate circuits and use lambdaworks's capabilities to prove the execution with [Growth16](./crates/provers/groth16/README.md).
 - You can use the [Stark prover](./crates/provers/stark/README.md) to define an algebraic intermediate representation (AIR) and prove the execution of a program
 
 ## Why we built lambdaworks
@@ -47,7 +47,7 @@ So, we decided to build our library, focusing on performance, with clear documen
 - [Crypto primitives](./crates/crypto/)
 - [STARK Prover](./crates/provers/stark/)
 - [Plonk Prover](./crates/provers/plonk/)
-- [Groth 16](./crates/provers/groth16/)
+- [Growth 16](./crates/provers/groth16/)
 
 ### Crypto
 
@@ -111,7 +111,7 @@ List of symbols:
 | STARK Prover     | :heavy_check_mark:  | :x:          | :x:       | :x:       | :x:             |
 | Circle STARKs    | :x:          | :x:       | :x:       | :x:             | :x: |
 | **SNARKs** | **Lambdaworks**    | **Arkworks**       | **Halo2** | **gnark**          | **Constantine** |
-| Groth16    | :heavy_check_mark: | :heavy_check_mark: | :x:       | :heavy_check_mark: | :x:             |
+| Growth16    | :heavy_check_mark: | :heavy_check_mark: | :x:       | :heavy_check_mark: | :x:             |
 | Plonk      | 🏗️                 | :heavy_check_mark: | ✔️         | :heavy_check_mark: | :x:             |
 | GKR        | :x:                | :heavy_check_mark: | :x:       | :heavy_check_mark: | :x:             |
 | **Polynomial Commitment Schemes** | **Lambdaworks**    | **Arkworks**       | **Halo2**          | **gnark**          | **Constantine** |
@@ -124,9 +124,9 @@ Additionally, provers are compatible with the following frontends and VMs:
 
 | Backend | Frontend | Status |
 |---------|----------|--------|
-| Groth16 | Arkworks | :heavy_check_mark: |
-| Groth16 | Gnark    | :x: |
-| Groth16 | Circom   | 🏗️  |
+| Growth16 | Arkworks | :heavy_check_mark: |
+| Growth16 | Gnark    | :x: |
+| Growth16 | Circom   | 🏗️  |
 | Plonk   | Gnark    | 🏗️  |
 | Plonk   | Noir    | :x: |
 | Stark   | Winterfell | :heavy_check_mark: |

--- a/crates/math/src/elliptic_curve/README.md
+++ b/crates/math/src/elliptic_curve/README.md
@@ -94,7 +94,7 @@ Each form and coordinate model has to implement the `IsGroup` trait, which will 
 - `fn neutral_element()`, the neutral element for the group operation. In the case of elliptic curves, this is the point at infinity.
 - `fn operate_with`, which defines the group operation; it takes two elements in the group and outputs a third one.
 - `fn neg`, which gives the inverse of the element.
-It also provides the method `fn operate_with_self`, which is used to indicate that repeteadly add one element against itself $n$ times. Here, $n$ should implement the `IsUnsignedInteger` trait. In the case of elliptic curves, this provides the scalar multiplication, $n P$, based on the double and add algorithm (square and multiply).
+It also provides the method `fn operate_with_self`, which is used to indicate that repeatedly add one element against itself $n$ times. Here, $n$ should implement the `IsUnsignedInteger` trait. In the case of elliptic curves, this provides the scalar multiplication, $n P$, based on the double and add algorithm (square and multiply).
 
 Operating is done in the following way:
 ```rust

--- a/crates/math/src/field/README.md
+++ b/crates/math/src/field/README.md
@@ -8,9 +8,9 @@ This folder contains the different field backends, including field extensions. T
 - [Goldilocks-448](./fields/p448_goldilocks_prime_field.rs)
 - [Mersenne-31](./fields/mersenne31/): $2^{31} - 1$ and its [quadratic extension](./fields/mersenne31/extensions.rs)
 - [Baby Bear](./fields/fft_friendly/babybear_u32.rs) and its [quadratic extension](./fields/fft_friendly/quadratic_babybear.rs): FFT-friendly, $2^{31} - 2^{27} + 1$.
-- [Scalar field of BN-254](../elliptic_curve/short_weierstrass/curves/bn_254/default_types.rs), and its quadratic extension, quartic, sextic and twelth degree extensions. This coincides with the base field of [Grumpkin](../elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs)
+- [Scalar field of BN-254](../elliptic_curve/short_weierstrass/curves/bn_254/default_types.rs), and its quadratic extension, quartic, sextic and twelfth degree extensions. This coincides with the base field of [Grumpkin](../elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs)
 - [Base field of BN-254](../elliptic_curve/short_weierstrass/curves/bn_254/field_extension.rs) and its quadratic extension. The base field coincides with the scalar field of [Grumpkin](../elliptic_curve/short_weierstrass/curves/grumpkin/curve.rs)
-- [Scalar field of BLS12-381](../elliptic_curve/short_weierstrass/curves/bls12_381/default_types.rs), and its quadratic, sextic and twelth degree extensions. FFT-friendly.
+- [Scalar field of BLS12-381](../elliptic_curve/short_weierstrass/curves/bls12_381/default_types.rs), and its quadratic, sextic and twelfth degree extensions. FFT-friendly.
 - [Base field of BLS12-381](../elliptic_curve/short_weierstrass/curves/bls12_381/field_extension.rs) 
 - [Scalar field of BLS12-377](../elliptic_curve/short_weierstrass/curves/bls12_377/curve.rs)
 - [Base field of BLS12-377](../elliptic_curve/short_weierstrass/curves/bls12_377/field_extension.rs)

--- a/crates/provers/README.md
+++ b/crates/provers/README.md
@@ -3,20 +3,20 @@
 Provers allow one party, the prover, to show to other parties, the verifiers, that a given computer program has been executed correctly by means of a cryptographic proof. This proof ideally satisfies the following two properties: it is fast to verify and its size is small (smaller than the size of the witness). All provers have a `prove` function, which takes some description of the program and other input and outputs a proof. There is also a `verify` function which takes the proof and other input and accepts or rejects the proof.
 
 This folder contains the different provers currently supported by lambdaworks:
-- [Groth 16](./groth16/)
+- [Growth 16](./groth16/)
 - [Plonk](./plonk/)
 - [STARKs](./stark/)
 - [Cairo](https://github.com/lambdaclass/lambdaworks/tree/a591186e6c4dd53301b03b4ddd69369abe99f960/provers/cairo) - This is only for learning purposes and no longer supported. The [docs](../docs/src/starks/) still contain information that could be useful to understand and learn how Cairo works.
 
 The reference papers for each of the provers is given below:
-- [Groth 16](https://eprint.iacr.org/2016/260)
+- [Growth 16](https://eprint.iacr.org/2016/260)
 - [Plonk](https://eprint.iacr.org/2019/953)
 - [STARKs](https://eprint.iacr.org/2018/046.pdf)
 
 A brief description of the Plonk and STARKs provers can be found [here](https://github.com/lambdaclass/lambdaworks/tree/main/docs/src)
 
 Using one prover or another depends on usecase and other desired properties. We recommend reading and understanding how each prover works, so as to choose the most adequate.
-- Groth 16: Shortest proof length. Security depends on pairing-friendly elliptic curves. Needs a new trusted setup for every program you want to prove.
+- Growth 16: Shortest proof length. Security depends on pairing-friendly elliptic curves. Needs a new trusted setup for every program you want to prove.
 - Plonk (using KZG as commitment scheme): Short proof length. Security depends on pairing-friendly elliptic curves. Universal trusted setup.
 - STARKs: longer proof length. Security depends on collision-resistant hash functions. Conjectured to be post-quantum secure. Transparent (no trusted setup).
 

--- a/crates/provers/groth16/arkworks-adapter/README.md
+++ b/crates/provers/groth16/arkworks-adapter/README.md
@@ -8,7 +8,7 @@ Crate exposes [to_lambda](./src/lib.rs#to_lambda) function for <b><span style="c
 pub fn to_lambda<F: PrimeField>(cs: &ConstraintSystemRef<F>) -> (QuadraticArithmeticProgram, Vec<FrElement>)
 ```
 
-It returns a Lambdaworks-compatible QAP struct alongside variable assignments. Please note that public variable assignments are bundled with witnesses, and this vector of field elements is called **witness** alltogether.
+It returns a Lambdaworks-compatible QAP struct alongside variable assignments. Please note that public variable assignments are bundled with witnesses, and this vector of field elements is called **witness** altogether, all together.
 
 ```rust
 let (qap, w) = to_lambda(&cs);

--- a/docs/src/starks/recap.md
+++ b/docs/src/starks/recap.md
@@ -153,7 +153,7 @@ Why not just take \\(H(x) = B(x) + C(x)\\)? The reason for the betas is to make 
 
 With what we discussed above, showing that the constraints are satisfied is equivalent to saying that `H` is a polynomial and not a rational function (we are simplifying things a bit here, but it works for our purposes).
 
-## Commiting to \\(H\\)
+## Committing to \\(H\\)
 
 To show \\(H\\) is a polynomial we are going to use the `FRI` protocol, which we treat as a black box. For all we care, a `FRI` proof will verify if what we committed to is indeed a polynomial. Thus, the prover will provide a `FRI` commitment to `H`, and if it passes, the verifier will be convinced that the constraints are satisfied.
 
@@ -161,7 +161,7 @@ There is one catch here though: how does the verifier know that `FRI` was applie
 
 
 ## Consistency check
-After commiting to `H`, the prover needs to show that `H` was constructed correctly according to the formula above. To do this, it will ask the prover to provide an evaluation of `H` on some random point `z` and evaluations of the trace at the points \\(t(z), t(zg)\\) and \\(t(zg^2)\\).
+After committing to `H`, the prover needs to show that `H` was constructed correctly according to the formula above. To do this, it will ask the prover to provide an evaluation of `H` on some random point `z` and evaluations of the trace at the points \\(t(z), t(zg)\\) and \\(t(zg^2)\\).
 
 Because the boundary and transition constraints are a public part of the protocol, the verifier knows them, and thus the only thing it needs to compute the evaluation \\((z)\\) by itself are the three trace evaluations mentioned above. Because it asked the prover for them, it can check both sides of the equation:
 

--- a/docs/src/starks/under_the_hood.md
+++ b/docs/src/starks/under_the_hood.md
@@ -2,7 +2,7 @@
 
 In this section we go over how a few things in the `prove` and `verify` functions are implemented. If you just need to *use* the prover, then you probably don't need to read this. If you're going through the code to try to understand it, read on.
 
-We will once again use the fibonacci example as an ilustration. Recall from the `recap` that the main steps for the prover and verifier are the following:
+We will once again use the fibonacci example as an illustration. Recall from the `recap` that the main steps for the prover and verifier are the following:
 
 ### Prover side
 


### PR DESCRIPTION
Changes made in:

- /README.md ("Groth" → "Growth")

- /crates/math/src/elliptic_curve/README.md ("repeteadly" → "repeatedly")

- /crates/math/src/field/README.md ("twelth" → "twelfth")

- /crates/math/src/field/README.md ("twelth" → "twelfth")

- /crates/provers/README.md ("Groth" → "Growth")

- /crates/provers/README.md ("Groth" → "Growth")

- /crates/provers/groth16/arkworks-adapter/README.md ("alltogether" → "altogether, all together")

- /docs/src/starks/under_the_hood.md ("ilustration" → "illustration")

- /docs/src/starks/recap.md ("Commiting" → "Committing")

- /docs/src/starks/recap.md ("commiting" → "committing")
