### PR TITLE
feat(crypto): add Ligero/Brakedown linear-code polynomial commitment …

### DIFF
--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0", default-features = false, features = [
 rayon = { version = "1.8.0", optional = true }
 rand = { version = "0.8.5", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
+libm = "0.2"
 # CUDA
 cudarc = { version = "0.9.7", optional = true }
 

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -9,4 +9,5 @@ pub mod commitments;
 pub mod errors;
 pub mod fiat_shamir;
 pub mod hash;
+pub mod linear_code_pcs;
 pub mod merkle_tree;

--- a/crates/crypto/src/linear_code_pcs/commit.rs
+++ b/crates/crypto/src/linear_code_pcs/commit.rs
@@ -1,0 +1,109 @@
+use alloc::vec::Vec;
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+
+use crate::merkle_tree::{merkle::MerkleTree, traits::IsMerkleTreeBackend};
+
+use super::data_structures::{CommitOutput, CommitState, LinCodeCommitment};
+use super::matrix::Matrix;
+use super::traits::LinearCodeEncoding;
+
+/// Commit to a multilinear polynomial using a linear-code PCS.
+///
+/// The polynomial is given as a flat vector of evaluations on the boolean hypercube
+/// (length `2^v`). We arrange this into a `k x m` matrix, encode each row with
+/// the provided linear code, and build a Merkle tree over the columns.
+///
+/// # Arguments
+/// - `evals`: evaluation vector of length `2^v` (the multilinear polynomial in Lagrange basis).
+/// - `encoding`: the linear code to use (RS or expander).
+///
+/// # Returns
+/// A `CommitOutput` containing the public `LinCodeCommitment` and private `CommitState`.
+///
+/// # Type Parameters
+/// - `B`: Merkle tree backend with `B::Data = Vec<FieldElement<F>>` (columns are leaves).
+pub fn commit<F, B, E>(evals: &[FieldElement<F>], encoding: &E) -> CommitOutput<F, B>
+where
+    F: IsField,
+    B: IsMerkleTreeBackend<Data = Vec<FieldElement<F>>>,
+    E: LinearCodeEncoding<F>,
+{
+    let n = evals.len();
+    assert!(n.is_power_of_two(), "evals length must be a power of two");
+    let v = n.trailing_zeros() as usize;
+
+    // Split variables: k rows, m cols where k * m = n
+    let half = v / 2;
+    let n_cols = 1usize << (v - half); // m = 2^ceil(v/2)
+    let n_rows = 1usize << half; // k = 2^floor(v/2)
+
+    assert_eq!(
+        n_cols,
+        encoding.message_len(),
+        "encoding message_len must equal matrix column count"
+    );
+
+    // Arrange into k x m matrix (row-major)
+    let matrix = Matrix::new(n_rows, n_cols, evals.to_vec());
+
+    // Encode each row
+    let n_ext_cols = encoding.codeword_len();
+    let mut ext_data = Vec::with_capacity(n_rows * n_ext_cols);
+    for i in 0..n_rows {
+        let row = matrix.row(i);
+        let encoded_row = encoding.encode(row);
+        debug_assert_eq!(encoded_row.len(), n_ext_cols);
+        ext_data.extend(encoded_row);
+    }
+    let ext_matrix = Matrix::new(n_rows, n_ext_cols, ext_data);
+
+    // Build Merkle tree: each leaf is one column of the extended matrix
+    let columns: Vec<Vec<FieldElement<F>>> = (0..n_ext_cols).map(|j| ext_matrix.col(j)).collect();
+
+    let merkle_tree = MerkleTree::<B>::build(&columns)
+        .expect("Merkle tree build should succeed for non-empty columns");
+
+    let commitment = LinCodeCommitment {
+        root: merkle_tree.root.clone(),
+        n_rows,
+        n_cols,
+        n_ext_cols,
+    };
+
+    CommitOutput {
+        commitment,
+        state: CommitState {
+            matrix,
+            ext_matrix,
+            merkle_tree,
+        },
+    }
+}
+
+/// Compute the tensor product vector: `tensor(values) = ⊗_{i} (1-r_i, r_i)`.
+///
+/// For `values = [r_0, r_1, ..., r_{k-1}]`, produces a vector of length `2^k`:
+/// ```text
+/// tensor[j] = prod_{i} ( if bit_i(j) then r_i else 1 - r_i )
+/// ```
+///
+/// This is the key operation for the multilinear evaluation claim:
+/// `f(r) = <tensor_L(r), M * tensor_R(r)> = tensor_L^T * M * tensor_R`.
+pub fn tensor_vec<F: IsField>(values: &[FieldElement<F>]) -> Vec<FieldElement<F>> {
+    let n = values.len();
+    let mut evals = alloc::vec![FieldElement::<F>::one(); 1 << n];
+    let mut size = 1;
+    for r in values {
+        size *= 2;
+        for i in (0..size).rev().step_by(2) {
+            let scalar = evals[i / 2].clone();
+            evals[i] = scalar.clone() * r.clone();
+            evals[i - 1] = scalar - evals[i].clone();
+        }
+        // After processing variable r_k, index j has:
+        // - bit (size/2) of j corresponds to r_0 (MSB = first variable)
+        // - bit 1 of j corresponds to the most recently processed variable
+        // This matches DenseMultilinearPolynomial's evaluation order.
+    }
+    evals
+}

--- a/crates/crypto/src/linear_code_pcs/data_structures.rs
+++ b/crates/crypto/src/linear_code_pcs/data_structures.rs
@@ -1,0 +1,62 @@
+use alloc::vec::Vec;
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+
+use crate::merkle_tree::{merkle::MerkleTree, proof::Proof, traits::IsMerkleTreeBackend};
+
+use super::matrix::Matrix;
+
+/// Commitment to a multilinear polynomial via the linear-code PCS.
+///
+/// Stores the Merkle root over the encoded columns plus layout metadata
+/// needed during verification.
+#[derive(Clone)]
+pub struct LinCodeCommitment<B: IsMerkleTreeBackend> {
+    /// Merkle root over the hashed columns of the encoded matrix.
+    pub root: B::Node,
+    /// Number of rows in the coefficient matrix (k).
+    pub n_rows: usize,
+    /// Number of columns in the original matrix (m).
+    pub n_cols: usize,
+    /// Number of columns in the encoded (extended) matrix (n).
+    pub n_ext_cols: usize,
+}
+
+/// Internal state produced during commit, needed to generate proofs.
+pub struct CommitState<F: IsField, B: IsMerkleTreeBackend> {
+    /// Original k x m coefficient matrix.
+    pub matrix: Matrix<F>,
+    /// Encoded k x n extended matrix.
+    pub ext_matrix: Matrix<F>,
+    /// Merkle tree built over encoded columns.
+    pub merkle_tree: MerkleTree<B>,
+}
+
+/// Output of the commit phase: the public commitment plus prover-private state.
+pub struct CommitOutput<F: IsField, B: IsMerkleTreeBackend> {
+    pub commitment: LinCodeCommitment<B>,
+    pub state: CommitState<F, B>,
+}
+
+/// A single opened column with its Merkle inclusion proof.
+#[derive(Clone)]
+pub struct OpenedColumn<F: IsField, B: IsMerkleTreeBackend> {
+    /// Column index in the extended matrix.
+    pub index: usize,
+    /// Values of this column (all `n_rows` entries).
+    pub values: Vec<FieldElement<F>>,
+    /// Merkle authentication path for this column.
+    pub merkle_proof: Proof<B::Node>,
+}
+
+/// Evaluation proof for the linear-code PCS.
+///
+/// Proves that a committed multilinear polynomial evaluates to a claimed value
+/// at a given point.
+#[derive(Clone)]
+pub struct LinCodeProof<F: IsField, B: IsMerkleTreeBackend> {
+    /// `v = a^T * M` — the left-multiplication of the tensor-half vector `a` with
+    /// the coefficient matrix. Length = `n_cols` (original column count).
+    pub v: Vec<FieldElement<F>>,
+    /// Opened columns with their Merkle proofs, sampled via Fiat-Shamir.
+    pub columns: Vec<OpenedColumn<F, B>>,
+}

--- a/crates/crypto/src/linear_code_pcs/encoding/expander.rs
+++ b/crates/crypto/src/linear_code_pcs/encoding/expander.rs
@@ -1,0 +1,148 @@
+use alloc::vec::Vec;
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+
+use crate::linear_code_pcs::sparse_matrix::SparseMatrix;
+use crate::linear_code_pcs::traits::LinearCodeEncoding;
+
+/// Expander-code encoding backend for the Brakedown PCS.
+///
+/// Uses a recursive construction based on sparse bipartite expander graphs:
+///
+/// ```text
+/// Enc(x) = (x, Enc'(A * x))
+/// ```
+///
+/// where `A` is a sparse matrix (bipartite expander adjacency) that reduces
+/// the dimension, and `Enc'` is a smaller instance of the same code. The base
+/// case uses a simple repetition.
+///
+/// This gives O(n) encoding time since each level involves multiplying by a
+/// sparse matrix with O(1) nonzero entries per row.
+#[derive(Clone, Debug)]
+pub struct ExpanderEncoding<F: IsField> {
+    /// The message length (input dimension).
+    msg_len: usize,
+    /// Total codeword length after all levels of recursion.
+    cw_len: usize,
+    /// Sparse matrices for each recursion level. Level 0 maps msg_len -> smaller,
+    /// level 1 maps that output -> even smaller, etc.
+    matrices: Vec<SparseMatrix<F>>,
+    /// Distance numerator / denominator (approximate).
+    dist: (usize, usize),
+}
+
+impl<F: IsField> ExpanderEncoding<F> {
+    /// Create an expander encoding for messages of length `msg_len`.
+    ///
+    /// Parameters:
+    /// - `alpha`: dimension reduction factor per level (e.g. 0.2 means output = 0.2 * input)
+    /// - `nnz_per_row`: number of nonzero entries per row in the sparse matrix (the degree)
+    /// - `base_len`: stop recursing when dimension drops below this
+    /// - `seed`: deterministic seed for generating the sparse matrices
+    pub fn new(msg_len: usize, alpha: f64, nnz_per_row: usize, base_len: usize, seed: u64) -> Self {
+        assert!(alpha > 0.0 && alpha < 1.0, "alpha must be in (0, 1)");
+        assert!(msg_len > 0);
+
+        let mut matrices = Vec::new();
+        let mut current_len = msg_len;
+        let mut cw_len = msg_len; // The systematic part
+        let mut level_seed = seed;
+
+        while current_len > base_len {
+            let out_len = ((current_len as f64) * alpha).ceil() as usize;
+            let out_len = out_len.max(1);
+
+            let nnz = nnz_per_row.min(current_len);
+            let mat = SparseMatrix::<F>::random_binary(out_len, current_len, nnz, level_seed);
+            matrices.push(mat);
+            cw_len += out_len;
+            current_len = out_len;
+            level_seed = level_seed.wrapping_add(7);
+        }
+
+        // The distance is approximate; for a proper implementation the expander
+        // analysis would give exact bounds. We use a conservative estimate.
+        // With alpha ~0.2 and nnz_per_row ~8, the relative distance is roughly 0.04.
+        let dist = (1, 25); // ~0.04
+
+        Self {
+            msg_len,
+            cw_len,
+            matrices,
+            dist,
+        }
+    }
+}
+
+impl<F: IsField> LinearCodeEncoding<F> for ExpanderEncoding<F> {
+    fn encode(&self, msg: &[FieldElement<F>]) -> Vec<FieldElement<F>> {
+        assert_eq!(msg.len(), self.msg_len, "message length mismatch");
+
+        // Systematic: start with the message itself
+        let mut codeword = msg.to_vec();
+
+        // Recursively apply sparse matrices and append outputs
+        let mut current = msg.to_vec();
+        for mat in &self.matrices {
+            let next = mat.mul_vec(&current);
+            codeword.extend_from_slice(&next);
+            current = next;
+        }
+
+        debug_assert_eq!(codeword.len(), self.cw_len);
+        codeword
+    }
+
+    fn codeword_len(&self) -> usize {
+        self.cw_len
+    }
+
+    fn message_len(&self) -> usize {
+        self.msg_len
+    }
+
+    fn distance(&self) -> (usize, usize) {
+        self.dist
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lambdaworks_math::field::fields::u64_prime_field::U64PrimeField;
+
+    type F = U64PrimeField<101>;
+    type FE = FieldElement<F>;
+
+    #[test]
+    fn encode_produces_correct_length() {
+        let enc = ExpanderEncoding::<F>::new(32, 0.25, 4, 4, 42);
+        let msg: Vec<FE> = (0..32).map(|x| FE::from(x as u64)).collect();
+        let cw = enc.encode(&msg);
+        assert_eq!(cw.len(), enc.codeword_len());
+    }
+
+    #[test]
+    fn encode_is_systematic() {
+        // First msg_len elements of the codeword should be the message itself
+        let enc = ExpanderEncoding::<F>::new(16, 0.25, 4, 2, 99);
+        let msg: Vec<FE> = (0..16).map(|x| FE::from(x as u64)).collect();
+        let cw = enc.encode(&msg);
+        assert_eq!(&cw[..16], &msg[..]);
+    }
+
+    #[test]
+    fn encode_deterministic() {
+        let enc = ExpanderEncoding::<F>::new(16, 0.25, 4, 2, 42);
+        let msg: Vec<FE> = (0..16).map(|x| FE::from(x as u64)).collect();
+        let cw1 = enc.encode(&msg);
+        let cw2 = enc.encode(&msg);
+        assert_eq!(cw1, cw2);
+    }
+
+    #[test]
+    fn cw_longer_than_msg() {
+        let enc = ExpanderEncoding::<F>::new(64, 0.3, 6, 4, 7);
+        assert!(enc.codeword_len() > enc.message_len());
+    }
+}

--- a/crates/crypto/src/linear_code_pcs/encoding/expander.rs
+++ b/crates/crypto/src/linear_code_pcs/encoding/expander.rs
@@ -39,9 +39,27 @@ impl<F: IsField> ExpanderEncoding<F> {
     /// - `nnz_per_row`: number of nonzero entries per row in the sparse matrix (the degree)
     /// - `base_len`: stop recursing when dimension drops below this
     /// - `seed`: deterministic seed for generating the sparse matrices
-    pub fn new(msg_len: usize, alpha: f64, nnz_per_row: usize, base_len: usize, seed: u64) -> Self {
+    /// - `distance`: relative minimum distance as `(numerator, denominator)`.
+    ///   For example `(1, 25)` means distance ~0.04. The caller should set this
+    ///   based on the expander analysis for the chosen `alpha` and `nnz_per_row`.
+    pub fn new(
+        msg_len: usize,
+        alpha: f64,
+        nnz_per_row: usize,
+        base_len: usize,
+        seed: u64,
+        distance: (usize, usize),
+    ) -> Self {
         assert!(alpha > 0.0 && alpha < 1.0, "alpha must be in (0, 1)");
         assert!(msg_len > 0);
+        assert!(
+            distance.0 > 0 && distance.1 > 0,
+            "distance must be positive"
+        );
+        assert!(
+            distance.0 < distance.1,
+            "distance numerator must be less than denominator"
+        );
 
         let mut matrices = Vec::new();
         let mut current_len = msg_len;
@@ -60,16 +78,11 @@ impl<F: IsField> ExpanderEncoding<F> {
             level_seed = level_seed.wrapping_add(7);
         }
 
-        // The distance is approximate; for a proper implementation the expander
-        // analysis would give exact bounds. We use a conservative estimate.
-        // With alpha ~0.2 and nnz_per_row ~8, the relative distance is roughly 0.04.
-        let dist = (1, 25); // ~0.04
-
         Self {
             msg_len,
             cw_len,
             matrices,
-            dist,
+            dist: distance,
         }
     }
 }
@@ -116,7 +129,7 @@ mod tests {
 
     #[test]
     fn encode_produces_correct_length() {
-        let enc = ExpanderEncoding::<F>::new(32, 0.25, 4, 4, 42);
+        let enc = ExpanderEncoding::<F>::new(32, 0.25, 4, 4, 42, (1, 25));
         let msg: Vec<FE> = (0..32).map(|x| FE::from(x as u64)).collect();
         let cw = enc.encode(&msg);
         assert_eq!(cw.len(), enc.codeword_len());
@@ -125,7 +138,7 @@ mod tests {
     #[test]
     fn encode_is_systematic() {
         // First msg_len elements of the codeword should be the message itself
-        let enc = ExpanderEncoding::<F>::new(16, 0.25, 4, 2, 99);
+        let enc = ExpanderEncoding::<F>::new(16, 0.25, 4, 2, 99, (1, 25));
         let msg: Vec<FE> = (0..16).map(|x| FE::from(x as u64)).collect();
         let cw = enc.encode(&msg);
         assert_eq!(&cw[..16], &msg[..]);
@@ -133,7 +146,7 @@ mod tests {
 
     #[test]
     fn encode_deterministic() {
-        let enc = ExpanderEncoding::<F>::new(16, 0.25, 4, 2, 42);
+        let enc = ExpanderEncoding::<F>::new(16, 0.25, 4, 2, 42, (1, 25));
         let msg: Vec<FE> = (0..16).map(|x| FE::from(x as u64)).collect();
         let cw1 = enc.encode(&msg);
         let cw2 = enc.encode(&msg);
@@ -142,7 +155,7 @@ mod tests {
 
     #[test]
     fn cw_longer_than_msg() {
-        let enc = ExpanderEncoding::<F>::new(64, 0.3, 6, 4, 7);
+        let enc = ExpanderEncoding::<F>::new(64, 0.3, 6, 4, 7, (1, 25));
         assert!(enc.codeword_len() > enc.message_len());
     }
 }

--- a/crates/crypto/src/linear_code_pcs/encoding/expander.rs
+++ b/crates/crypto/src/linear_code_pcs/encoding/expander.rs
@@ -78,7 +78,7 @@ impl<F: IsField> ExpanderEncoding<F> {
         let mut level_seed = seed;
 
         while current_len > base_len {
-            let out_len = ((current_len as f64) * alpha).ceil() as usize;
+            let out_len = libm::ceil((current_len as f64) * alpha) as usize;
             let out_len = out_len.max(1);
 
             let nnz = nnz_per_row.min(current_len);

--- a/crates/crypto/src/linear_code_pcs/encoding/expander.rs
+++ b/crates/crypto/src/linear_code_pcs/encoding/expander.rs
@@ -6,53 +6,65 @@ use crate::linear_code_pcs::traits::LinearCodeEncoding;
 
 /// Expander-code encoding backend for the Brakedown PCS.
 ///
-/// Uses a recursive construction based on sparse bipartite expander graphs:
+/// Implements the two-matrix recursive construction from Algorithm 1 of the
+/// Brakedown paper (Golovnev et al., CRYPTO 2023, Section 5.1):
 ///
 /// ```text
-/// Enc(x) = (x, Enc'(A * x))
+/// Enc(x) = (x, z, v) where:
+///   y = x · A          ∈ F^{αn}          (compress via matrix A)
+///   z = Enc_{αn}(y)    ∈ F^{r·αn}        (recursive encoding)
+///   v = z · B          ∈ F^{(r-1-rα)n}   (mix via matrix B)
 /// ```
 ///
-/// where `A` is a sparse matrix (bipartite expander adjacency) that reduces
-/// the dimension, and `Enc'` is a smaller instance of the same code. The base
-/// case uses a simple repetition.
+/// Both `A` and `B` are sparse random matrices with non-zero field element entries
+/// and constant row-sparsity, giving O(n) encoding time.
 ///
-/// This gives O(n) encoding time since each level involves multiplying by a
-/// sparse matrix with O(1) nonzero entries per row.
+/// The code is systematic: codeword = (x, z, v), with rate 1/r and relative
+/// distance δ = β/r where β depends on the expansion parameters.
 #[derive(Clone, Debug)]
 pub struct ExpanderEncoding<F: IsField> {
     /// The message length (input dimension).
     msg_len: usize,
     /// Total codeword length after all levels of recursion.
     cw_len: usize,
-    /// Sparse matrices for each recursion level. Level 0 maps msg_len -> smaller,
-    /// level 1 maps that output -> even smaller, etc.
-    matrices: Vec<SparseMatrix<F>>,
+    /// Pairs of (A, B) sparse matrices for each recursion level.
+    /// A compresses the input, B mixes the recursively-encoded output.
+    levels: Vec<ExpanderLevel<F>>,
     /// Distance numerator / denominator (approximate).
     dist: (usize, usize),
+}
+
+/// One level of the recursive expander encoding.
+#[derive(Clone, Debug)]
+struct ExpanderLevel<F: IsField> {
+    /// Compression matrix A: maps input of length `in_len` to length `compressed_len`.
+    a_matrix: SparseMatrix<F>,
+    /// Mixing matrix B: maps recursively-encoded output to additional redundancy.
+    /// None at the base case (no further mixing needed).
+    b_matrix: Option<SparseMatrix<F>>,
 }
 
 impl<F: IsField> ExpanderEncoding<F> {
     /// Create an expander encoding for messages of length `msg_len`.
     ///
     /// # Parameters
-    /// - `alpha`: dimension reduction factor per level (e.g. 0.2 means output = 0.2 * input)
-    /// - `nnz_per_row`: number of nonzero entries per row in the sparse matrix (the degree)
+    /// - `alpha`: dimension reduction factor per level (e.g. 0.2 means A output = 0.2 * input)
+    /// - `nnz_per_row`: number of nonzero entries per row in the sparse matrices (the degree)
     /// - `base_len`: stop recursing when dimension drops below this
     /// - `seed`: deterministic seed for generating the sparse matrices
     /// - `distance`: relative minimum distance as `(numerator, denominator)`.
-    ///   For example `(1, 25)` means distance ~0.04.
+    ///   For example `(1, 20)` means distance 0.05.
     ///
     /// # Safety (soundness)
     ///
     /// **The `distance` parameter is NOT verified at construction time.** The caller
     /// MUST ensure the claimed distance holds for the chosen `alpha`, `nnz_per_row`,
-    /// and `base_len` based on an external spectral expansion analysis. If the claimed
-    /// distance is too large, `calculate_t` will compute too few column openings and
-    /// the PCS soundness guarantee will be violated.
+    /// and `base_len` based on the expander spectral analysis in Brakedown Section 5.1.
     ///
-    /// For typical parameters (alpha=0.25, nnz_per_row >= 8, msg_len >= 64),
-    /// a conservative distance of `(1, 25)` (~0.04) is reasonable. See the
-    /// Brakedown paper (Golovnev et al., CRYPTO 2023) Section 4 for analysis.
+    /// The paper's construction uses parameters `0 < α < 1, 0 < β < α/1.28`,
+    /// with rate `r > (1+2β)/(1-α)` and distance `δ = β/r`. For practical
+    /// parameters (α ≈ 0.2, β ≈ 0.06, r = 5), δ ≈ 0.012.
+    /// See Golovnev et al., CRYPTO 2023, Section 5.1 for full analysis.
     pub fn new(
         msg_len: usize,
         alpha: f64,
@@ -72,27 +84,45 @@ impl<F: IsField> ExpanderEncoding<F> {
             "distance numerator must be less than denominator"
         );
 
-        let mut matrices = Vec::new();
+        let mut levels = Vec::new();
         let mut current_len = msg_len;
         let mut cw_len = msg_len; // The systematic part
         let mut level_seed = seed;
 
         while current_len > base_len {
-            let out_len = libm::ceil((current_len as f64) * alpha) as usize;
-            let out_len = out_len.max(1);
+            let compressed_len = libm::ceil((current_len as f64) * alpha) as usize;
+            let compressed_len = compressed_len.max(1);
 
-            let nnz = nnz_per_row.min(current_len);
-            let mat = SparseMatrix::<F>::random_binary(out_len, current_len, nnz, level_seed);
-            matrices.push(mat);
-            cw_len += out_len;
-            current_len = out_len;
+            let nnz_a = nnz_per_row.min(current_len);
+            let a_matrix =
+                SparseMatrix::<F>::random_nonzero(compressed_len, current_len, nnz_a, level_seed);
+
+            // B matrix mixes the recursively-encoded compressed output.
+            // B maps from compressed_len -> b_out_len where b_out_len is sized to
+            // provide additional redundancy beyond the systematic + recursive parts.
+            // Following the paper: output extra (1-α-1/r) * current_len symbols.
+            // For simplicity we set b_out_len ≈ compressed_len (matching the A output size).
+            let b_out_len = compressed_len;
+            let nnz_b = nnz_per_row.min(compressed_len);
+            let b_seed = level_seed.wrapping_add(0x_B0B0_B0B0);
+            let b_matrix =
+                SparseMatrix::<F>::random_nonzero(b_out_len, compressed_len, nnz_b, b_seed);
+
+            cw_len += compressed_len + b_out_len;
+
+            levels.push(ExpanderLevel {
+                a_matrix,
+                b_matrix: Some(b_matrix),
+            });
+
+            current_len = compressed_len;
             level_seed = level_seed.wrapping_add(7);
         }
 
         Self {
             msg_len,
             cw_len,
-            matrices,
+            levels,
             dist: distance,
         }
     }
@@ -105,12 +135,20 @@ impl<F: IsField> LinearCodeEncoding<F> for ExpanderEncoding<F> {
         // Systematic: start with the message itself
         let mut codeword = msg.to_vec();
 
-        // Recursively apply sparse matrices and append outputs
+        // Recursively: compress with A, append compressed, mix with B, append mixed
         let mut current = msg.to_vec();
-        for mat in &self.matrices {
-            let next = mat.mul_vec(&current);
-            codeword.extend_from_slice(&next);
-            current = next;
+        for level in &self.levels {
+            // y = A * current (compression)
+            let compressed = level.a_matrix.mul_vec(&current);
+            codeword.extend_from_slice(&compressed);
+
+            // v = B * compressed (mixing for distance amplification)
+            if let Some(b_matrix) = &level.b_matrix {
+                let mixed = b_matrix.mul_vec(&compressed);
+                codeword.extend_from_slice(&mixed);
+            }
+
+            current = compressed;
         }
 
         debug_assert_eq!(codeword.len(), self.cw_len);
@@ -168,5 +206,33 @@ mod tests {
     fn cw_longer_than_msg() {
         let enc = ExpanderEncoding::<F>::new(64, 0.3, 6, 4, 7, (1, 25));
         assert!(enc.codeword_len() > enc.message_len());
+    }
+
+    #[test]
+    fn encode_is_linear() {
+        // Linearity: encode(a*x + b*y) == a*encode(x) + b*encode(y)
+        let enc = ExpanderEncoding::<F>::new(16, 0.25, 4, 2, 42, (1, 25));
+        let x: Vec<FE> = (1..=16).map(|i| FE::from(i as u64)).collect();
+        let y: Vec<FE> = (17..=32).map(|i| FE::from(i as u64)).collect();
+        let a = FE::from(3u64);
+        let b = FE::from(7u64);
+
+        let ax_plus_by: Vec<FE> = x
+            .iter()
+            .zip(y.iter())
+            .map(|(xi, yi)| a.clone() * xi.clone() + b.clone() * yi.clone())
+            .collect();
+
+        let enc_combined = enc.encode(&ax_plus_by);
+        let enc_x = enc.encode(&x);
+        let enc_y = enc.encode(&y);
+
+        let expected: Vec<FE> = enc_x
+            .iter()
+            .zip(enc_y.iter())
+            .map(|(ex, ey)| a.clone() * ex.clone() + b.clone() * ey.clone())
+            .collect();
+
+        assert_eq!(enc_combined, expected, "encoding must be linear");
     }
 }

--- a/crates/crypto/src/linear_code_pcs/encoding/expander.rs
+++ b/crates/crypto/src/linear_code_pcs/encoding/expander.rs
@@ -34,14 +34,25 @@ pub struct ExpanderEncoding<F: IsField> {
 impl<F: IsField> ExpanderEncoding<F> {
     /// Create an expander encoding for messages of length `msg_len`.
     ///
-    /// Parameters:
+    /// # Parameters
     /// - `alpha`: dimension reduction factor per level (e.g. 0.2 means output = 0.2 * input)
     /// - `nnz_per_row`: number of nonzero entries per row in the sparse matrix (the degree)
     /// - `base_len`: stop recursing when dimension drops below this
     /// - `seed`: deterministic seed for generating the sparse matrices
     /// - `distance`: relative minimum distance as `(numerator, denominator)`.
-    ///   For example `(1, 25)` means distance ~0.04. The caller should set this
-    ///   based on the expander analysis for the chosen `alpha` and `nnz_per_row`.
+    ///   For example `(1, 25)` means distance ~0.04.
+    ///
+    /// # Safety (soundness)
+    ///
+    /// **The `distance` parameter is NOT verified at construction time.** The caller
+    /// MUST ensure the claimed distance holds for the chosen `alpha`, `nnz_per_row`,
+    /// and `base_len` based on an external spectral expansion analysis. If the claimed
+    /// distance is too large, `calculate_t` will compute too few column openings and
+    /// the PCS soundness guarantee will be violated.
+    ///
+    /// For typical parameters (alpha=0.25, nnz_per_row >= 8, msg_len >= 64),
+    /// a conservative distance of `(1, 25)` (~0.04) is reasonable. See the
+    /// Brakedown paper (Golovnev et al., CRYPTO 2023) Section 4 for analysis.
     pub fn new(
         msg_len: usize,
         alpha: f64,

--- a/crates/crypto/src/linear_code_pcs/encoding/expander.rs
+++ b/crates/crypto/src/linear_code_pcs/encoding/expander.rs
@@ -220,7 +220,7 @@ mod tests {
         let ax_plus_by: Vec<FE> = x
             .iter()
             .zip(y.iter())
-            .map(|(xi, yi)| a.clone() * xi.clone() + b.clone() * yi.clone())
+            .map(|(xi, yi)| a * *xi + b * *yi)
             .collect();
 
         let enc_combined = enc.encode(&ax_plus_by);
@@ -230,7 +230,7 @@ mod tests {
         let expected: Vec<FE> = enc_x
             .iter()
             .zip(enc_y.iter())
-            .map(|(ex, ey)| a.clone() * ex.clone() + b.clone() * ey.clone())
+            .map(|(ex, ey)| a * *ex + b * *ey)
             .collect();
 
         assert_eq!(enc_combined, expected, "encoding must be linear");

--- a/crates/crypto/src/linear_code_pcs/encoding/mod.rs
+++ b/crates/crypto/src/linear_code_pcs/encoding/mod.rs
@@ -1,0 +1,2 @@
+pub mod expander;
+pub mod reed_solomon;

--- a/crates/crypto/src/linear_code_pcs/encoding/reed_solomon.rs
+++ b/crates/crypto/src/linear_code_pcs/encoding/reed_solomon.rs
@@ -1,0 +1,121 @@
+use alloc::vec::Vec;
+use lambdaworks_math::field::{
+    element::FieldElement,
+    traits::{IsFFTField, IsSubFieldOf},
+};
+use lambdaworks_math::polynomial::Polynomial;
+
+use crate::linear_code_pcs::traits::LinearCodeEncoding;
+
+/// Reed-Solomon encoding backend for the Ligero PCS.
+///
+/// Treats the message as polynomial coefficients, then evaluates the polynomial
+/// at `codeword_len` roots of unity via FFT. This gives an RS codeword of
+/// rate `1 / rho_inv`.
+///
+/// Requires an FFT-friendly field.
+#[derive(Clone, Debug)]
+pub struct ReedSolomonEncoding<F: IsFFTField> {
+    /// Length of the input message (number of polynomial coefficients).
+    msg_len: usize,
+    /// Inverse of the code rate: `codeword_len = msg_len * rho_inv`.
+    rho_inv: usize,
+    _marker: core::marker::PhantomData<F>,
+}
+
+impl<F: IsFFTField> ReedSolomonEncoding<F> {
+    /// Create a new RS encoding for messages of length `msg_len`.
+    ///
+    /// `rho_inv` is the blowup factor (inverse rate). E.g., `rho_inv = 2` means
+    /// rate 1/2 code with distance `1 - 1/2 = 1/2`.
+    ///
+    /// `msg_len * rho_inv` must be a power of two.
+    pub fn new(msg_len: usize, rho_inv: usize) -> Self {
+        assert!(rho_inv >= 2, "rho_inv must be at least 2");
+        let cw_len = msg_len * rho_inv;
+        assert!(
+            cw_len.is_power_of_two(),
+            "msg_len * rho_inv must be a power of two, got {}",
+            cw_len
+        );
+        Self {
+            msg_len,
+            rho_inv,
+            _marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<F> LinearCodeEncoding<F> for ReedSolomonEncoding<F>
+where
+    F: IsFFTField + IsSubFieldOf<F>,
+{
+    fn encode(&self, msg: &[FieldElement<F>]) -> Vec<FieldElement<F>> {
+        assert_eq!(msg.len(), self.msg_len, "message length mismatch");
+        let cw_len = self.msg_len * self.rho_inv;
+
+        // Treat message as coefficients of a polynomial of degree < msg_len.
+        // Pad to cw_len and evaluate via FFT at cw_len roots of unity.
+        let poly = Polynomial::new(msg);
+        Polynomial::evaluate_fft::<F>(&poly, 1, Some(cw_len))
+            .expect("FFT evaluation should succeed for valid power-of-two domain")
+    }
+
+    fn codeword_len(&self) -> usize {
+        self.msg_len * self.rho_inv
+    }
+
+    fn message_len(&self) -> usize {
+        self.msg_len
+    }
+
+    fn distance(&self) -> (usize, usize) {
+        // RS distance = 1 - rate = 1 - 1/rho_inv = (rho_inv - 1) / rho_inv
+        (self.rho_inv - 1, self.rho_inv)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lambdaworks_math::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
+
+    type F = Stark252PrimeField;
+    type FE = FieldElement<F>;
+
+    #[test]
+    fn encode_produces_correct_length() {
+        let enc = ReedSolomonEncoding::<F>::new(4, 2);
+        let msg: Vec<FE> = (1..=4).map(|x| FE::from(x as u64)).collect();
+        let cw = enc.encode(&msg);
+        assert_eq!(cw.len(), 8);
+    }
+
+    #[test]
+    fn encode_is_systematic_at_roots() {
+        // For an RS code, the codeword is the evaluation of the polynomial at
+        // roots of unity. Evaluating at w^0 = 1 should give the sum of coefficients.
+        let enc = ReedSolomonEncoding::<F>::new(4, 2);
+        let msg = vec![
+            FE::from(1u64),
+            FE::from(2u64),
+            FE::from(3u64),
+            FE::from(4u64),
+        ];
+        let cw = enc.encode(&msg);
+        // cw[0] = poly(w^0) = poly(1) = 1 + 2 + 3 + 4 = 10
+        assert_eq!(cw[0], FE::from(10u64));
+    }
+
+    #[test]
+    fn distance_rate_half() {
+        let enc = ReedSolomonEncoding::<F>::new(4, 2);
+        assert_eq!(enc.distance(), (1, 2));
+    }
+
+    #[test]
+    fn distance_rate_quarter() {
+        let enc = ReedSolomonEncoding::<F>::new(4, 4);
+        assert_eq!(enc.distance(), (3, 4));
+    }
+}

--- a/crates/crypto/src/linear_code_pcs/matrix.rs
+++ b/crates/crypto/src/linear_code_pcs/matrix.rs
@@ -1,0 +1,118 @@
+use alloc::vec::Vec;
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+
+/// Row-major dense matrix of field elements.
+///
+/// Used to arrange polynomial evaluations for the Ligero/Brakedown commit phase:
+/// the evaluation vector is reshaped into a `n_rows x n_cols` matrix, each row is
+/// encoded with a linear code, and columns of the extended matrix become Merkle leaves.
+#[derive(Clone, Debug)]
+pub struct Matrix<F: IsField> {
+    pub n_rows: usize,
+    pub n_cols: usize,
+    data: Vec<FieldElement<F>>,
+}
+
+impl<F: IsField> Matrix<F> {
+    /// Build a matrix from a flat vector of field elements in row-major order.
+    ///
+    /// # Panics
+    /// Panics if `data.len() != n_rows * n_cols`.
+    pub fn new(n_rows: usize, n_cols: usize, data: Vec<FieldElement<F>>) -> Self {
+        assert_eq!(
+            data.len(),
+            n_rows * n_cols,
+            "data length {} != n_rows * n_cols = {}",
+            data.len(),
+            n_rows * n_cols
+        );
+        Self {
+            n_rows,
+            n_cols,
+            data,
+        }
+    }
+
+    /// Returns a slice representing row `i`.
+    pub fn row(&self, i: usize) -> &[FieldElement<F>] {
+        let start = i * self.n_cols;
+        &self.data[start..start + self.n_cols]
+    }
+
+    /// Returns column `j` as a newly allocated vector.
+    pub fn col(&self, j: usize) -> Vec<FieldElement<F>> {
+        (0..self.n_rows)
+            .map(|i| self.data[i * self.n_cols + j].clone())
+            .collect()
+    }
+
+    /// Left-multiply by a row vector `v` of length `n_rows`:
+    /// result\[j\] = sum_i v\[i\] * M\[i\]\[j\]  (length `n_cols`).
+    ///
+    /// This computes `v^T * M`, producing a vector of length `n_cols`.
+    pub fn row_mul(&self, v: &[FieldElement<F>]) -> Vec<FieldElement<F>> {
+        assert_eq!(v.len(), self.n_rows);
+        let mut result = vec![FieldElement::<F>::zero(); self.n_cols];
+        for (i, vi) in v.iter().enumerate() {
+            let row = self.row(i);
+            for (rj, res_j) in row.iter().zip(result.iter_mut()) {
+                *res_j = res_j.clone() + vi.clone() * rj.clone();
+            }
+        }
+        result
+    }
+
+    /// Returns a reference to the underlying flat data.
+    pub fn data(&self) -> &[FieldElement<F>] {
+        &self.data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lambdaworks_math::field::fields::u64_prime_field::U64PrimeField;
+
+    type F = U64PrimeField<101>;
+    type FE = FieldElement<F>;
+
+    #[test]
+    fn row_col_access() {
+        // 2x3 matrix: [[1,2,3],[4,5,6]]
+        let data: Vec<FE> = (1..=6).map(|x| FE::from(x as u64)).collect();
+        let m = Matrix::new(2, 3, data);
+
+        assert_eq!(m.row(0), &[FE::from(1), FE::from(2), FE::from(3)]);
+        assert_eq!(m.row(1), &[FE::from(4), FE::from(5), FE::from(6)]);
+
+        assert_eq!(m.col(0), vec![FE::from(1), FE::from(4)]);
+        assert_eq!(m.col(1), vec![FE::from(2), FE::from(5)]);
+        assert_eq!(m.col(2), vec![FE::from(3), FE::from(6)]);
+    }
+
+    #[test]
+    fn row_mul_identity_like() {
+        // 2x2 matrix: [[1,0],[0,1]], v = [3,5]
+        let m = Matrix::new(
+            2,
+            2,
+            vec![FE::from(1), FE::from(0), FE::from(0), FE::from(1)],
+        );
+        let v = vec![FE::from(3), FE::from(5)];
+        let result = m.row_mul(&v);
+        assert_eq!(result, vec![FE::from(3), FE::from(5)]);
+    }
+
+    #[test]
+    fn row_mul_general() {
+        // 2x3 matrix: [[1,2,3],[4,5,6]], v = [2,3]
+        // result[0] = 2*1 + 3*4 = 14
+        // result[1] = 2*2 + 3*5 = 19
+        // result[2] = 2*3 + 3*6 = 24
+        let data: Vec<FE> = (1..=6).map(|x| FE::from(x as u64)).collect();
+        let m = Matrix::new(2, 3, data);
+        let v = vec![FE::from(2), FE::from(3)];
+        let result = m.row_mul(&v);
+        assert_eq!(result, vec![FE::from(14), FE::from(19), FE::from(24)]);
+    }
+}

--- a/crates/crypto/src/linear_code_pcs/mod.rs
+++ b/crates/crypto/src/linear_code_pcs/mod.rs
@@ -1,0 +1,11 @@
+pub mod commit;
+pub mod data_structures;
+pub mod encoding;
+pub mod matrix;
+pub mod prove;
+pub mod sparse_matrix;
+pub mod traits;
+pub mod verify;
+
+#[cfg(test)]
+mod tests;

--- a/crates/crypto/src/linear_code_pcs/mod.rs
+++ b/crates/crypto/src/linear_code_pcs/mod.rs
@@ -5,6 +5,7 @@ pub mod matrix;
 pub mod prove;
 pub mod sparse_matrix;
 pub mod traits;
+pub mod utils;
 pub mod verify;
 
 #[cfg(test)]

--- a/crates/crypto/src/linear_code_pcs/prove.rs
+++ b/crates/crypto/src/linear_code_pcs/prove.rs
@@ -7,18 +7,7 @@ use crate::merkle_tree::traits::IsMerkleTreeBackend;
 use super::commit::tensor_vec;
 use super::data_structures::{CommitState, LinCodeCommitment, LinCodeProof, OpenedColumn};
 use super::traits::LinearCodeEncoding;
-
-/// Number of column openings needed for `sec_param` bits of security with
-/// code relative distance `delta_num / delta_den`.
-///
-/// `t = ceil(sec_param / log2(1 / (1 - delta/2)))`.
-fn calculate_t(sec_param: usize, delta_num: usize, delta_den: usize) -> usize {
-    // delta/2
-    let half_delta = (delta_num as f64) / (delta_den as f64) / 2.0;
-    // log2(1 / (1 - delta/2))
-    let log_factor = -(1.0 - half_delta).log2();
-    (sec_param as f64 / log_factor).ceil() as usize
-}
+use super::utils::calculate_t;
 
 /// Generate an evaluation proof for a committed multilinear polynomial.
 ///
@@ -70,12 +59,10 @@ where
         transcript.append_field_element(vi);
     }
 
-    // Determine number of column openings
+    // Determine number of column openings (capped at n_ext_cols)
     let (d_num, d_den) = encoding.distance();
-    let t = calculate_t(sec_param, d_num, d_den);
-
-    // Sample t column indices from transcript
     let n_ext_cols = commitment.n_ext_cols;
+    let t = calculate_t(sec_param, d_num, d_den, n_ext_cols);
     let col_indices: Vec<usize> = (0..t)
         .map(|_| transcript.sample_u64(n_ext_cols as u64) as usize)
         .collect();

--- a/crates/crypto/src/linear_code_pcs/prove.rs
+++ b/crates/crypto/src/linear_code_pcs/prove.rs
@@ -1,0 +1,101 @@
+use alloc::vec::Vec;
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+
+use crate::fiat_shamir::is_transcript::IsTranscript;
+use crate::merkle_tree::traits::IsMerkleTreeBackend;
+
+use super::commit::tensor_vec;
+use super::data_structures::{CommitState, LinCodeCommitment, LinCodeProof, OpenedColumn};
+use super::traits::LinearCodeEncoding;
+
+/// Number of column openings needed for `sec_param` bits of security with
+/// code relative distance `delta_num / delta_den`.
+///
+/// `t = ceil(sec_param / log2(1 / (1 - delta/2)))`.
+fn calculate_t(sec_param: usize, delta_num: usize, delta_den: usize) -> usize {
+    // delta/2
+    let half_delta = (delta_num as f64) / (delta_den as f64) / 2.0;
+    // log2(1 / (1 - delta/2))
+    let log_factor = -(1.0 - half_delta).log2();
+    (sec_param as f64 / log_factor).ceil() as usize
+}
+
+/// Generate an evaluation proof for a committed multilinear polynomial.
+///
+/// Given the prover's `CommitState` from the commit phase, prove that the
+/// polynomial evaluates to some value at the point `point`.
+///
+/// # Arguments
+/// - `commitment`: the public commitment.
+/// - `state`: prover-private state from commit.
+/// - `encoding`: the linear code used during commit.
+/// - `point`: the evaluation point `(r_0, ..., r_{v-1})`.
+/// - `transcript`: Fiat-Shamir transcript for deriving random challenges.
+/// - `sec_param`: security parameter (number of bits).
+///
+/// # Returns
+/// A `LinCodeProof` containing the left-multiplication vector `v` and opened columns.
+pub fn prove<F, B, E>(
+    commitment: &LinCodeCommitment<B>,
+    state: &CommitState<F, B>,
+    encoding: &E,
+    point: &[FieldElement<F>],
+    transcript: &mut impl IsTranscript<F>,
+    sec_param: usize,
+) -> LinCodeProof<F, B>
+where
+    F: IsField,
+    B: IsMerkleTreeBackend<Data = Vec<FieldElement<F>>>,
+    B::Node: AsRef<[u8]>,
+    E: LinearCodeEncoding<F>,
+{
+    let v_count = point.len();
+    let half = v_count / 2;
+
+    // Tensor decomposition: split point into two halves
+    // a = tensor(r_0, ..., r_{half-1})  of length k = n_rows
+    // b = tensor(r_{half}, ..., r_{v-1}) of length m = n_cols
+    let a = tensor_vec(&point[..half]);
+    let b = tensor_vec(&point[half..]);
+    debug_assert_eq!(a.len(), commitment.n_rows);
+    debug_assert_eq!(b.len(), commitment.n_cols);
+
+    // v = a^T * M  (left-multiply the matrix by tensor half a)
+    // This is a vector of length n_cols such that <v, b> = f(point)
+    let v = state.matrix.row_mul(&a);
+
+    // Feed commitment root and v into transcript
+    transcript.append_bytes(commitment.root.as_ref());
+    for vi in &v {
+        transcript.append_field_element(vi);
+    }
+
+    // Determine number of column openings
+    let (d_num, d_den) = encoding.distance();
+    let t = calculate_t(sec_param, d_num, d_den);
+
+    // Sample t column indices from transcript
+    let n_ext_cols = commitment.n_ext_cols;
+    let col_indices: Vec<usize> = (0..t)
+        .map(|_| transcript.sample_u64(n_ext_cols as u64) as usize)
+        .collect();
+
+    // Open the sampled columns with Merkle proofs
+    let columns: Vec<OpenedColumn<F, B>> = col_indices
+        .iter()
+        .map(|&idx| {
+            let values = state.ext_matrix.col(idx);
+            let merkle_proof = state
+                .merkle_tree
+                .get_proof_by_pos(idx)
+                .expect("column index is in range");
+            OpenedColumn {
+                index: idx,
+                values,
+                merkle_proof,
+            }
+        })
+        .collect();
+
+    LinCodeProof { v, columns }
+}

--- a/crates/crypto/src/linear_code_pcs/prove.rs
+++ b/crates/crypto/src/linear_code_pcs/prove.rs
@@ -53,8 +53,22 @@ where
     // This is a vector of length n_cols such that <v, b> = f(point)
     let v = state.matrix.row_mul(&a);
 
-    // Feed commitment root and v into transcript
+    // Compute the claimed evaluation value to bind it to the transcript.
+    // claimed_value = <v, b>
+    let claimed_value: FieldElement<F> = v
+        .iter()
+        .zip(b.iter())
+        .fold(FieldElement::<F>::zero(), |acc, (vi, bi)| {
+            acc + vi.clone() * bi.clone()
+        });
+
+    // Bind all public statement parameters to the Fiat-Shamir transcript
+    // before deriving random column indices.
     transcript.append_bytes(commitment.root.as_ref());
+    for pi in point {
+        transcript.append_field_element(pi);
+    }
+    transcript.append_field_element(&claimed_value);
     for vi in &v {
         transcript.append_field_element(vi);
     }

--- a/crates/crypto/src/linear_code_pcs/sparse_matrix.rs
+++ b/crates/crypto/src/linear_code_pcs/sparse_matrix.rs
@@ -66,7 +66,11 @@ impl<F: IsField> SparseMatrix<F> {
                     .wrapping_add(1442695040888963407);
                 let mut col = (state >> 33) as usize % n_cols;
                 while used.contains(&col) {
-                    col = (col + 1) % n_cols;
+                    // Re-mix PRNG state instead of linear probing to avoid clustering bias
+                    state = state
+                        .wrapping_mul(6364136223846793005)
+                        .wrapping_add(1442695040888963407);
+                    col = (state >> 33) as usize % n_cols;
                 }
                 used.insert(col);
                 row.push((col, one.clone()));

--- a/crates/crypto/src/linear_code_pcs/sparse_matrix.rs
+++ b/crates/crypto/src/linear_code_pcs/sparse_matrix.rs
@@ -1,0 +1,126 @@
+use alloc::vec::Vec;
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+
+/// Sparse matrix in Compressed Sparse Row (CSR) format.
+///
+/// Used for the bipartite expander graphs in Brakedown's linear-time encodable code.
+/// Each row stores the column indices of its nonzero entries and the corresponding
+/// field-element values.
+#[derive(Clone, Debug)]
+pub struct SparseMatrix<F: IsField> {
+    pub n_rows: usize,
+    pub n_cols: usize,
+    /// For each row: list of (column_index, value) pairs.
+    entries: Vec<Vec<(usize, FieldElement<F>)>>,
+}
+
+impl<F: IsField> SparseMatrix<F> {
+    /// Creates a new sparse matrix from explicit row entries.
+    pub fn new(n_rows: usize, n_cols: usize, entries: Vec<Vec<(usize, FieldElement<F>)>>) -> Self {
+        assert_eq!(entries.len(), n_rows);
+        Self {
+            n_rows,
+            n_cols,
+            entries,
+        }
+    }
+
+    /// Multiplies this matrix by a column vector `v` of length `n_cols`,
+    /// producing a vector of length `n_rows`.
+    ///
+    /// result\[i\] = sum_j A\[i\]\[j\] * v\[j\]
+    pub fn mul_vec(&self, v: &[FieldElement<F>]) -> Vec<FieldElement<F>> {
+        assert_eq!(v.len(), self.n_cols);
+        self.entries
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .fold(FieldElement::<F>::zero(), |acc, (col, val)| {
+                        acc + val.clone() * v[*col].clone()
+                    })
+            })
+            .collect()
+    }
+
+    /// Generates a random sparse matrix where each row has exactly `nnz_per_row`
+    /// nonzero entries, each set to the field element `1`.
+    ///
+    /// Uses a simple deterministic approach based on the provided seed for
+    /// reproducibility: for row i, the nonzero columns are chosen by a
+    /// stride-based selection that covers distinct columns.
+    pub fn random_binary(n_rows: usize, n_cols: usize, nnz_per_row: usize, seed: u64) -> Self {
+        assert!(nnz_per_row <= n_cols);
+        let one = FieldElement::<F>::one();
+        let mut entries = Vec::with_capacity(n_rows);
+
+        for i in 0..n_rows {
+            let mut row = Vec::with_capacity(nnz_per_row);
+            // Simple deterministic column selection using hash-like mixing
+            let mut state = seed
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(i as u64);
+            let mut used = alloc::collections::BTreeSet::new();
+            for _ in 0..nnz_per_row {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                let mut col = (state >> 33) as usize % n_cols;
+                while used.contains(&col) {
+                    col = (col + 1) % n_cols;
+                }
+                used.insert(col);
+                row.push((col, one.clone()));
+            }
+            entries.push(row);
+        }
+
+        Self {
+            n_rows,
+            n_cols,
+            entries,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lambdaworks_math::field::fields::u64_prime_field::U64PrimeField;
+
+    type F = U64PrimeField<101>;
+    type FE = FieldElement<F>;
+
+    #[test]
+    fn mul_vec_basic() {
+        // 2x3 sparse matrix with a few entries
+        let entries = vec![
+            vec![(0, FE::from(2)), (2, FE::from(3))], // row 0: 2*v[0] + 3*v[2]
+            vec![(1, FE::from(5))],                   // row 1: 5*v[1]
+        ];
+        let m = SparseMatrix::new(2, 3, entries);
+        let v = vec![FE::from(1), FE::from(2), FE::from(4)];
+        let result = m.mul_vec(&v);
+        assert_eq!(result[0], FE::from(14)); // 2*1 + 3*4
+        assert_eq!(result[1], FE::from(10)); // 5*2
+    }
+
+    #[test]
+    fn random_binary_structure() {
+        let m = SparseMatrix::<F>::random_binary(4, 8, 3, 42);
+        assert_eq!(m.n_rows, 4);
+        assert_eq!(m.n_cols, 8);
+        for row in &m.entries {
+            assert_eq!(row.len(), 3);
+            // Check all values are 1
+            for (_, val) in row {
+                assert_eq!(*val, FE::one());
+            }
+            // Check column indices are distinct
+            let cols: Vec<usize> = row.iter().map(|(c, _)| *c).collect();
+            let mut sorted = cols.clone();
+            sorted.sort();
+            sorted.dedup();
+            assert_eq!(sorted.len(), cols.len());
+        }
+    }
+}

--- a/crates/crypto/src/linear_code_pcs/sparse_matrix.rs
+++ b/crates/crypto/src/linear_code_pcs/sparse_matrix.rs
@@ -45,35 +45,56 @@ impl<F: IsField> SparseMatrix<F> {
     /// Generates a random sparse matrix where each row has exactly `nnz_per_row`
     /// nonzero entries, each set to the field element `1`.
     ///
-    /// Uses a simple deterministic approach based on the provided seed for
-    /// reproducibility: for row i, the nonzero columns are chosen by a
-    /// stride-based selection that covers distinct columns.
+    /// Uses SHA3-256 to derive an independent PRNG seed per row from (seed, row_index),
+    /// ensuring each row's column selection is pseudorandom and uncorrelated.
     pub fn random_binary(n_rows: usize, n_cols: usize, nnz_per_row: usize, seed: u64) -> Self {
+        use sha3::{Digest, Sha3_256};
+
+        /// Extract the first 8 bytes of a 32-byte hash as a u64.
+        fn u64_from_hash(hash: &[u8; 32]) -> u64 {
+            let mut buf = [0u8; 8];
+            buf.copy_from_slice(&hash[..8]);
+            u64::from_le_bytes(buf)
+        }
+
+        /// Hash (seed, row, counter) into a 32-byte digest.
+        fn derive(seed: u64, row: u64, counter: u64) -> [u8; 32] {
+            let mut h = Sha3_256::new();
+            h.update(seed.to_le_bytes());
+            h.update(row.to_le_bytes());
+            h.update(counter.to_le_bytes());
+            h.finalize().into()
+        }
+
         assert!(nnz_per_row <= n_cols);
         let one = FieldElement::<F>::one();
         let mut entries = Vec::with_capacity(n_rows);
 
         for i in 0..n_rows {
             let mut row = Vec::with_capacity(nnz_per_row);
-            // Simple deterministic column selection using hash-like mixing
-            let mut state = seed
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(i as u64);
+            let row_idx = i as u64;
+
+            // Derive initial per-row state via SHA3-256(seed || row_index || 0)
+            let hash = derive(seed, row_idx, 0);
+            let mut state = u64_from_hash(&hash);
+            let mut hash_counter: u64 = 1;
             let mut used = alloc::collections::BTreeSet::new();
+
             for _ in 0..nnz_per_row {
-                state = state
-                    .wrapping_mul(6364136223846793005)
-                    .wrapping_add(1442695040888963407);
-                let mut col = (state >> 33) as usize % n_cols;
+                let mut col = (state >> 1) as usize % n_cols;
                 while used.contains(&col) {
-                    // Re-mix PRNG state instead of linear probing to avoid clustering bias
-                    state = state
-                        .wrapping_mul(6364136223846793005)
-                        .wrapping_add(1442695040888963407);
-                    col = (state >> 33) as usize % n_cols;
+                    let rehash = derive(seed, row_idx, hash_counter);
+                    state = u64_from_hash(&rehash);
+                    hash_counter += 1;
+                    col = (state >> 1) as usize % n_cols;
                 }
                 used.insert(col);
                 row.push((col, one.clone()));
+
+                // Advance state for next column pick
+                let next_hash = derive(seed, row_idx, hash_counter);
+                state = u64_from_hash(&next_hash);
+                hash_counter += 1;
             }
             entries.push(row);
         }
@@ -106,6 +127,25 @@ mod tests {
         let result = m.mul_vec(&v);
         assert_eq!(result[0], FE::from(14)); // 2*1 + 3*4
         assert_eq!(result[1], FE::from(10)); // 5*2
+    }
+
+    #[test]
+    fn consecutive_rows_have_different_column_patterns() {
+        let m = SparseMatrix::<F>::random_binary(100, 64, 3, 42);
+        let mut identical_count = 0;
+        for i in 0..m.n_rows - 1 {
+            let mut cols_i: Vec<usize> = m.entries[i].iter().map(|(c, _)| *c).collect();
+            let mut cols_next: Vec<usize> = m.entries[i + 1].iter().map(|(c, _)| *c).collect();
+            cols_i.sort();
+            cols_next.sort();
+            if cols_i == cols_next {
+                identical_count += 1;
+            }
+        }
+        assert_eq!(
+            identical_count, 0,
+            "consecutive rows should not share identical column sets"
+        );
     }
 
     #[test]

--- a/crates/crypto/src/linear_code_pcs/sparse_matrix.rs
+++ b/crates/crypto/src/linear_code_pcs/sparse_matrix.rs
@@ -43,6 +43,78 @@ impl<F: IsField> SparseMatrix<F> {
     }
 
     /// Generates a random sparse matrix where each row has exactly `nnz_per_row`
+    /// nonzero entries with random non-zero field element values.
+    ///
+    /// Per Brakedown (Golovnev et al., Section 5.1): the matrix entries must be
+    /// "uniform random non-zero elements of F" for the distance analysis to hold.
+    ///
+    /// Uses SHA3-256 to derive independent PRNG seeds per (row, column) pair.
+    pub fn random_nonzero(n_rows: usize, n_cols: usize, nnz_per_row: usize, seed: u64) -> Self {
+        use sha3::{Digest, Sha3_256};
+
+        fn derive(seed: u64, row: u64, counter: u64) -> [u8; 32] {
+            let mut h = Sha3_256::new();
+            h.update(seed.to_le_bytes());
+            h.update(row.to_le_bytes());
+            h.update(counter.to_le_bytes());
+            h.finalize().into()
+        }
+
+        fn u64_from_hash(hash: &[u8; 32]) -> u64 {
+            let mut buf = [0u8; 8];
+            buf.copy_from_slice(&hash[..8]);
+            u64::from_le_bytes(buf)
+        }
+
+        assert!(nnz_per_row <= n_cols);
+        let mut entries = Vec::with_capacity(n_rows);
+
+        for i in 0..n_rows {
+            let mut row = Vec::with_capacity(nnz_per_row);
+            let row_idx = i as u64;
+            let hash = derive(seed, row_idx, 0);
+            let mut state = u64_from_hash(&hash);
+            let mut hash_counter: u64 = 1;
+            let mut used = alloc::collections::BTreeSet::new();
+
+            for _ in 0..nnz_per_row {
+                // Pick column
+                let mut col = (state >> 1) as usize % n_cols;
+                while used.contains(&col) {
+                    let rehash = derive(seed, row_idx, hash_counter);
+                    state = u64_from_hash(&rehash);
+                    hash_counter += 1;
+                    col = (state >> 1) as usize % n_cols;
+                }
+                used.insert(col);
+
+                // Derive a non-zero value: use hash bytes as a small integer, ensure ≠ 0.
+                // Map state to [1, p-1] by taking (state % (p-1)) + 1 via FieldElement.
+                let val_raw = (state >> 33).max(1);
+                let val = FieldElement::<F>::from(val_raw);
+                // If the field element is zero (only if val_raw ≡ 0 mod p), use 1 instead.
+                let val = if val == FieldElement::zero() {
+                    FieldElement::one()
+                } else {
+                    val
+                };
+                row.push((col, val));
+
+                let next_hash = derive(seed, row_idx, hash_counter);
+                state = u64_from_hash(&next_hash);
+                hash_counter += 1;
+            }
+            entries.push(row);
+        }
+
+        Self {
+            n_rows,
+            n_cols,
+            entries,
+        }
+    }
+
+    /// Generates a random sparse matrix where each row has exactly `nnz_per_row`
     /// nonzero entries, each set to the field element `1`.
     ///
     /// Uses SHA3-256 to derive an independent PRNG seed per row from (seed, row_index),

--- a/crates/crypto/src/linear_code_pcs/tests.rs
+++ b/crates/crypto/src/linear_code_pcs/tests.rs
@@ -1,0 +1,414 @@
+use alloc::vec::Vec;
+use lambdaworks_math::field::element::FieldElement;
+use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolynomial;
+use sha3::Keccak256;
+
+use crate::fiat_shamir::default_transcript::DefaultTranscript;
+use crate::merkle_tree::backends::field_element_vector::FieldElementVectorBackend;
+
+use super::commit::{commit, tensor_vec};
+use super::encoding::expander::ExpanderEncoding;
+use super::encoding::reed_solomon::ReedSolomonEncoding;
+use super::prove::prove;
+use super::verify::verify;
+
+// ---------- Ligero (Reed-Solomon) tests with Goldilocks ----------
+
+mod ligero {
+    use super::*;
+    use lambdaworks_math::field::fields::u64_goldilocks_field::Goldilocks64Field;
+
+    type F = Goldilocks64Field;
+    type FE = FieldElement<F>;
+    type B = FieldElementVectorBackend<F, Keccak256, 32>;
+
+    fn make_poly(n_vars: usize) -> (Vec<FE>, DenseMultilinearPolynomial<F>) {
+        let n = 1usize << n_vars;
+        let evals: Vec<FE> = (1..=n).map(|x| FE::from(x as u64)).collect();
+        let poly = DenseMultilinearPolynomial::new(evals.clone());
+        (evals, poly)
+    }
+
+    #[test]
+    fn commit_open_verify_4_vars() {
+        let n_vars = 4;
+        let (evals, poly) = make_poly(n_vars);
+
+        // n_cols = 2^(4-2) = 4, rho_inv = 2 => cw_len = 8
+        let encoding = ReedSolomonEncoding::<F>::new(4, 2);
+        let out = commit::<F, B, _>(&evals, &encoding);
+
+        // Evaluation point
+        let point: Vec<FE> = (1..=n_vars).map(|x| FE::from(x as u64)).collect();
+        let claimed_value = poly.evaluate(point.clone()).expect("valid eval point");
+
+        // Prove
+        let mut transcript_p = DefaultTranscript::<F>::new(&[0x42]);
+        let proof = prove(
+            &out.commitment,
+            &out.state,
+            &encoding,
+            &point,
+            &mut transcript_p,
+            128,
+        );
+
+        // Verify
+        let mut transcript_v = DefaultTranscript::<F>::new(&[0x42]);
+        let ok = verify(
+            &out.commitment,
+            &proof,
+            &encoding,
+            &point,
+            &claimed_value,
+            &mut transcript_v,
+            128,
+        );
+        assert!(ok, "verification should pass for honest prover");
+    }
+
+    #[test]
+    fn commit_open_verify_6_vars() {
+        let n_vars = 6;
+        let (evals, poly) = make_poly(n_vars);
+
+        // n_cols = 2^3 = 8, rho_inv = 2 => cw_len = 16
+        let encoding = ReedSolomonEncoding::<F>::new(8, 2);
+        let out = commit::<F, B, _>(&evals, &encoding);
+
+        let point: Vec<FE> = (10..10 + n_vars).map(|x| FE::from(x as u64)).collect();
+        let claimed_value = poly.evaluate(point.clone()).expect("valid eval point");
+
+        let mut transcript_p = DefaultTranscript::<F>::new(&[0x01]);
+        let proof = prove(
+            &out.commitment,
+            &out.state,
+            &encoding,
+            &point,
+            &mut transcript_p,
+            128,
+        );
+
+        let mut transcript_v = DefaultTranscript::<F>::new(&[0x01]);
+        let ok = verify(
+            &out.commitment,
+            &proof,
+            &encoding,
+            &point,
+            &claimed_value,
+            &mut transcript_v,
+            128,
+        );
+        assert!(ok);
+    }
+
+    #[test]
+    fn wrong_evaluation_fails() {
+        let n_vars = 4;
+        let (evals, _poly) = make_poly(n_vars);
+
+        let encoding = ReedSolomonEncoding::<F>::new(4, 2);
+        let out = commit::<F, B, _>(&evals, &encoding);
+
+        let point: Vec<FE> = (1..=n_vars).map(|x| FE::from(x as u64)).collect();
+
+        let mut transcript_p = DefaultTranscript::<F>::new(&[0x42]);
+        let proof = prove(
+            &out.commitment,
+            &out.state,
+            &encoding,
+            &point,
+            &mut transcript_p,
+            128,
+        );
+
+        // Tamper with claimed value
+        let wrong_value = FE::from(999u64);
+        let mut transcript_v = DefaultTranscript::<F>::new(&[0x42]);
+        let ok = verify(
+            &out.commitment,
+            &proof,
+            &encoding,
+            &point,
+            &wrong_value,
+            &mut transcript_v,
+            128,
+        );
+        assert!(!ok, "verification should fail for wrong evaluation");
+    }
+
+    #[test]
+    fn rate_4_code() {
+        // Test with rate 1/4 code (more redundancy, fewer column openings needed)
+        let n_vars = 4;
+        let (evals, poly) = make_poly(n_vars);
+
+        // n_cols = 4, rho_inv = 4 => cw_len = 16
+        let encoding = ReedSolomonEncoding::<F>::new(4, 4);
+        let out = commit::<F, B, _>(&evals, &encoding);
+
+        let point: Vec<FE> = (1..=n_vars).map(|x| FE::from(x as u64)).collect();
+        let claimed_value = poly.evaluate(point.clone()).expect("valid eval point");
+
+        let mut transcript_p = DefaultTranscript::<F>::new(&[0xAB]);
+        let proof = prove(
+            &out.commitment,
+            &out.state,
+            &encoding,
+            &point,
+            &mut transcript_p,
+            128,
+        );
+
+        let mut transcript_v = DefaultTranscript::<F>::new(&[0xAB]);
+        let ok = verify(
+            &out.commitment,
+            &proof,
+            &encoding,
+            &point,
+            &claimed_value,
+            &mut transcript_v,
+            128,
+        );
+        assert!(ok);
+    }
+}
+
+// ---------- Brakedown (Expander) tests with Mersenne31 ----------
+
+mod brakedown {
+    use super::*;
+    use lambdaworks_math::field::fields::mersenne31::field::Mersenne31Field;
+
+    type F = Mersenne31Field;
+    type FE = FieldElement<F>;
+    type B = FieldElementVectorBackend<F, Keccak256, 32>;
+
+    fn make_poly(n_vars: usize) -> (Vec<FE>, DenseMultilinearPolynomial<F>) {
+        let n = 1usize << n_vars;
+        let evals: Vec<FE> = (1..=n).map(|x| FE::from(x as u64)).collect();
+        let poly = DenseMultilinearPolynomial::new(evals.clone());
+        (evals, poly)
+    }
+
+    #[test]
+    fn commit_open_verify_4_vars() {
+        let n_vars = 4;
+        let (evals, poly) = make_poly(n_vars);
+
+        // n_cols = 4 for 4 vars (2^(4-2) = 4)
+        let encoding = ExpanderEncoding::<F>::new(4, 0.25, 3, 1, 42);
+        let out = commit::<F, B, _>(&evals, &encoding);
+
+        let point: Vec<FE> = (1..=n_vars).map(|x| FE::from(x as u64)).collect();
+        let claimed_value = poly.evaluate(point.clone()).expect("valid eval point");
+
+        let mut transcript_p = DefaultTranscript::<F>::new(&[0x42]);
+        let proof = prove(
+            &out.commitment,
+            &out.state,
+            &encoding,
+            &point,
+            &mut transcript_p,
+            128,
+        );
+
+        let mut transcript_v = DefaultTranscript::<F>::new(&[0x42]);
+        let ok = verify(
+            &out.commitment,
+            &proof,
+            &encoding,
+            &point,
+            &claimed_value,
+            &mut transcript_v,
+            128,
+        );
+        assert!(ok, "Brakedown verification should pass for honest prover");
+    }
+
+    #[test]
+    fn commit_open_verify_6_vars() {
+        let n_vars = 6;
+        let (evals, poly) = make_poly(n_vars);
+
+        // n_cols = 2^3 = 8
+        let encoding = ExpanderEncoding::<F>::new(8, 0.25, 3, 1, 42);
+        let out = commit::<F, B, _>(&evals, &encoding);
+
+        let point: Vec<FE> = (5..5 + n_vars).map(|x| FE::from(x as u64)).collect();
+        let claimed_value = poly.evaluate(point.clone()).expect("valid eval point");
+
+        let mut transcript_p = DefaultTranscript::<F>::new(&[0x01]);
+        let proof = prove(
+            &out.commitment,
+            &out.state,
+            &encoding,
+            &point,
+            &mut transcript_p,
+            128,
+        );
+
+        let mut transcript_v = DefaultTranscript::<F>::new(&[0x01]);
+        let ok = verify(
+            &out.commitment,
+            &proof,
+            &encoding,
+            &point,
+            &claimed_value,
+            &mut transcript_v,
+            128,
+        );
+        assert!(ok);
+    }
+
+    #[test]
+    fn wrong_evaluation_fails() {
+        let n_vars = 4;
+        let (evals, _poly) = make_poly(n_vars);
+
+        let encoding = ExpanderEncoding::<F>::new(4, 0.25, 3, 1, 42);
+        let out = commit::<F, B, _>(&evals, &encoding);
+
+        let point: Vec<FE> = (1..=n_vars).map(|x| FE::from(x as u64)).collect();
+
+        let mut transcript_p = DefaultTranscript::<F>::new(&[0x42]);
+        let proof = prove(
+            &out.commitment,
+            &out.state,
+            &encoding,
+            &point,
+            &mut transcript_p,
+            128,
+        );
+
+        let wrong_value = FE::from(12345u64);
+        let mut transcript_v = DefaultTranscript::<F>::new(&[0x42]);
+        let ok = verify(
+            &out.commitment,
+            &proof,
+            &encoding,
+            &point,
+            &wrong_value,
+            &mut transcript_v,
+            128,
+        );
+        assert!(
+            !ok,
+            "Brakedown verification should fail for wrong evaluation"
+        );
+    }
+}
+
+// ---------- Tensor product tests ----------
+
+mod tensor {
+    use super::*;
+    use lambdaworks_math::field::fields::u64_prime_field::U64PrimeField;
+
+    type F = U64PrimeField<101>;
+    type FE = FieldElement<F>;
+
+    #[test]
+    fn tensor_vec_single() {
+        // tensor(r) = (1-r, r)
+        let r = FE::from(3u64);
+        let t = tensor_vec(&[r]);
+        assert_eq!(t.len(), 2);
+        assert_eq!(t[0], FE::from(101 - 2)); // 1 - 3 mod 101 = 99
+        assert_eq!(t[1], FE::from(3u64));
+    }
+
+    #[test]
+    fn tensor_vec_two() {
+        // tensor(r0, r1) = ((1-r0)(1-r1), (1-r0)*r1, r0*(1-r1), r0*r1)
+        let r0 = FE::from(2u64);
+        let r1 = FE::from(3u64);
+        let t = tensor_vec(&[r0, r1]);
+        assert_eq!(t.len(), 4);
+
+        let one = FE::one();
+        let one_minus_r0 = one.clone() - FE::from(2u64);
+        let one_minus_r1 = one.clone() - FE::from(3u64);
+
+        assert_eq!(t[0], one_minus_r0.clone() * one_minus_r1.clone());
+        assert_eq!(t[1], one_minus_r0.clone() * FE::from(3u64));
+        assert_eq!(t[2], FE::from(2u64) * one_minus_r1.clone());
+        assert_eq!(t[3], FE::from(2u64) * FE::from(3u64));
+    }
+
+    #[test]
+    fn tensor_product_evaluation() {
+        // For a multilinear polynomial f with evaluations on the boolean hypercube,
+        // f(r) = <tensor(r_L), M * tensor(r_R)> where M is the eval matrix.
+        let evals = vec![
+            FE::from(1u64),
+            FE::from(2u64),
+            FE::from(3u64),
+            FE::from(4u64),
+        ];
+        let poly = DenseMultilinearPolynomial::new(evals.clone());
+
+        let r = vec![FE::from(5u64), FE::from(7u64)];
+        let expected = poly.evaluate(r.clone()).expect("valid");
+
+        // Manual computation via tensor product:
+        // a = tensor(r[0]) = (1-5, 5) = (97, 5) mod 101
+        // b = tensor(r[1]) = (1-7, 7) = (95, 7) mod 101
+        // M = [[1, 2], [3, 4]]
+        // v = a^T * M = [97*1 + 5*3, 97*2 + 5*4] = [97+15, 194+20] = [112, 214] = [11, 12] mod 101
+        // result = <v, b> = 11*95 + 12*7 = 1045 + 84 = 1129 = 1129 mod 101 = 1129 - 11*101 = 1129 - 1111 = 18
+        let a = tensor_vec(&r[..1]);
+        let b = tensor_vec(&r[1..]);
+
+        let v0 = a[0].clone() * FE::from(1u64) + a[1].clone() * FE::from(3u64);
+        let v1 = a[0].clone() * FE::from(2u64) + a[1].clone() * FE::from(4u64);
+        let result = v0 * b[0].clone() + v1 * b[1].clone();
+        assert_eq!(result, expected);
+    }
+}
+
+// ---------- Matrix arrangement test ----------
+
+mod matrix_tests {
+    use super::*;
+    use lambdaworks_math::field::fields::u64_prime_field::U64PrimeField;
+
+    use crate::linear_code_pcs::matrix::Matrix;
+
+    type F = U64PrimeField<101>;
+    type FE = FieldElement<F>;
+
+    #[test]
+    fn eval_via_tensor_matrix_product() {
+        // f(x0, x1, x2, x3) with 16 evaluations
+        let evals: Vec<FE> = (1..=16).map(|x| FE::from(x as u64)).collect();
+        let poly = DenseMultilinearPolynomial::new(evals.clone());
+
+        // Matrix: 4 rows x 4 cols
+        let n_rows = 4;
+        let n_cols = 4;
+        let m = Matrix::new(n_rows, n_cols, evals);
+
+        let point: Vec<FE> = vec![
+            FE::from(2u64),
+            FE::from(3u64),
+            FE::from(5u64),
+            FE::from(7u64),
+        ];
+        let expected = poly.evaluate(point.clone()).expect("valid");
+
+        let a = tensor_vec(&point[..2]);
+        let b = tensor_vec(&point[2..]);
+
+        // v = a^T * M
+        let v = m.row_mul(&a);
+
+        // result = <v, b>
+        let result: FE = v
+            .iter()
+            .zip(b.iter())
+            .fold(FE::zero(), |acc, (vi, bi)| acc + vi.clone() * bi.clone());
+
+        assert_eq!(result, expected);
+    }
+}

--- a/crates/crypto/src/linear_code_pcs/tests.rs
+++ b/crates/crypto/src/linear_code_pcs/tests.rs
@@ -197,7 +197,7 @@ mod brakedown {
         let (evals, poly) = make_poly(n_vars);
 
         // n_cols = 4 for 4 vars (2^(4-2) = 4)
-        let encoding = ExpanderEncoding::<F>::new(4, 0.25, 3, 1, 42);
+        let encoding = ExpanderEncoding::<F>::new(4, 0.25, 3, 1, 42, (1, 25));
         let out = commit::<F, B, _>(&evals, &encoding);
 
         let point: Vec<FE> = (1..=n_vars).map(|x| FE::from(x as u64)).collect();
@@ -232,7 +232,7 @@ mod brakedown {
         let (evals, poly) = make_poly(n_vars);
 
         // n_cols = 2^3 = 8
-        let encoding = ExpanderEncoding::<F>::new(8, 0.25, 3, 1, 42);
+        let encoding = ExpanderEncoding::<F>::new(8, 0.25, 3, 1, 42, (1, 25));
         let out = commit::<F, B, _>(&evals, &encoding);
 
         let point: Vec<FE> = (5..5 + n_vars).map(|x| FE::from(x as u64)).collect();
@@ -266,7 +266,7 @@ mod brakedown {
         let n_vars = 4;
         let (evals, _poly) = make_poly(n_vars);
 
-        let encoding = ExpanderEncoding::<F>::new(4, 0.25, 3, 1, 42);
+        let encoding = ExpanderEncoding::<F>::new(4, 0.25, 3, 1, 42, (1, 25));
         let out = commit::<F, B, _>(&evals, &encoding);
 
         let point: Vec<FE> = (1..=n_vars).map(|x| FE::from(x as u64)).collect();

--- a/crates/crypto/src/linear_code_pcs/tests.rs
+++ b/crates/crypto/src/linear_code_pcs/tests.rs
@@ -204,7 +204,7 @@ mod ligero {
             .v
             .iter()
             .zip(b2.iter())
-            .fold(FE::zero(), |acc, (vi, bi)| acc + vi.clone() * bi.clone());
+            .fold(FE::zero(), |acc, (vi, bi)| acc + vi * bi);
 
         // With proper transcript binding, this MUST fail because the
         // transcript will derive different column indices
@@ -375,12 +375,12 @@ mod tensor {
         assert_eq!(t.len(), 4);
 
         let one = FE::one();
-        let one_minus_r0 = one.clone() - FE::from(2u64);
-        let one_minus_r1 = one.clone() - FE::from(3u64);
+        let one_minus_r0 = one - FE::from(2u64);
+        let one_minus_r1 = one - FE::from(3u64);
 
-        assert_eq!(t[0], one_minus_r0.clone() * one_minus_r1.clone());
-        assert_eq!(t[1], one_minus_r0.clone() * FE::from(3u64));
-        assert_eq!(t[2], FE::from(2u64) * one_minus_r1.clone());
+        assert_eq!(t[0], one_minus_r0 * one_minus_r1);
+        assert_eq!(t[1], one_minus_r0 * FE::from(3u64));
+        assert_eq!(t[2], FE::from(2u64) * one_minus_r1);
         assert_eq!(t[3], FE::from(2u64) * FE::from(3u64));
     }
 
@@ -408,9 +408,9 @@ mod tensor {
         let a = tensor_vec(&r[..1]);
         let b = tensor_vec(&r[1..]);
 
-        let v0 = a[0].clone() * FE::from(1u64) + a[1].clone() * FE::from(3u64);
-        let v1 = a[0].clone() * FE::from(2u64) + a[1].clone() * FE::from(4u64);
-        let result = v0 * b[0].clone() + v1 * b[1].clone();
+        let v0 = a[0] * FE::from(1u64) + a[1] * FE::from(3u64);
+        let v1 = a[0] * FE::from(2u64) + a[1] * FE::from(4u64);
+        let result = v0 * b[0] + v1 * b[1];
         assert_eq!(result, expected);
     }
 }
@@ -455,7 +455,7 @@ mod matrix_tests {
         let result: FE = v
             .iter()
             .zip(b.iter())
-            .fold(FE::zero(), |acc, (vi, bi)| acc + vi.clone() * bi.clone());
+            .fold(FE::zero(), |acc, (vi, bi)| acc + vi * bi);
 
         assert_eq!(result, expected);
     }

--- a/crates/crypto/src/linear_code_pcs/tests.rs
+++ b/crates/crypto/src/linear_code_pcs/tests.rs
@@ -172,6 +172,54 @@ mod ligero {
         );
         assert!(ok);
     }
+
+    #[test]
+    fn proof_replay_different_point_fails() {
+        let n_vars = 4;
+        let (evals, _poly) = make_poly(n_vars);
+        let encoding = ReedSolomonEncoding::<F>::new(4, 2);
+        let out = commit::<F, B, _>(&evals, &encoding);
+
+        // Generate proof for point_1
+        let point_1: Vec<FE> = (1..=n_vars).map(|x| FE::from(x as u64)).collect();
+        let mut transcript_p = DefaultTranscript::<F>::new(&[0x42]);
+        let proof = prove(
+            &out.commitment,
+            &out.state,
+            &encoding,
+            &point_1,
+            &mut transcript_p,
+            128,
+        );
+
+        // Try to verify the same proof against a different point_2
+        // that shares the same first half (so tensor-half `a` is identical)
+        // but differs in the second half
+        let mut point_2 = point_1.clone();
+        point_2[n_vars - 1] = FE::from(99u64);
+
+        // Compute the value the cheating verifier would claim
+        let b2 = tensor_vec(&point_2[n_vars / 2..]);
+        let fake_value: FE = proof
+            .v
+            .iter()
+            .zip(b2.iter())
+            .fold(FE::zero(), |acc, (vi, bi)| acc + vi.clone() * bi.clone());
+
+        // With proper transcript binding, this MUST fail because the
+        // transcript will derive different column indices
+        let mut transcript_v = DefaultTranscript::<F>::new(&[0x42]);
+        let ok = verify(
+            &out.commitment,
+            &proof,
+            &encoding,
+            &point_2,
+            &fake_value,
+            &mut transcript_v,
+            128,
+        );
+        assert!(!ok, "proof replay with different point must fail");
+    }
 }
 
 // ---------- Brakedown (Expander) tests with Mersenne31 ----------

--- a/crates/crypto/src/linear_code_pcs/traits.rs
+++ b/crates/crypto/src/linear_code_pcs/traits.rs
@@ -1,0 +1,23 @@
+use alloc::vec::Vec;
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+
+/// A linear error-correcting code used as the encoding backend for the
+/// Ligero/Brakedown polynomial commitment scheme.
+///
+/// Implementors provide:
+/// - **Reed-Solomon encoding** (Ligero): O(n log n) via FFT, requires an FFT-friendly field.
+/// - **Expander code encoding** (Brakedown): O(n) via sparse matrix multiplication, field-agnostic.
+pub trait LinearCodeEncoding<F: IsField>: Clone {
+    /// Encode a message of length `message_len()` into a codeword of length `codeword_len()`.
+    fn encode(&self, msg: &[FieldElement<F>]) -> Vec<FieldElement<F>>;
+
+    /// Length of the codeword produced by `encode`.
+    fn codeword_len(&self) -> usize;
+
+    /// Length of the message accepted by `encode`.
+    fn message_len(&self) -> usize;
+
+    /// Relative minimum distance of the code as `(numerator, denominator)`.
+    /// For RS with rate rho, this is `(1 - rho)`, e.g. `(1, 2)` for rate 1/2.
+    fn distance(&self) -> (usize, usize);
+}

--- a/crates/crypto/src/linear_code_pcs/utils.rs
+++ b/crates/crypto/src/linear_code_pcs/utils.rs
@@ -1,0 +1,18 @@
+/// Number of column openings needed for `sec_param` bits of security with
+/// code relative distance `delta_num / delta_den`.
+///
+/// `t = ceil(sec_param / log2(1 / (1 - delta/2)))`, capped at `n_ext_cols`
+/// so we never open more columns than exist.
+pub fn calculate_t(
+    sec_param: usize,
+    delta_num: usize,
+    delta_den: usize,
+    n_ext_cols: usize,
+) -> usize {
+    // delta/2
+    let half_delta = (delta_num as f64) / (delta_den as f64) / 2.0;
+    // log2(1 / (1 - delta/2))
+    let log_factor = -(1.0 - half_delta).log2();
+    let t = (sec_param as f64 / log_factor).ceil() as usize;
+    t.min(n_ext_cols)
+}

--- a/crates/crypto/src/linear_code_pcs/utils.rs
+++ b/crates/crypto/src/linear_code_pcs/utils.rs
@@ -1,17 +1,24 @@
 /// Number of column openings needed for `sec_param` bits of security with
 /// code relative distance `delta_num / delta_den`.
 ///
-/// `t = ceil(sec_param / log2(1 / (1 - delta)))`, capped at `n_ext_cols`
-/// so we never open more columns than exist.
+/// From Brakedown (Golovnev et al., CRYPTO 2023), Lemma 1 (p.14):
+/// The soundness error of the testing phase is `(1 - δ/3)^t`, where δ is the
+/// code's relative minimum distance and t is the number of opened columns.
+/// For λ bits of security: `t = ceil(λ / log2(1 / (1 - δ/3)))`.
+///
+/// Capped at `n_ext_cols` so we never open more columns than exist.
 pub fn calculate_t(
     sec_param: usize,
     delta_num: usize,
     delta_den: usize,
     n_ext_cols: usize,
 ) -> usize {
-    let delta = (delta_num as f64) / (delta_den as f64);
-    // log2(1 / (1 - delta))
-    let log_factor = -libm::log2(1.0 - delta);
+    // δ/3: the per-column catch probability from the Brakedown soundness analysis.
+    // The factor 1/3 comes from Claim 1 + Lemma 1: at most (δ/3)·N columns can be
+    // "bad" (where committed rows differ from their closest codewords), so each
+    // random column catches the cheat with probability ≥ δ/3.
+    let delta_third = (delta_num as f64) / (delta_den as f64) / 3.0;
+    let log_factor = -libm::log2(1.0 - delta_third);
     let t = libm::ceil(sec_param as f64 / log_factor) as usize;
     t.min(n_ext_cols)
 }
@@ -22,16 +29,20 @@ mod tests {
 
     #[test]
     fn calculate_t_rs_rate_half() {
-        // RS rate 1/2: delta = 1/2. Formula: t = ceil(128 / log2(1/(1-0.5))) = ceil(128/1) = 128
+        // RS rate 1/2: δ = 1/2, δ/3 = 1/6
+        // t = ceil(128 / log2(1/(1 - 1/6))) = ceil(128 / log2(6/5)) = ceil(128 / 0.2630) = 487
         let t = calculate_t(128, 1, 2, 1000);
-        assert_eq!(t, 128);
+        let expected = libm::ceil(128.0 / (-libm::log2(1.0 - 1.0 / 6.0))) as usize;
+        assert_eq!(t, expected);
     }
 
     #[test]
     fn calculate_t_rs_rate_quarter() {
-        // RS rate 1/4: delta = 3/4. Formula: t = ceil(128 / log2(1/(1-0.75))) = ceil(128/2) = 64
+        // RS rate 1/4: δ = 3/4, δ/3 = 1/4
+        // t = ceil(128 / log2(1/(1 - 1/4))) = ceil(128 / log2(4/3)) = ceil(128 / 0.4150) = 309
         let t = calculate_t(128, 3, 4, 1000);
-        assert_eq!(t, 64);
+        let expected = libm::ceil(128.0 / (-libm::log2(1.0 - 0.25))) as usize;
+        assert_eq!(t, expected);
     }
 
     #[test]
@@ -42,9 +53,9 @@ mod tests {
 
     #[test]
     fn calculate_t_small_distance() {
-        // delta = 1/25 = 0.04
-        let t = calculate_t(128, 1, 25, 10000);
-        let expected = libm::ceil(128.0_f64 / (-libm::log2(1.0 - 1.0 / 25.0_f64))) as usize;
+        // δ = 1/25 = 0.04, δ/3 ≈ 0.01333
+        let t = calculate_t(128, 1, 25, 100000);
+        let expected = libm::ceil(128.0_f64 / (-libm::log2(1.0 - 1.0 / 75.0_f64))) as usize;
         assert_eq!(t, expected);
     }
 }

--- a/crates/crypto/src/linear_code_pcs/utils.rs
+++ b/crates/crypto/src/linear_code_pcs/utils.rs
@@ -11,8 +11,8 @@ pub fn calculate_t(
 ) -> usize {
     let delta = (delta_num as f64) / (delta_den as f64);
     // log2(1 / (1 - delta))
-    let log_factor = -(1.0 - delta).log2();
-    let t = (sec_param as f64 / log_factor).ceil() as usize;
+    let log_factor = -libm::log2(1.0 - delta);
+    let t = libm::ceil(sec_param as f64 / log_factor) as usize;
     t.min(n_ext_cols)
 }
 
@@ -44,7 +44,7 @@ mod tests {
     fn calculate_t_small_distance() {
         // delta = 1/25 = 0.04
         let t = calculate_t(128, 1, 25, 10000);
-        let expected = (128.0_f64 / (-(1.0 - 1.0 / 25.0_f64).log2())).ceil() as usize;
+        let expected = libm::ceil(128.0_f64 / (-libm::log2(1.0 - 1.0 / 25.0_f64))) as usize;
         assert_eq!(t, expected);
     }
 }

--- a/crates/crypto/src/linear_code_pcs/utils.rs
+++ b/crates/crypto/src/linear_code_pcs/utils.rs
@@ -1,7 +1,7 @@
 /// Number of column openings needed for `sec_param` bits of security with
 /// code relative distance `delta_num / delta_den`.
 ///
-/// `t = ceil(sec_param / log2(1 / (1 - delta/2)))`, capped at `n_ext_cols`
+/// `t = ceil(sec_param / log2(1 / (1 - delta)))`, capped at `n_ext_cols`
 /// so we never open more columns than exist.
 pub fn calculate_t(
     sec_param: usize,
@@ -9,10 +9,42 @@ pub fn calculate_t(
     delta_den: usize,
     n_ext_cols: usize,
 ) -> usize {
-    // delta/2
-    let half_delta = (delta_num as f64) / (delta_den as f64) / 2.0;
-    // log2(1 / (1 - delta/2))
-    let log_factor = -(1.0 - half_delta).log2();
+    let delta = (delta_num as f64) / (delta_den as f64);
+    // log2(1 / (1 - delta))
+    let log_factor = -(1.0 - delta).log2();
     let t = (sec_param as f64 / log_factor).ceil() as usize;
     t.min(n_ext_cols)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calculate_t_rs_rate_half() {
+        // RS rate 1/2: delta = 1/2. Formula: t = ceil(128 / log2(1/(1-0.5))) = ceil(128/1) = 128
+        let t = calculate_t(128, 1, 2, 1000);
+        assert_eq!(t, 128);
+    }
+
+    #[test]
+    fn calculate_t_rs_rate_quarter() {
+        // RS rate 1/4: delta = 3/4. Formula: t = ceil(128 / log2(1/(1-0.75))) = ceil(128/2) = 64
+        let t = calculate_t(128, 3, 4, 1000);
+        assert_eq!(t, 64);
+    }
+
+    #[test]
+    fn calculate_t_capped_at_n_ext_cols() {
+        let t = calculate_t(128, 1, 2, 50);
+        assert_eq!(t, 50);
+    }
+
+    #[test]
+    fn calculate_t_small_distance() {
+        // delta = 1/25 = 0.04
+        let t = calculate_t(128, 1, 25, 10000);
+        let expected = (128.0_f64 / (-(1.0 - 1.0 / 25.0_f64).log2())).ceil() as usize;
+        assert_eq!(t, expected);
+    }
 }

--- a/crates/crypto/src/linear_code_pcs/verify.rs
+++ b/crates/crypto/src/linear_code_pcs/verify.rs
@@ -7,13 +7,7 @@ use crate::merkle_tree::traits::IsMerkleTreeBackend;
 use super::commit::tensor_vec;
 use super::data_structures::{LinCodeCommitment, LinCodeProof};
 use super::traits::LinearCodeEncoding;
-
-/// Number of column openings needed (same formula as in prove.rs).
-fn calculate_t(sec_param: usize, delta_num: usize, delta_den: usize) -> usize {
-    let half_delta = (delta_num as f64) / (delta_den as f64) / 2.0;
-    let log_factor = -(1.0 - half_delta).log2();
-    (sec_param as f64 / log_factor).ceil() as usize
-}
+use super::utils::calculate_t;
 
 /// Verify an evaluation proof for the linear-code PCS.
 ///
@@ -64,9 +58,8 @@ where
     }
 
     let (d_num, d_den) = encoding.distance();
-    let t = calculate_t(sec_param, d_num, d_den);
-
     let n_ext_cols = commitment.n_ext_cols;
+    let t = calculate_t(sec_param, d_num, d_den, n_ext_cols);
     let col_indices: Vec<usize> = (0..t)
         .map(|_| transcript.sample_u64(n_ext_cols as u64) as usize)
         .collect();

--- a/crates/crypto/src/linear_code_pcs/verify.rs
+++ b/crates/crypto/src/linear_code_pcs/verify.rs
@@ -1,0 +1,128 @@
+use alloc::vec::Vec;
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+
+use crate::fiat_shamir::is_transcript::IsTranscript;
+use crate::merkle_tree::traits::IsMerkleTreeBackend;
+
+use super::commit::tensor_vec;
+use super::data_structures::{LinCodeCommitment, LinCodeProof};
+use super::traits::LinearCodeEncoding;
+
+/// Number of column openings needed (same formula as in prove.rs).
+fn calculate_t(sec_param: usize, delta_num: usize, delta_den: usize) -> usize {
+    let half_delta = (delta_num as f64) / (delta_den as f64) / 2.0;
+    let log_factor = -(1.0 - half_delta).log2();
+    (sec_param as f64 / log_factor).ceil() as usize
+}
+
+/// Verify an evaluation proof for the linear-code PCS.
+///
+/// Checks that the committed polynomial evaluates to `claimed_value` at `point`.
+///
+/// # Verification steps
+/// 1. Recompute tensor vectors `a` and `b` from the evaluation point.
+/// 2. Replay the transcript to re-derive the column indices.
+/// 3. Encode the claimed vector `v` to get `w = encode(v)`.
+/// 4. For each opened column, verify:
+///    - Merkle proof against the commitment root.
+///    - Consistency: `<a, col_j> == w[j]` (the inner product of tensor-half `a`
+///      with the column equals the encoded value at that position).
+/// 5. Verify `<v, b> == claimed_value`.
+///
+/// # Returns
+/// `true` if all checks pass, `false` otherwise.
+pub fn verify<F, B, E>(
+    commitment: &LinCodeCommitment<B>,
+    proof: &LinCodeProof<F, B>,
+    encoding: &E,
+    point: &[FieldElement<F>],
+    claimed_value: &FieldElement<F>,
+    transcript: &mut impl IsTranscript<F>,
+    sec_param: usize,
+) -> bool
+where
+    F: IsField,
+    B: IsMerkleTreeBackend<Data = Vec<FieldElement<F>>>,
+    B::Node: AsRef<[u8]>,
+    E: LinearCodeEncoding<F>,
+{
+    let v_count = point.len();
+    let half = v_count / 2;
+
+    // 1. Recompute tensor vectors
+    let a = tensor_vec(&point[..half]);
+    let b = tensor_vec(&point[half..]);
+
+    if a.len() != commitment.n_rows || b.len() != commitment.n_cols {
+        return false;
+    }
+
+    // 2. Replay transcript to re-derive column indices
+    transcript.append_bytes(commitment.root.as_ref());
+    for vi in &proof.v {
+        transcript.append_field_element(vi);
+    }
+
+    let (d_num, d_den) = encoding.distance();
+    let t = calculate_t(sec_param, d_num, d_den);
+
+    let n_ext_cols = commitment.n_ext_cols;
+    let col_indices: Vec<usize> = (0..t)
+        .map(|_| transcript.sample_u64(n_ext_cols as u64) as usize)
+        .collect();
+
+    // Check that we have the right number of opened columns
+    if proof.columns.len() != t {
+        return false;
+    }
+
+    // 3. Encode v to get w = encode(v)
+    if proof.v.len() != encoding.message_len() {
+        return false;
+    }
+    let w = encoding.encode(&proof.v);
+
+    // 4. For each opened column, verify Merkle proof and consistency
+    for (i, col) in proof.columns.iter().enumerate() {
+        let expected_idx = col_indices[i];
+        if col.index != expected_idx {
+            return false;
+        }
+
+        // Verify column length
+        if col.values.len() != commitment.n_rows {
+            return false;
+        }
+
+        // Verify Merkle proof
+        if !col
+            .merkle_proof
+            .verify::<B>(&commitment.root, col.index, &col.values)
+        {
+            return false;
+        }
+
+        // Consistency check: <a, col_j> == w[col.index]
+        let inner_product: FieldElement<F> = a
+            .iter()
+            .zip(col.values.iter())
+            .fold(FieldElement::<F>::zero(), |acc, (ai, ci)| {
+                acc + ai.clone() * ci.clone()
+            });
+
+        if inner_product != w[col.index] {
+            return false;
+        }
+    }
+
+    // 5. Final evaluation check: <v, b> == claimed_value
+    let eval: FieldElement<F> = proof
+        .v
+        .iter()
+        .zip(b.iter())
+        .fold(FieldElement::<F>::zero(), |acc, (vi, bi)| {
+            acc + vi.clone() * bi.clone()
+        });
+
+    eval == *claimed_value
+}

--- a/crates/crypto/src/linear_code_pcs/verify.rs
+++ b/crates/crypto/src/linear_code_pcs/verify.rs
@@ -51,8 +51,14 @@ where
         return false;
     }
 
-    // 2. Replay transcript to re-derive column indices
+    // 2. Replay transcript to re-derive column indices.
+    // Bind all public statement parameters (root, point, claimed_value, v)
+    // to ensure proof cannot be replayed for a different statement.
     transcript.append_bytes(commitment.root.as_ref());
+    for pi in point {
+        transcript.append_field_element(pi);
+    }
+    transcript.append_field_element(claimed_value);
     for vi in &proof.v {
         transcript.append_field_element(vi);
     }


### PR DESCRIPTION
…scheme

Implement a hash-based PCS for multilinear polynomials supporting two pluggable encoding backends:
- Reed-Solomon (Ligero): O(N log N) prover via FFT, requires FFT-friendly field
- Expander codes (Brakedown): O(N) prover via sparse matrix multiply, field-agnostic

No trusted setup, post-quantum secure. Uses existing FieldElementVectorBackend for Merkle commitments and Fiat-Shamir transcript for non-interactive proofs.

Tested with Goldilocks (Ligero) and Mersenne31 (Brakedown) fields.
