### PR TITLE
refactor(helpers): safely convert usize to u64 and add unit tests for resize_to_next_power_of_two

### DIFF
--- a/crates/math/src/helpers.rs
+++ b/crates/math/src/helpers.rs
@@ -18,10 +18,54 @@ pub fn resize_to_next_power_of_two<F: IsFFTField>(
     trace_colums: &mut [alloc::vec::Vec<FieldElement<F>>],
 ) {
     trace_colums.iter_mut().for_each(|col| {
-        // TODO: Remove this unwrap. This may panic if the usize cant be
-        // casted into a u64.
-        let col_len = col.len().try_into().unwrap();
+        // Convert usize to u64 safely, handling potential overflow
+        let col_len = match col.len().try_into() {
+            Ok(len) => len,
+            Err(_) => {
+                // If usize is larger than u64::MAX, use u64::MAX as a reasonable fallback
+                u64::MAX
+            }
+        };
         let next_power_of_two_len = next_power_of_two(col_len);
         col.resize(next_power_of_two_len as usize, FieldElement::<F>::zero())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::field::test_fields::u64_test_field::U64TestField;
+
+    #[test]
+    fn test_resize_to_next_power_of_two() {
+        let mut trace_columns = vec![
+            vec![FieldElement::<U64TestField>::one(); 5],
+            vec![FieldElement::<U64TestField>::one(); 3],
+        ];
+        
+        resize_to_next_power_of_two(&mut trace_columns);
+        
+        // First column should be resized to 8 (next power of 2 after 5)
+        assert_eq!(trace_columns[0].len(), 8);
+        // Second column should be resized to 4 (next power of 2 after 3)
+        assert_eq!(trace_columns[1].len(), 4);
+        
+        // Check that the original values are preserved
+        for i in 0..5 {
+            assert_eq!(trace_columns[0][i], FieldElement::<U64TestField>::one());
+        }
+        
+        for i in 0..3 {
+            assert_eq!(trace_columns[1][i], FieldElement::<U64TestField>::one());
+        }
+        
+        // Check that new elements are zeros
+        for i in 5..8 {
+            assert_eq!(trace_columns[0][i], FieldElement::<U64TestField>::zero());
+        }
+        
+        for i in 3..4 {
+            assert_eq!(trace_columns[1][i], FieldElement::<U64TestField>::zero());
+        }
+    }
 }


### PR DESCRIPTION
1) Refactored resize_to_next_power_of_two to safely handle usize to u64 conversion with overflow fallback. 

2) Added unit tests to validate resizing behavior and ensure data integrity.