### PR TITLE
chore: remove unused alloc::format import from polynomial tests

### DIFF
--- a/crates/math/src/polynomial/mod.rs
+++ b/crates/math/src/polynomial/mod.rs
@@ -1222,7 +1222,6 @@ mod tests {
         assert_eq!(p1, &p1_expected);
     }
 
-    use alloc::format;
     use proptest::prelude::*;
     proptest! {
         #[test]


### PR DESCRIPTION
Removed unused `alloc::format` import from polynomial test module to clean up compiler warnings.

This improves code quality by removing dead imports in the polynomial module.