### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,5 +14,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@1.90.0
-      - name: Publish crate lambdaworks
-        run: cargo publish --workspace --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --all-features
+      - name: Publish crate lambdaworks-gpu
+        run: cargo publish -p lambdaworks-gpu --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish crate lambdaworks-math
+        run: cargo publish -p lambdaworks-math --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --all-features
+      - name: Publish crate lambdaworks-crypto
+        run: cargo publish -p lambdaworks-crypto --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --all-features


### PR DESCRIPTION
This PR removes the--workspace flag, which attempted to publish all crates in the repository. Instead, now we publish only the necessary crates in the correct order.
