### PR TITLE
Add modulus range check when creating `FieldElement` from hex

### DIFF
--- a/crates/math/src/errors.rs
+++ b/crates/math/src/errors.rs
@@ -13,6 +13,7 @@ pub enum CreationError {
     InvalidHexString,
     InvalidDecString,
     HexStringIsTooBig,
+    RepresentativeOutOfRange,
     EmptyString,
 }
 

--- a/crates/math/src/field/element.rs
+++ b/crates/math/src/field/element.rs
@@ -608,6 +608,8 @@ impl<F: IsPrimeField> FieldElement<F> {
     /// Returns a `CreationError::EmptyString` if the input string is empty.
     /// Returns a `CreationError::HexStringIsTooBig` if the the input hex string is bigger than the
     /// maximum amount of characters for this element.
+    /// Returns a `CreationError::RepresentativeOutOfRange` if the representative of the value is
+    /// out of the range [0, p-1] where p is the modulus.
     pub fn from_hex(hex_string: &str) -> Result<Self, CreationError> {
         if hex_string.is_empty() {
             return Err(CreationError::EmptyString);
@@ -978,6 +980,14 @@ mod tests {
         type F = Stark252PrimeField;
         type FE = FieldElement<F>;
         assert!(FE::from_hex("").is_err());
+    }
+
+    #[test]
+    fn construct_new_field_element_from_value_bigger_than_modulus() {
+        type F = Stark252PrimeField;
+        type FE = FieldElement<F>;
+        // A number that consists of 255 1s is bigger than the `Stark252PrimeField` modulus
+        assert!(FE::from_hex(&format!("0x{}", "f".repeat(65))).is_err());
     }
 
     prop_compose! {

--- a/crates/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/crates/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -1,3 +1,4 @@
+use crate::errors::CreationError;
 use crate::field::element::FieldElement;
 use crate::field::errors::FieldError;
 use crate::field::traits::{HasDefaultTranscript, IsPrimeField};
@@ -305,8 +306,12 @@ where
         evaluated_bit + 1
     }
 
-    fn from_hex(hex_string: &str) -> Result<Self::BaseType, crate::errors::CreationError> {
+    fn from_hex(hex_string: &str) -> Result<Self::BaseType, CreationError> {
         let integer = Self::BaseType::from_hex(hex_string)?;
+        if integer > M::MODULUS {
+            return Err(CreationError::RepresentativeOutOfRange);
+        }
+
         Ok(MontgomeryAlgorithms::cios(
             &integer,
             &MontgomeryBackendPrimeField::<M, NUM_LIMBS>::R2,

--- a/crates/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/crates/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -1299,9 +1299,14 @@ mod tests_u256_prime_fields {
     }
 
     #[test]
-    fn creating_a_field_element_from_hex_works_on_the_size_limit() {
+    fn creating_a_field_element_from_hex_bigger_than_modulus_errors() {
+        // A number that consists of 255 1s is bigger than the `U256FP1` modulus
         let a = U256FP1Element::from_hex(&"f".repeat(64));
-        assert!(a.is_ok());
+        assert!(a.is_err());
+        assert_eq!(
+            a.unwrap_err(),
+            crate::errors::CreationError::RepresentativeOutOfRange
+        )
     }
 
     #[test]


### PR DESCRIPTION
This PR serves as a proposal to add a check for the creation of a `FieldElement` from a hex string.

See https://github.com/starknet-io/types-rs/issues/81 for further details.

Note that this is one of two alternatives mentioned. The other alternative is to add this check in the `from_hex` function from `types-rs`.