### PR TITLE
chore: remove unused alloc::format imports from FFT module

### DIFF
--- a/crates/math/src/fft/cpu/fft.rs
+++ b/crates/math/src/fft/cpu/fft.rs
@@ -183,7 +183,6 @@ mod tests {
     use crate::fft::cpu::roots_of_unity::get_twiddles;
     use crate::fft::test_helpers::naive_matrix_dft_test;
     use crate::field::{test_fields::u64_test_field::U64TestField, traits::RootsConfig};
-    use alloc::format;
     use proptest::{collection, prelude::*};
 
     use super::*;

--- a/crates/math/src/fft/cpu/roots_of_unity.rs
+++ b/crates/math/src/fft/cpu/roots_of_unity.rs
@@ -83,7 +83,6 @@ mod tests {
         },
         field::{test_fields::u64_test_field::U64TestField, traits::RootsConfig},
     };
-    use alloc::format;
     use proptest::prelude::*;
 
     type F = U64TestField;

--- a/crates/math/src/fft/test_helpers.rs
+++ b/crates/math/src/fft/test_helpers.rs
@@ -36,7 +36,6 @@ mod fft_helpers_test {
     use super::*;
     use crate::{field::test_fields::u64_test_field::U64TestField, polynomial::Polynomial};
 
-    use alloc::format;
     use proptest::{collection, prelude::*};
 
     type F = U64TestField;


### PR DESCRIPTION
Removed unused `alloc::format` imports from FFT module test files to clean up compiler warnings.

Files cleaned:
- fft/test_helpers.rs
- fft/cpu/fft.rs  
- fft/cpu/roots_of_unity.rs
