### PR TITLE
chore: remove unused format import from MSM pippenger tests

### DIFF
--- a/crates/math/src/msm/pippenger.rs
+++ b/crates/math/src/msm/pippenger.rs
@@ -170,7 +170,7 @@ mod tests {
         },
         unsigned_integer::element::UnsignedInteger,
     };
-    use alloc::{format, vec::Vec};
+    use alloc::vec::Vec;
     use proptest::{collection, prelude::*, prop_assert_eq, prop_compose, proptest};
 
     const _CASES: u32 = 20;


### PR DESCRIPTION
Removed unused `format` import from MSM pippenger test module to clean up compiler warnings.

This improves code quality by removing dead imports in the MSM module.