### PR TITLE
Fix: Update dead link for Domb's fast modular multiplication

### DIFF
--- a/References.md
+++ b/References.md
@@ -5,7 +5,7 @@ The following links, repos and projects have been important in the development o
 - [zkcrypto](https://github.com/zkcrypto/ff)
 - [Nilfoundation's crypto 3 multiprecision](https://github.com/nilfoundation/crypto3-multiprecision)
 - [Montgomery REDC](https://jeffhurchalla.com/2022/04/28/montgomery-redc-using-the-positive-inverse-mod-r/)
-- [Domb's fast modular multiplication](http://ingonyama.com/s/modular_multiplication.pdf)
+- [Domb's fast modular multiplication](https://www.ingonyama.com/post/fast-modular-multiplication)
 - [Rust crypto bigint](https://github.com/RustCrypto/crypto-bigint)
 - [Cairo felt](https://github.com/lambdaclass/cairo-rs/blob/main/felt/src/lib.rs)
 - [Various optimizations](https://github.com/mratsim/constantine/blob/master/docs/optimizations.md)


### PR DESCRIPTION
## Fix Dead Link in References.md

Updates the broken link for "Domb's fast modular multiplication" to ensure documentation reliability.

### Changes
- **File:** `References.md`
- **Link:** Domb's fast modular multiplication

### Before
```diff
- [Domb's fast modular multiplication](http://ingonyama.com/s/modular_multiplication.pdf)
```

### After  
```diff
+ [Domb's fast modular multiplication](https://www.ingonyama.com/post/fast-modular-multiplication)
```

