### PR TITLE
chore(transcript): make sample_u64 advancing via sample bytes

### DIFF
--- a/crates/crypto/src/fiat_shamir/default_transcript.rs
+++ b/crates/crypto/src/fiat_shamir/default_transcript.rs
@@ -68,7 +68,9 @@ where
     }
 
     fn sample_u64(&mut self, upper_bound: u64) -> u64 {
-        u64::from_be_bytes(self.state()[..8].try_into().unwrap()) % upper_bound
+        let mut bytes = [0u8; 8];
+        bytes.copy_from_slice(&self.sample()[..8]);
+        u64::from_be_bytes(bytes) % upper_bound
     }
 }
 

--- a/crates/provers/winterfell_adapter/src/adapter/mod.rs
+++ b/crates/provers/winterfell_adapter/src/adapter/mod.rs
@@ -46,7 +46,10 @@ impl IsStarkTranscript<Felt> for FeltTranscript {
     }
 
     fn sample_u64(&mut self, upper_bound: u64) -> u64 {
-        u64::from_be_bytes(self.state()[..8].try_into().unwrap()) % upper_bound
+        let bytes = self.sample(8);
+        let mut arr = [0u8; 8];
+        arr.copy_from_slice(&bytes);
+        u64::from_be_bytes(arr) % upper_bound
     }
 }
 
@@ -82,6 +85,9 @@ impl IsStarkTranscript<QuadFelt> for QuadFeltTranscript {
     }
 
     fn sample_u64(&mut self, upper_bound: u64) -> u64 {
-        u64::from_be_bytes(self.state()[..8].try_into().unwrap()) % upper_bound
+        let bytes = self.felt_transcript.sample(8);
+        let mut arr = [0u8; 8];
+        arr.copy_from_slice(&bytes);
+        u64::from_be_bytes(arr) % upper_bound
     }
 }


### PR DESCRIPTION
Update sample_u64 to draw 8 bytes from advancing sources (DefaultTranscript: sample(); FeltTranscript/QuadFeltTranscript: sample(8)), ensuring subsequent calls produce different values without changing bias handling or adding new checks.

What this fixes:
Ensures sequential sample_u64 calls don’t repeat the same value unless the transcript input changes.
Aligns behavior with rng-like expectations and with the STARK transcript’s advancing sampling pattern.