### PR TITLE
Use black_box on function arguments instead of result in Pedersen benchmark

### DIFF
--- a/crates/crypto/benches/criterion_pedersen.rs
+++ b/crates/crypto/benches/criterion_pedersen.rs
@@ -20,7 +20,7 @@ fn pedersen_benchmarks(c: &mut Criterion) {
 
     // Benchmark with black_box is 0.41% faster
     group.bench_function("Hashing with black_box", |bench| {
-        bench.iter(|| black_box(PedersenStarkCurve::hash(&x, &y)))
+        bench.iter(|| PedersenStarkCurve::hash(black_box(&x), black_box(&y)))
     });
 }
 criterion_group!(pedersen, pedersen_benchmarks);


### PR DESCRIPTION
This commit updates the Pedersen hash benchmark to apply black_box to the input arguments (x and y) of the PedersenStarkCurve::hash function, rather than to its result. This change aligns with Criterion best practices, ensuring that the compiler does not optimize away the input values and that the benchmark more accurately measures the true performance of the hash function. No other logic was changed.