### PR TITLE
Add spartan zkSNARK with Zeromorph PCS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/provers/sumcheck",
     "crates/provers/gkr",
     "crates/provers/gkr-logup",
+    "crates/provers/spartan",
     "crates/provers/winterfell_adapter",
     "examples/merkle-tree-cli",
     "examples/prove-miden",
@@ -47,6 +48,7 @@ lambdaworks-circom-adapter = { path = "./crates/provers/groth16/circom-adapter" 
 lambdaworks-sumcheck = { path = "./crates/provers/sumcheck" }
 lambdaworks-sumcheck-gkr = { path = "./crates/provers/gkr" }
 lambdaworks-gkr-logup = { path = "./crates/provers/gkr-logup" }
+lambdaworks-spartan = { path = "./crates/provers/spartan" }
 lambdaworks-winterfell-adapter = { path = "./crates/provers/winterfell_adapter" }
 stark-platinum-prover = { path = "./crates/provers/stark" }
 iai-callgrind = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ For more examples, see the [examples directory](./examples/) and the [math crate
 - [STARK Prover](./crates/provers/stark/)
 - [Plonk Prover](./crates/provers/plonk/)
 - [Groth 16](./crates/provers/groth16/)
+- [Spartan](./crates/provers/spartan/)
 
 ### Crypto
 
@@ -211,6 +212,7 @@ List of symbols:
 | Groth16    | :heavy_check_mark: | :heavy_check_mark: | :x:         | :heavy_check_mark: | :x:             | :x:                |
 | Plonk      | 🏗️                 | :heavy_check_mark: | :x:         | :heavy_check_mark: | :x:             | :heavy_check_mark: |
 | GKR        | :heavy_check_mark: | :heavy_check_mark: | :x:         | :heavy_check_mark: | :x:             | :x:                |
+| Spartan    | :heavy_check_mark: | :x:                | :x:         | :x:                | :x:             | :x:                |
 | **Polynomial Commitment Schemes** | **Lambdaworks**    | **Arkworks**       | **Plonky3**        | **gnark**          | **Constantine**    | **Halo2**          |
 | KZG10                             | :heavy_check_mark: | :heavy_check_mark: | :x:                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | 
 | FRI                               | :heavy_check_mark: | :x:                | :heavy_check_mark: | :heavy_check_mark: | :x:                | :x:                |

--- a/crates/crypto/src/commitments/kzg.rs
+++ b/crates/crypto/src/commitments/kzg.rs
@@ -142,6 +142,11 @@ impl<F: IsPrimeField, P: IsPairing> KateZaveruchaGoldberg<F, P> {
             phantom: PhantomData,
         }
     }
+
+    /// Returns the number of powers in the SRS (maximum polynomial degree + 1 supported).
+    pub fn srs_size(&self) -> usize {
+        self.srs.powers_main_group.len()
+    }
 }
 
 impl<const N: usize, F: IsPrimeField<CanonicalType = UnsignedInteger<N>>, P: IsPairing>

--- a/crates/crypto/src/commitments/mod.rs
+++ b/crates/crypto/src/commitments/mod.rs
@@ -1,2 +1,6 @@
 pub mod kzg;
+#[cfg(feature = "std")]
+pub mod multilinear;
 pub mod traits;
+#[cfg(feature = "std")]
+pub mod zeromorph;

--- a/crates/crypto/src/commitments/multilinear.rs
+++ b/crates/crypto/src/commitments/multilinear.rs
@@ -1,0 +1,62 @@
+//! Multilinear polynomial commitment scheme (PCS) trait.
+//!
+//! Defines the interface for committing to a multilinear polynomial,
+//! opening it at a point, and verifying the opening.
+
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolynomial;
+
+/// Error type for multilinear PCS operations.
+#[derive(Debug)]
+pub struct PcsError(pub String);
+
+impl std::fmt::Display for PcsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PCS error: {}", self.0)
+    }
+}
+
+impl std::error::Error for PcsError {}
+
+/// Trait for multilinear polynomial commitment schemes.
+///
+/// Defines the interface for committing to a multilinear polynomial,
+/// opening it at a point, and verifying the opening.
+///
+/// All implementations must also implement `serialize_commitment` so that
+/// the Fiat-Shamir transcript can absorb the commitment before challenges
+/// are drawn — a requirement for protocol soundness.
+pub trait IsMultilinearPCS<F: IsField>
+where
+    F::BaseType: Send + Sync,
+{
+    type Commitment: Clone;
+    type Proof: Clone;
+    type Error: std::error::Error;
+
+    /// Commit to a multilinear polynomial.
+    fn commit(&self, poly: &DenseMultilinearPolynomial<F>)
+        -> Result<Self::Commitment, Self::Error>;
+
+    /// Open the polynomial at a point, returning the value and a proof.
+    fn open(
+        &self,
+        poly: &DenseMultilinearPolynomial<F>,
+        point: &[FieldElement<F>],
+    ) -> Result<(FieldElement<F>, Self::Proof), Self::Error>;
+
+    /// Verify an opening proof.
+    fn verify(
+        &self,
+        commitment: &Self::Commitment,
+        point: &[FieldElement<F>],
+        value: &FieldElement<F>,
+        proof: &Self::Proof,
+    ) -> Result<bool, Self::Error>;
+
+    /// Serialize a commitment to bytes for Fiat-Shamir transcript absorption.
+    ///
+    /// Must be implemented so that the prover and verifier can both absorb the
+    /// commitment into the transcript before drawing challenges.
+    fn serialize_commitment(commitment: &Self::Commitment) -> Vec<u8>;
+}

--- a/crates/crypto/src/commitments/multilinear.rs
+++ b/crates/crypto/src/commitments/multilinear.rs
@@ -45,6 +45,20 @@ where
         point: &[FieldElement<F>],
     ) -> Result<(FieldElement<F>, Self::Proof), Self::Error>;
 
+    /// Open with a precomputed commitment, avoiding redundant commitment recomputation.
+    ///
+    /// Default implementation ignores the commitment and delegates to `open()`.
+    /// PCS implementations that need the commitment for Fiat-Shamir (e.g., Zeromorph)
+    /// should override this to avoid the redundant MSM.
+    fn open_with_commitment(
+        &self,
+        poly: &DenseMultilinearPolynomial<F>,
+        point: &[FieldElement<F>],
+        _commitment: &Self::Commitment,
+    ) -> Result<(FieldElement<F>, Self::Proof), Self::Error> {
+        self.open(poly, point)
+    }
+
     /// Verify an opening proof.
     fn verify(
         &self,

--- a/crates/crypto/src/commitments/zeromorph.rs
+++ b/crates/crypto/src/commitments/zeromorph.rs
@@ -364,12 +364,23 @@ mod tests {
         // 2-variable polynomial needs SRS of size >= 4, but we only give 2.
         let srs = create_srs(2); // undersized: only 2 powers
         let pcs = ZeromorphPCS::new(Kzg::new(srs));
-        let evals = vec![FE::from(1u64), FE::from(2u64), FE::from(3u64), FE::from(4u64)];
+        let evals = vec![
+            FE::from(1u64),
+            FE::from(2u64),
+            FE::from(3u64),
+            FE::from(4u64),
+        ];
         let poly = DenseMultilinearPolynomial::new(evals);
         let result = pcs.commit(&poly);
-        assert!(result.is_err(), "commit with undersized SRS should return Err");
+        assert!(
+            result.is_err(),
+            "commit with undersized SRS should return Err"
+        );
         let msg = result.err().unwrap().to_string();
-        assert!(msg.contains("4") && msg.contains("2"), "error should mention sizes: {msg}");
+        assert!(
+            msg.contains("4") && msg.contains("2"),
+            "error should mention sizes: {msg}"
+        );
     }
 
     #[test]

--- a/crates/crypto/src/commitments/zeromorph.rs
+++ b/crates/crypto/src/commitments/zeromorph.rs
@@ -1,10 +1,11 @@
 //! Zeromorph PCS: reduces multilinear evaluation to univariate KZG opening.
 //! Reference: Kohrita & Towa, "Zeromorph" (2023), https://eprint.iacr.org/2023/917
 
-use lambdaworks_crypto::commitments::kzg::KateZaveruchaGoldberg;
-use lambdaworks_crypto::commitments::traits::IsCommitmentScheme;
-use lambdaworks_crypto::fiat_shamir::default_transcript::DefaultTranscript;
-use lambdaworks_crypto::fiat_shamir::is_transcript::IsTranscript;
+use crate::commitments::kzg::KateZaveruchaGoldberg;
+use crate::commitments::multilinear::{IsMultilinearPCS, PcsError};
+use crate::commitments::traits::IsCommitmentScheme;
+use crate::fiat_shamir::default_transcript::DefaultTranscript;
+use crate::fiat_shamir::is_transcript::IsTranscript;
 use lambdaworks_math::elliptic_curve::traits::IsPairing;
 use lambdaworks_math::field::element::FieldElement;
 use lambdaworks_math::field::traits::{HasDefaultTranscript, IsField, IsPrimeField};
@@ -12,8 +13,6 @@ use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolyno
 use lambdaworks_math::polynomial::Polynomial;
 use lambdaworks_math::traits::{AsBytes, ByteConversion};
 use lambdaworks_math::unsigned_integer::element::UnsignedInteger;
-
-use super::{IsMultilinearPCS, PcsError};
 
 /// Zeromorph PCS backed by KZG over an elliptic pairing.
 #[derive(Clone)]
@@ -154,12 +153,12 @@ where
 ///
 /// Absorbs the f commitment, evaluation point, claimed value, and quotient
 /// commitments, then samples the evaluation challenge x and batching factor upsilon.
-// TODO(security): The Zeromorph internal transcript is independent of the outer
-// Spartan transcript. In a standalone Spartan, the evaluation point r_y is derived
-// from the Spartan transcript (which binds R1CS + public inputs + commitment), so
-// proof transplant attacks are hard in practice. For recursive/IVC settings, the
+// TODO(security): The Zeromorph internal transcript is independent of any outer
+// proof system transcript. In a standalone Spartan, the evaluation point r_y is
+// derived from the Spartan transcript (which binds R1CS + public inputs + commitment),
+// so proof transplant attacks are hard in practice. For recursive/IVC settings, the
 // `IsMultilinearPCS::open` and `verify` signatures should be extended to accept an
-// outer transcript binding (e.g., a hash of the current Spartan transcript state).
+// outer transcript binding (e.g., a hash of the current proof system transcript state).
 fn derive_zeromorph_challenges<F, P>(
     f_commitment: &P::G1Point,
     point: &[FieldElement<F>],
@@ -309,7 +308,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lambdaworks_crypto::commitments::kzg::StructuredReferenceString;
+    use crate::commitments::kzg::StructuredReferenceString;
     use lambdaworks_math::cyclic_group::IsGroup;
     use lambdaworks_math::elliptic_curve::short_weierstrass::curves::bls12_381::{
         curve::BLS12381Curve,
@@ -348,7 +347,6 @@ mod tests {
 
     #[test]
     fn test_zeromorph_pcs_1_var() {
-        // f̃(x_0) with evals [a, b]: f̃(0) = a, f̃(1) = b
         let pcs = new_zeromorph(1);
         let evals = vec![FE::from(3u64), FE::from(7u64)];
         let poly = DenseMultilinearPolynomial::new(evals);
@@ -361,7 +359,6 @@ mod tests {
 
     #[test]
     fn test_zeromorph_pcs_2_vars() {
-        // f̃(x_0, x_1) with evals [1, 2, 3, 4]
         let pcs = new_zeromorph(2);
         let evals = vec![
             FE::from(1u64),
@@ -379,7 +376,6 @@ mod tests {
 
     #[test]
     fn test_zeromorph_pcs_wrong_value() {
-        // Verifier should reject a tampered claimed value
         let pcs = new_zeromorph(2);
         let evals = vec![
             FE::from(1u64),
@@ -400,7 +396,6 @@ mod tests {
 
     #[test]
     fn test_zeromorph_pcs_3_vars() {
-        // f̃(x_0, x_1, x_2) with 8 evaluations
         let pcs = new_zeromorph(3);
         let evals: Vec<FE> = (1u64..=8).map(FE::from).collect();
         let poly = DenseMultilinearPolynomial::new(evals);
@@ -413,7 +408,6 @@ mod tests {
 
     #[test]
     fn test_zeromorph_pcs_tampered_commitment() {
-        // A proof generated for commitment C should not verify under a different C'.
         let pcs = new_zeromorph(2);
         let evals = vec![
             FE::from(1u64),
@@ -426,7 +420,6 @@ mod tests {
         let point = vec![FE::from(2u64), FE::from(5u64)];
         let (value, proof) = pcs.open(&poly, &point).unwrap();
 
-        // Tamper: use commitment from a different polynomial
         let other_evals = vec![
             FE::from(9u64),
             FE::from(9u64),
@@ -444,7 +437,6 @@ mod tests {
 
     #[test]
     fn test_zeromorph_pcs_constant_poly() {
-        // f̃ = constant 42: all evals are 42, so f̃(u) = 42 for any u.
         let pcs = new_zeromorph(2);
         let evals = vec![FE::from(42u64); 4];
         let poly = DenseMultilinearPolynomial::new(evals);
@@ -458,7 +450,6 @@ mod tests {
 
     #[test]
     fn test_zeromorph_pcs_4_vars() {
-        // f̃(x_0,...,x_3) with 16 evaluations
         let pcs = new_zeromorph(4);
         let evals: Vec<FE> = (1u64..=16).map(FE::from).collect();
         let poly = DenseMultilinearPolynomial::new(evals);

--- a/crates/crypto/src/commitments/zeromorph.rs
+++ b/crates/crypto/src/commitments/zeromorph.rs
@@ -205,6 +205,13 @@ where
         &self,
         poly: &DenseMultilinearPolynomial<F>,
     ) -> Result<Self::Commitment, Self::Error> {
+        let n_evals = poly.evals().len();
+        if n_evals > self.kzg.srs_size() {
+            return Err(PcsError(format!(
+                "polynomial has {n_evals} evaluations but SRS only supports {}",
+                self.kzg.srs_size()
+            )));
+        }
         let f_hat = Polynomial::new(poly.evals());
         let g1 = self.kzg.commit(&f_hat);
         Ok(ZeromorphCommitment { g1 })
@@ -221,6 +228,13 @@ where
                 "point length {} != num_vars {}",
                 point.len(),
                 n
+            )));
+        }
+        let n_evals = poly.evals().len();
+        if n_evals > self.kzg.srs_size() {
+            return Err(PcsError(format!(
+                "polynomial has {n_evals} evaluations but SRS only supports {}",
+                self.kzg.srs_size()
             )));
         }
 
@@ -343,6 +357,19 @@ mod tests {
     fn new_zeromorph(num_vars: usize) -> Zeromorph {
         let srs = create_srs(1 << num_vars);
         ZeromorphPCS::new(Kzg::new(srs))
+    }
+
+    #[test]
+    fn test_zeromorph_undersized_srs_returns_error() {
+        // 2-variable polynomial needs SRS of size >= 4, but we only give 2.
+        let srs = create_srs(2); // undersized: only 2 powers
+        let pcs = ZeromorphPCS::new(Kzg::new(srs));
+        let evals = vec![FE::from(1u64), FE::from(2u64), FE::from(3u64), FE::from(4u64)];
+        let poly = DenseMultilinearPolynomial::new(evals);
+        let result = pcs.commit(&poly);
+        assert!(result.is_err(), "commit with undersized SRS should return Err");
+        let msg = result.err().unwrap().to_string();
+        assert!(msg.contains("4") && msg.contains("2"), "error should mention sizes: {msg}");
     }
 
     #[test]

--- a/crates/crypto/src/commitments/zeromorph.rs
+++ b/crates/crypto/src/commitments/zeromorph.rs
@@ -152,13 +152,26 @@ where
 /// Derive internal Fiat-Shamir challenges for Zeromorph.
 ///
 /// Absorbs the f commitment, evaluation point, claimed value, and quotient
-/// commitments, then samples the evaluation challenge x and batching factor upsilon.
-// TODO(security): The Zeromorph internal transcript is independent of any outer
-// proof system transcript. In a standalone Spartan, the evaluation point r_y is
-// derived from the Spartan transcript (which binds R1CS + public inputs + commitment),
-// so proof transplant attacks are hard in practice. For recursive/IVC settings, the
-// `IsMultilinearPCS::open` and `verify` signatures should be extended to accept an
-// outer transcript binding (e.g., a hash of the current proof system transcript state).
+/// commitments, then samples the evaluation challenge x and batching factor υ.
+///
+/// # Known limitation: independent transcript
+///
+/// This function creates a **fresh, standalone** `DefaultTranscript` that is NOT
+/// bound to any outer proof system transcript. Concretely:
+///
+/// - **Standalone Spartan (safe):** The evaluation point `r_y` passed to this
+///   function is derived from the Spartan Fiat-Shamir transcript, which already
+///   binds the R1CS instance, public inputs, and witness commitment. A different
+///   Spartan proof session produces a different `r_y`, making proof-transplant
+///   attacks computationally infeasible.
+///
+/// - **Recursive / IVC settings (unsafe):** If multiple Zeromorph openings share
+///   a context (e.g., recursive proof composition), the independent transcript
+///   enables transplanting a sub-proof from one context to another. To fix this,
+///   `IsMultilinearPCS::open` and `verify` should be extended to accept an outer
+///   transcript binding (e.g., a hash of the current proof system state).
+///
+/// Reference: Zeromorph paper (Kohrita & Towa, ePrint 2023/917), Section 4.
 fn derive_zeromorph_challenges<F, P>(
     f_commitment: &P::G1Point,
     point: &[FieldElement<F>],

--- a/crates/crypto/src/commitments/zeromorph.rs
+++ b/crates/crypto/src/commitments/zeromorph.rs
@@ -313,8 +313,7 @@ where
             .map_err(|e| PcsError(format!("{e:?}")))?;
 
         let q_hats = compute_zeromorph_quotients(poly.evals(), point);
-        let q_commitments: Vec<P::G1Point> =
-            q_hats.iter().map(|q| self.kzg.commit(q)).collect();
+        let q_commitments: Vec<P::G1Point> = q_hats.iter().map(|q| self.kzg.commit(q)).collect();
 
         // Use the provided commitment instead of recomputing it
         let (x, upsilon) =

--- a/crates/crypto/src/commitments/zeromorph.rs
+++ b/crates/crypto/src/commitments/zeromorph.rs
@@ -286,6 +286,61 @@ where
         ))
     }
 
+    fn open_with_commitment(
+        &self,
+        poly: &DenseMultilinearPolynomial<F>,
+        point: &[FieldElement<F>],
+        commitment: &Self::Commitment,
+    ) -> Result<(FieldElement<F>, Self::Proof), Self::Error> {
+        let n = poly.num_vars();
+        if point.len() != n {
+            return Err(PcsError(format!(
+                "point length {} != num_vars {}",
+                point.len(),
+                n
+            )));
+        }
+        let n_evals = poly.evals().len();
+        if n_evals > self.kzg.srs_size() {
+            return Err(PcsError(format!(
+                "polynomial has {n_evals} evaluations but SRS only supports {}",
+                self.kzg.srs_size()
+            )));
+        }
+
+        let value = poly
+            .evaluate(point.to_vec())
+            .map_err(|e| PcsError(format!("{e:?}")))?;
+
+        let q_hats = compute_zeromorph_quotients(poly.evals(), point);
+        let q_commitments: Vec<P::G1Point> =
+            q_hats.iter().map(|q| self.kzg.commit(q)).collect();
+
+        // Use the provided commitment instead of recomputing it
+        let (x, upsilon) =
+            derive_zeromorph_challenges::<F, P>(&commitment.g1, point, &value, &q_commitments);
+
+        let f_hat = Polynomial::new(poly.evals());
+        let z_f = f_hat.evaluate(&x);
+        let z_qs: Vec<FieldElement<F>> = q_hats.iter().map(|q| q.evaluate(&x)).collect();
+
+        let all_polys: Vec<Polynomial<FieldElement<F>>> =
+            std::iter::once(f_hat).chain(q_hats).collect();
+        let all_ys: Vec<FieldElement<F>> =
+            std::iter::once(z_f.clone()).chain(z_qs.clone()).collect();
+        let kzg_proof = self.kzg.open_batch(&x, &all_ys, &all_polys, &upsilon);
+
+        Ok((
+            value,
+            ZeromorphProof {
+                q_commitments,
+                z_f,
+                z_qs,
+                kzg_proof,
+            },
+        ))
+    }
+
     fn verify(
         &self,
         commitment: &Self::Commitment,

--- a/crates/provers/README.md
+++ b/crates/provers/README.md
@@ -6,12 +6,14 @@ This folder contains the different provers currently supported by lambdaworks:
 - [Groth 16](./groth16/)
 - [Plonk](./plonk/)
 - [STARKs](./stark/)
+- [Spartan](./spartan/)
 - [Cairo](https://github.com/lambdaclass/lambdaworks/tree/a591186e6c4dd53301b03b4ddd69369abe99f960/provers/cairo) - This is only for learning purposes and no longer supported. The [docs](../docs/src/starks/) still contain information that could be useful to understand and learn how Cairo works.
 
 The reference papers for each of the provers is given below:
 - [Groth 16](https://eprint.iacr.org/2016/260)
 - [Plonk](https://eprint.iacr.org/2019/953)
 - [STARKs](https://eprint.iacr.org/2018/046.pdf)
+- [Spartan](https://eprint.iacr.org/2019/550)
 
 A brief description of the Plonk and STARKs provers can be found [here](https://github.com/lambdaclass/lambdaworks/tree/main/docs/src)
 
@@ -19,6 +21,7 @@ Using one prover or another depends on usecase and other desired properties. We 
 - Groth 16: Shortest proof length. Security depends on pairing-friendly elliptic curves. Needs a new trusted setup for every program you want to prove.
 - Plonk (using KZG as commitment scheme): Short proof length. Security depends on pairing-friendly elliptic curves. Universal trusted setup.
 - STARKs: longer proof length. Security depends on collision-resistant hash functions. Conjectured to be post-quantum secure. Transparent (no trusted setup).
+- Spartan: Transparent (no trusted setup). Proves R1CS satisfiability directly using two rounds of the Sumcheck Protocol and a multilinear PCS. $O(n)$ prover work.
 
 ## Using provers
 

--- a/crates/provers/spartan/Cargo.toml
+++ b/crates/provers/spartan/Cargo.toml
@@ -11,3 +11,4 @@ lambdaworks-sumcheck = { workspace = true }
 
 [dev-dependencies]
 lambdaworks-groth16 = { workspace = true }
+rand = "0.8.5"

--- a/crates/provers/spartan/Cargo.toml
+++ b/crates/provers/spartan/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 thiserror = "1.0"
 lambdaworks-math = { workspace = true, features = ["std"] }
-lambdaworks-crypto = { workspace = true }
+lambdaworks-crypto = { workspace = true, features = ["std"] }
 lambdaworks-sumcheck = { workspace = true }
 
 [dev-dependencies]

--- a/crates/provers/spartan/Cargo.toml
+++ b/crates/provers/spartan/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "lambdaworks-spartan"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+thiserror = "1.0"
+lambdaworks-math = { workspace = true, features = ["std"] }
+lambdaworks-crypto = { workspace = true }
+lambdaworks-sumcheck = { workspace = true }
+
+[dev-dependencies]
+lambdaworks-groth16 = { workspace = true }

--- a/crates/provers/spartan/Cargo.toml
+++ b/crates/provers/spartan/Cargo.toml
@@ -11,4 +11,3 @@ lambdaworks-sumcheck = { workspace = true }
 
 [dev-dependencies]
 lambdaworks-groth16 = { workspace = true }
-rand = "0.8.5"

--- a/crates/provers/spartan/Cargo.toml
+++ b/crates/provers/spartan/Cargo.toml
@@ -11,3 +11,8 @@ lambdaworks-sumcheck = { workspace = true }
 
 [dev-dependencies]
 lambdaworks-groth16 = { workspace = true }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "spartan_bench"
+harness = false

--- a/crates/provers/spartan/README.md
+++ b/crates/provers/spartan/README.md
@@ -1,0 +1,117 @@
+# Spartan
+
+An implementation of the [Spartan](https://eprint.iacr.org/2019/550) zkSNARK prover for R1CS satisfiability.
+
+**Warning:** This implementation is for educational purposes and should not be used in production.
+
+## Overview
+
+Spartan is a zkSNARK that proves knowledge of a witness satisfying an R1CS instance without a trusted setup. The prover's work is $O(n)$ field operations where $n$ is the number of R1CS constraints, making it one of the most efficient transparent SNARKs for general circuits.
+
+The protocol combines two phases of the [Sumcheck Protocol](../sumcheck/) with a multilinear Polynomial Commitment Scheme (PCS) to produce a succinct proof. The verifier only needs to evaluate three sparse matrix polynomials and verify a single PCS opening, achieving $O(\sqrt{n})$ verification time.
+
+### Key Features
+
+- **Transparent**: No trusted setup required; all randomness is derived via Fiat-Shamir.
+- **R1CS-native**: Directly proves $(Az) \cdot (Bz) = Cz$ without conversion to other arithmetizations.
+- **Modular PCS**: The prover is generic over any `IsMultilinearPCS` implementation.
+- **Zeromorph PCS**: Ships with a [Zeromorph](https://eprint.iacr.org/2023/917) backend backed by BLS12-381 KZG for production-quality polynomial commitments.
+
+## API
+
+### Main Functions
+
+- `spartan_prove(r1cs, public_inputs, witness, pcs)` — Generate a Spartan proof.
+- `spartan_verify(r1cs, public_inputs, proof, pcs)` — Verify a Spartan proof.
+
+### PCS Backends
+
+- `ZeromorphPCS<N, F, P>` — Multilinear PCS via Zeromorph reduction to univariate KZG. Backed by any `IsPairing` curve; ships ready to use with BLS12-381.
+- `TrivialPCS` — Sends the full witness in the clear. Useful for testing the sumcheck layer in isolation.
+
+## Example
+
+```rust
+use lambdaworks_math::field::{
+    element::FieldElement,
+    fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
+};
+use lambdaworks_spartan::{
+    r1cs::R1CS,
+    prover::spartan_prove,
+    verifier::spartan_verify,
+    pcs::trivial::TrivialPCS,
+};
+
+type F = Stark252PrimeField;
+type FE = FieldElement<F>;
+
+// Build R1CS for: a * b = c  (witness = [1, c, a, b])
+let zero = FE::zero();
+let one = FE::one();
+let r1cs = R1CS::new(
+    vec![vec![zero, zero, one, zero]],   // A: picks a
+    vec![vec![zero, zero, zero, one]],   // B: picks b
+    vec![vec![zero, one, zero, zero]],   // C: picks c
+    1, // 1 public input (c)
+).unwrap();
+
+let witness = vec![one, FE::from(6), FE::from(2), FE::from(3)];
+let public_inputs = vec![FE::from(6)];
+
+let pcs = TrivialPCS::default();
+let proof = spartan_prove(&r1cs, &public_inputs, &witness, pcs.clone()).unwrap();
+let ok = spartan_verify(&r1cs, &public_inputs, &proof, pcs).unwrap();
+assert!(ok);
+```
+
+### With Zeromorph PCS (BLS12-381)
+
+```rust
+use lambdaworks_crypto::commitments::kzg::KateZaveruchaGoldberg;
+use lambdaworks_math::elliptic_curve::short_weierstrass::curves::bls12_381::{
+    default_types::FrField,
+    pairing::BLS12381AtePairing,
+};
+use lambdaworks_spartan::pcs::zeromorph::ZeromorphPCS;
+
+type Kzg = KateZaveruchaGoldberg<FrField, BLS12381AtePairing>;
+type Pcs = ZeromorphPCS<4, FrField, BLS12381AtePairing>;
+
+// Build a structured reference string (SRS) with enough powers.
+// srs_size >= 2^(log2(num_variables) + 1)
+let srs = Kzg::create_srs(toxic_waste, srs_size);
+let pcs = Pcs::new(Kzg::new(srs));
+
+let proof = spartan_prove(&r1cs, &public_inputs, &witness, pcs.clone()).unwrap();
+let ok = spartan_verify(&r1cs, &public_inputs, &proof, pcs).unwrap();
+assert!(ok);
+```
+
+## Protocol Details
+
+### Phase 1 — Outer Sumcheck
+
+The prover encodes R1CS satisfiability as a sum over the boolean hypercube. For a random point $\tau \in \mathbb{F}^{\log m}$ (derived from the transcript), the prover runs a sumcheck on:
+
+$$\sum_{x \in \{0,1\}^{\log m}} \widetilde{eq}(\tau, x) \cdot \left(\tilde{A}(x, \cdot) \cdot z\right) \left(\tilde{B}(x, \cdot) \cdot z\right) - \left(\tilde{C}(x, \cdot) \cdot z\right) = 0$$
+
+This reduces to three claimed evaluations $v_A$, $v_B$, $v_C$ of the matrix-times-witness products at a random point $r_x$.
+
+### Phase 2 — Inner Sumcheck
+
+The prover batches the three matrix polynomials $\tilde{A}$, $\tilde{B}$, $\tilde{C}$ with random scalars $\rho_A$, $\rho_B$, $\rho_C$ and runs a second sumcheck to reduce the combined claim to a single evaluation of the witness multilinear extension $\tilde{z}(r_y)$.
+
+### PCS Opening
+
+The prover opens $\tilde{z}$ at the inner sumcheck point $r_y$ using the provided multilinear PCS. The verifier recomputes the matrix evaluations $\tilde{A}(r_x, r_y)$, $\tilde{B}(r_x, r_y)$, $\tilde{C}(r_x, r_y)$ directly and checks consistency.
+
+### Zeromorph PCS
+
+The Zeromorph backend (Kohrita & Towa, 2023) reduces a multilinear evaluation claim to a univariate KZG opening. Given $f(u_0, \ldots, u_{n-1}) = v$, it produces quotient polynomials $\hat{q}_0, \ldots, \hat{q}_{n-1}$ via a halving algorithm and batches them into a single KZG proof, achieving $O(n)$ prover work and $O(n)$ verifier work in group operations.
+
+## References
+
+- [Spartan: Efficient and general-purpose zkSNARKs without trusted setup — Setty (2020)](https://eprint.iacr.org/2019/550)
+- [Zeromorph: Zero-Knowledge Multilinear-Evaluation Proofs from Homomorphic Univariate Commitments — Kohrita & Towa (2023)](https://eprint.iacr.org/2023/917)
+- [Proofs, Arguments, and Zero-Knowledge — Thaler (2022)](https://people.cs.georgetown.edu/jthaler/ProofsArgsAndZK.pdf)

--- a/crates/provers/spartan/benches/spartan_bench.rs
+++ b/crates/provers/spartan/benches/spartan_bench.rs
@@ -1,0 +1,96 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use lambdaworks_math::field::{element::FieldElement, fields::u64_prime_field::U64PrimeField};
+use lambdaworks_spartan::{
+    spartan_prove, spartan_verify, SparseEntry, SparseMatrix, TrivialPCS, R1CS,
+};
+
+const MODULUS: u64 = 4611686018427387903; // 2^62 - 1 (Mersenne prime)
+type F = U64PrimeField<MODULUS>;
+type FE = FieldElement<F>;
+
+/// Generates a multiplication-chain circuit with `n` constraints.
+///
+/// Variables: [1, x_0, x_1, ..., x_{n}]
+/// Constraint i: x_i * x_i = x_{i+1}  (repeated squaring from x_0=2)
+fn generate_chain_circuit(n: usize) -> (R1CS<F>, Vec<FE>, Vec<FE>) {
+    let num_vars = n + 2; // 1 + x_0 + ... + x_n
+    let one = FE::one();
+
+    // Compute the chain: x_0=2, x_{i+1} = x_i^2
+    let mut values = vec![one.clone()]; // z[0] = 1 (constant)
+    let mut cur = FE::from(2u64);
+    values.push(cur.clone());
+    for _ in 0..n {
+        cur = &cur * &cur;
+        values.push(cur.clone());
+    }
+
+    let mut a_entries = Vec::with_capacity(n);
+    let mut b_entries = Vec::with_capacity(n);
+    let mut c_entries = Vec::with_capacity(n);
+
+    for i in 0..n {
+        a_entries.push(SparseEntry {
+            row: i,
+            col: i + 1,
+            val: one.clone(),
+        });
+        b_entries.push(SparseEntry {
+            row: i,
+            col: i + 1,
+            val: one.clone(),
+        });
+        c_entries.push(SparseEntry {
+            row: i,
+            col: i + 2,
+            val: one.clone(),
+        });
+    }
+
+    let a = SparseMatrix::new(a_entries, n, num_vars).unwrap();
+    let b = SparseMatrix::new(b_entries, n, num_vars).unwrap();
+    let c = SparseMatrix::new(c_entries, n, num_vars).unwrap();
+
+    // Public input: just the final result x_n
+    let r1cs = R1CS::new(a, b, c, 1).unwrap();
+    let public_inputs = vec![values[n + 1].clone()];
+
+    (r1cs, values, public_inputs)
+}
+
+fn bench_spartan(c: &mut Criterion) {
+    let mut group = c.benchmark_group("spartan_trivial_pcs");
+
+    for log_n in [4, 6, 8, 10] {
+        let n = 1usize << log_n;
+        let (r1cs, witness, public_inputs) = generate_chain_circuit(n);
+
+        group.bench_with_input(
+            BenchmarkId::new("prove", format!("2^{log_n}")),
+            &n,
+            |b, _| {
+                b.iter(|| {
+                    spartan_prove(&r1cs, &public_inputs, &witness, TrivialPCS).unwrap();
+                });
+            },
+        );
+
+        // Pre-generate proof for verify benchmark
+        let proof = spartan_prove(&r1cs, &public_inputs, &witness, TrivialPCS).unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::new("verify", format!("2^{log_n}")),
+            &n,
+            |b, _| {
+                b.iter(|| {
+                    spartan_verify(&r1cs, &public_inputs, &proof, TrivialPCS).unwrap();
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_spartan);
+criterion_main!(benches);

--- a/crates/provers/spartan/benches/spartan_bench.rs
+++ b/crates/provers/spartan/benches/spartan_bench.rs
@@ -10,39 +10,51 @@ type FE = FieldElement<F>;
 
 /// Generates a multiplication-chain circuit with `n` constraints.
 ///
-/// Variables: [1, x_0, x_1, ..., x_{n}]
-/// Constraint i: x_i * x_i = x_{i+1}  (repeated squaring from x_0=2)
+/// Variables: [1, output, x_0, x_1, ..., x_{n-1}]
+///   index:    0    1      2    3          n+1
+///
+/// Constraint i (0..n-1): x_i * x_i = x_{i+1}
+/// Constraint n-1:        x_{n-1} * x_{n-1} = output
+///
+/// The output (x_n = 2^(2^n)) is placed at index 1 so it matches
+/// the public input slot (z = (1, public, witness...)).
 fn generate_chain_circuit(n: usize) -> (R1CS<F>, Vec<FE>, Vec<FE>) {
-    let num_vars = n + 2; // 1 + x_0 + ... + x_n
+    let num_vars = n + 2; // 1 + output + x_0 + ... + x_{n-1}
     let one = FE::one();
 
     // Compute the chain: x_0=2, x_{i+1} = x_i^2
-    let mut values = vec![one.clone()]; // z[0] = 1 (constant)
-    let mut cur = FE::from(2u64);
-    values.push(cur.clone());
+    let mut chain = vec![FE::from(2u64)];
     for _ in 0..n {
-        cur = &cur * &cur;
-        values.push(cur.clone());
+        let prev = chain.last().unwrap();
+        chain.push(prev * prev);
     }
+    // chain = [x_0, x_1, ..., x_n] where x_n is the output
+
+    // Build witness: z = [1, output, x_0, x_1, ..., x_{n-1}]
+    let mut witness = vec![one.clone(), chain[n].clone()];
+    witness.extend_from_slice(&chain[..n]);
 
     let mut a_entries = Vec::with_capacity(n);
     let mut b_entries = Vec::with_capacity(n);
     let mut c_entries = Vec::with_capacity(n);
 
     for i in 0..n {
+        // A and B select x_i (at column i+2 in the witness)
         a_entries.push(SparseEntry {
             row: i,
-            col: i + 1,
+            col: i + 2,
             val: one.clone(),
         });
         b_entries.push(SparseEntry {
             row: i,
-            col: i + 1,
+            col: i + 2,
             val: one.clone(),
         });
+        // C selects the result: x_{i+1} if i < n-1, or output (col 1) if i == n-1
+        let result_col = if i < n - 1 { i + 3 } else { 1 };
         c_entries.push(SparseEntry {
             row: i,
-            col: i + 2,
+            col: result_col,
             val: one.clone(),
         });
     }
@@ -51,11 +63,10 @@ fn generate_chain_circuit(n: usize) -> (R1CS<F>, Vec<FE>, Vec<FE>) {
     let b = SparseMatrix::new(b_entries, n, num_vars).unwrap();
     let c = SparseMatrix::new(c_entries, n, num_vars).unwrap();
 
-    // Public input: just the final result x_n
     let r1cs = R1CS::new(a, b, c, 1).unwrap();
-    let public_inputs = vec![values[n + 1].clone()];
+    let public_inputs = vec![chain[n].clone()];
 
-    (r1cs, values, public_inputs)
+    (r1cs, witness, public_inputs)
 }
 
 fn bench_spartan(c: &mut Criterion) {

--- a/crates/provers/spartan/benches/spartan_bench.rs
+++ b/crates/provers/spartan/benches/spartan_bench.rs
@@ -31,7 +31,7 @@ fn generate_chain_circuit(n: usize) -> (R1CS<F>, Vec<FE>, Vec<FE>) {
     // chain = [x_0, x_1, ..., x_n] where x_n is the output
 
     // Build witness: z = [1, output, x_0, x_1, ..., x_{n-1}]
-    let mut witness = vec![one.clone(), chain[n].clone()];
+    let mut witness = vec![one, chain[n]];
     witness.extend_from_slice(&chain[..n]);
 
     let mut a_entries = Vec::with_capacity(n);
@@ -43,19 +43,19 @@ fn generate_chain_circuit(n: usize) -> (R1CS<F>, Vec<FE>, Vec<FE>) {
         a_entries.push(SparseEntry {
             row: i,
             col: i + 2,
-            val: one.clone(),
+            val: one,
         });
         b_entries.push(SparseEntry {
             row: i,
             col: i + 2,
-            val: one.clone(),
+            val: one,
         });
         // C selects the result: x_{i+1} if i < n-1, or output (col 1) if i == n-1
         let result_col = if i < n - 1 { i + 3 } else { 1 };
         c_entries.push(SparseEntry {
             row: i,
             col: result_col,
-            val: one.clone(),
+            val: one,
         });
     }
 
@@ -64,7 +64,7 @@ fn generate_chain_circuit(n: usize) -> (R1CS<F>, Vec<FE>, Vec<FE>) {
     let c = SparseMatrix::new(c_entries, n, num_vars).unwrap();
 
     let r1cs = R1CS::new(a, b, c, 1).unwrap();
-    let public_inputs = vec![chain[n].clone()];
+    let public_inputs = vec![chain[n]];
 
     (r1cs, witness, public_inputs)
 }

--- a/crates/provers/spartan/src/errors.rs
+++ b/crates/provers/spartan/src/errors.rs
@@ -1,0 +1,14 @@
+/// Errors that can occur during the Spartan proving protocol.
+#[derive(Debug, thiserror::Error)]
+pub enum SpartanError {
+    #[error("R1CS error: {0}")]
+    R1CSError(String),
+    #[error("MLE encoding error: {0}")]
+    MleError(String),
+    #[error("Sumcheck error: {0}")]
+    SumcheckError(String),
+    #[error("PCS error: {0}")]
+    PcsError(String),
+    #[error("Verification failed: {0}")]
+    VerificationFailed(String),
+}

--- a/crates/provers/spartan/src/lib.rs
+++ b/crates/provers/spartan/src/lib.rs
@@ -444,4 +444,66 @@ mod tests {
 
         assert_eq!(sum, FE::zero(), "Outer sum should be 0 for satisfied R1CS");
     }
+
+    // -------------------------------------------------------------------------
+    // Integration test: full Spartan prove+verify with ZeromorphPCS over BLS12-381
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_spartan_prove_verify_zeromorph() {
+        use crate::pcs::zeromorph::ZeromorphPCS;
+        use lambdaworks_crypto::commitments::kzg::{
+            KateZaveruchaGoldberg, StructuredReferenceString,
+        };
+        use lambdaworks_math::cyclic_group::IsGroup;
+        use lambdaworks_math::elliptic_curve::short_weierstrass::curves::bls12_381::{
+            curve::BLS12381Curve,
+            default_types::{FrElement, FrField},
+            pairing::BLS12381AtePairing,
+            twist::BLS12381TwistCurve,
+        };
+        use lambdaworks_math::elliptic_curve::short_weierstrass::point::ShortWeierstrassJacobianPoint;
+        use lambdaworks_math::elliptic_curve::traits::IsEllipticCurve;
+        use lambdaworks_math::field::element::FieldElement;
+
+        type G1 = ShortWeierstrassJacobianPoint<BLS12381Curve>;
+        type KZG = KateZaveruchaGoldberg<FrField, BLS12381AtePairing>;
+        type ZM = ZeromorphPCS<4, FrField, BLS12381AtePairing>;
+        type FE = FrElement;
+
+        // Build a simple multiplication circuit: x * y = z over BLS12-381 Fr.
+        // witness = [1, 6, 2, 3]  (constant=1, output=6, x=2, y=3)
+        // A[0] = [0, 0, 1, 0]  (picks x)
+        // B[0] = [0, 0, 0, 1]  (picks y)
+        // C[0] = [0, 1, 0, 0]  (picks output)
+        let zero = FE::zero();
+        let one = FE::one();
+        let a = vec![vec![zero.clone(), zero.clone(), one.clone(), zero.clone()]];
+        let b = vec![vec![zero.clone(), zero.clone(), zero.clone(), one.clone()]];
+        let c = vec![vec![zero.clone(), one.clone(), zero.clone(), zero.clone()]];
+        let r1cs = R1CS::new(a, b, c, 1).unwrap();
+
+        let witness: Vec<FE> = vec![
+            FieldElement::one(),
+            FE::from(6u64),
+            FE::from(2u64),
+            FE::from(3u64),
+        ];
+        let public_inputs = vec![FE::from(6u64)];
+        assert!(r1cs.is_satisfied(&witness));
+
+        // SRS needs ≥ 4 powers (witness has 4 elements, padded to 2^2 = 4)
+        let toxic = FE::from(13u64);
+        let g1 = BLS12381Curve::generator();
+        let g2 = BLS12381TwistCurve::generator();
+        let powers: Vec<G1> = (0..8)
+            .map(|i| g1.operate_with_self(toxic.pow(i as u128).canonical()))
+            .collect();
+        let g2_powers = [g2.clone(), g2.operate_with_self(toxic.canonical())];
+        let srs = StructuredReferenceString::new(&powers, &g2_powers);
+        let pcs = ZM::new(KZG::new(srs));
+
+        let proof = spartan_prove(&r1cs, &public_inputs, &witness, pcs.clone()).unwrap();
+        let ok = spartan_verify(&r1cs, &public_inputs, &proof, pcs).unwrap();
+        assert!(ok, "Spartan+Zeromorph should verify for satisfied R1CS");
+    }
 }

--- a/crates/provers/spartan/src/lib.rs
+++ b/crates/provers/spartan/src/lib.rs
@@ -156,20 +156,20 @@ mod tests {
 
         let a = fe(3);
         let b = fe(5);
-        let tau = vec![a.clone(), b.clone()];
+        let tau = vec![a, b];
         let eq = eq_poly(&tau);
 
         let evals = eq.evals();
         let one = FE::one();
 
         // (0,0) -> (1-a)(1-b)
-        assert_eq!(evals[0], (&one - &a) * (&one - &b));
+        assert_eq!(evals[0], (one - a) * (one - b));
         // (0,1) -> (1-a)*b
-        assert_eq!(evals[1], (&one - &a) * &b);
+        assert_eq!(evals[1], (one - a) * b);
         // (1,0) -> a*(1-b)
-        assert_eq!(evals[2], &a * (&one - &b));
+        assert_eq!(evals[2], a * (one - b));
         // (1,1) -> a*b
-        assert_eq!(evals[3], &a * &b);
+        assert_eq!(evals[3], a * b);
     }
 
     // -------------------------------------------------------------------------
@@ -180,7 +180,7 @@ mod tests {
         use crate::mle::matrix_vector_product_mle;
 
         let two = fe(2);
-        let a = vec![vec![one(), zero()], vec![zero(), two.clone()]];
+        let a = vec![vec![one(), zero()], vec![zero(), two]];
 
         // r_x = [0] -> selects row 0 weighted by eq([0], i)
         let r_x = vec![FE::zero()];
@@ -296,71 +296,22 @@ mod tests {
 
         // 6 variables: [1, c, e, a, b, d]
         let a_mat = vec![
-            vec![
-                zero.clone(),
-                zero.clone(),
-                zero.clone(),
-                one.clone(),
-                zero.clone(),
-                zero.clone(),
-            ],
-            vec![
-                zero.clone(),
-                one.clone(),
-                zero.clone(),
-                zero.clone(),
-                zero.clone(),
-                zero.clone(),
-            ],
+            vec![zero, zero, zero, one, zero, zero],
+            vec![zero, one, zero, zero, zero, zero],
         ];
         let b_mat = vec![
-            vec![
-                zero.clone(),
-                zero.clone(),
-                zero.clone(),
-                zero.clone(),
-                one.clone(),
-                zero.clone(),
-            ],
-            vec![
-                zero.clone(),
-                zero.clone(),
-                zero.clone(),
-                zero.clone(),
-                zero.clone(),
-                one.clone(),
-            ],
+            vec![zero, zero, zero, zero, one, zero],
+            vec![zero, zero, zero, zero, zero, one],
         ];
         let c_mat = vec![
-            vec![
-                zero.clone(),
-                one.clone(),
-                zero.clone(),
-                zero.clone(),
-                zero.clone(),
-                zero.clone(),
-            ],
-            vec![
-                zero.clone(),
-                zero.clone(),
-                one.clone(),
-                zero.clone(),
-                zero.clone(),
-                zero.clone(),
-            ],
+            vec![zero, one, zero, zero, zero, zero],
+            vec![zero, zero, one, zero, zero, zero],
         ];
 
         let r1cs = R1CS::new(a_mat, b_mat, c_mat, 2).unwrap();
 
         // witness = [1, c, e, a, b, d]
-        let witness = vec![
-            one.clone(),
-            fe(c_val),
-            fe(e_val),
-            fe(a_val),
-            fe(b_val),
-            fe(d_val),
-        ];
+        let witness = vec![one, fe(c_val), fe(e_val), fe(a_val), fe(b_val), fe(d_val)];
 
         assert!(
             r1cs.is_satisfied(&witness),
@@ -439,7 +390,7 @@ mod tests {
                 .map(|(c, z)| c * z)
                 .fold(FE::zero(), |acc, x| acc + x);
 
-            sum = sum + &eq_ev.evals()[i] * &(az_i * bz_i - cz_i);
+            sum += eq_ev.evals()[i] * (az_i * bz_i - cz_i);
         }
 
         assert_eq!(sum, FE::zero(), "Outer sum should be 0 for satisfied R1CS");
@@ -466,7 +417,7 @@ mod tests {
         use lambdaworks_math::field::element::FieldElement;
 
         type G1 = ShortWeierstrassJacobianPoint<BLS12381Curve>;
-        type KZG = KateZaveruchaGoldberg<FrField, BLS12381AtePairing>;
+        type Kzg = KateZaveruchaGoldberg<FrField, BLS12381AtePairing>;
         type ZM = ZeromorphPCS<4, FrField, BLS12381AtePairing>;
         type FE = FrElement;
 
@@ -500,7 +451,7 @@ mod tests {
             .collect();
         let g2_powers = [g2.clone(), g2.operate_with_self(toxic.canonical())];
         let srs = StructuredReferenceString::new(&powers, &g2_powers);
-        let pcs = ZM::new(KZG::new(srs));
+        let pcs = ZM::new(Kzg::new(srs));
 
         let proof = spartan_prove(&r1cs, &public_inputs, &witness, pcs.clone()).unwrap();
         let ok = spartan_verify(&r1cs, &public_inputs, &proof, pcs).unwrap();

--- a/crates/provers/spartan/src/lib.rs
+++ b/crates/provers/spartan/src/lib.rs
@@ -1,0 +1,447 @@
+//! Spartan: Efficient and general-purpose zkSNARKs without trusted setup.
+//!
+//! This crate implements the Spartan proof system (Setty 2019) for proving
+//! R1CS satisfiability using two nested sumcheck protocols over multilinear
+//! extensions (MLEs).
+//!
+//! # Protocol overview
+//!
+//! Given R1CS matrices A, B, C ∈ F^{m×n} and witness z = (1, x, w) ∈ F^n:
+//!
+//! 1. **Commit**: Commit to witness polynomial z̃
+//! 2. **Outer sumcheck**: Prove ∑_{x ∈ {0,1}^s} eq(τ,x)·[ÃZ(x)·B̃Z(x) − C̃Z(x)] = 0
+//! 3. **Inner sumcheck**: Reduce matrix-vector product claims to z̃ evaluation
+//! 4. **PCS opening**: Open z̃ at inner sumcheck challenge point r_y
+//!
+//! # References
+//!
+//! - Setty, "Spartan: Efficient and general-purpose zkSNARKs without trusted setup"
+//!   <https://eprint.iacr.org/2019/550>
+
+pub mod errors;
+pub mod mle;
+pub mod pcs;
+pub mod prover;
+pub mod r1cs;
+mod transcript;
+pub mod verifier;
+
+pub use errors::SpartanError;
+pub use pcs::zeromorph::{TrivialCommitment, TrivialPCS, TrivialProof};
+pub use prover::{SpartanProof, SpartanProver};
+pub use r1cs::R1CS;
+pub use verifier::SpartanVerifier;
+
+use lambdaworks_math::field::{
+    element::FieldElement, traits::HasDefaultTranscript, traits::IsField,
+};
+use lambdaworks_math::traits::ByteConversion;
+use pcs::IsMultilinearPCS;
+
+/// Convenience function: prove R1CS satisfiability using Spartan.
+pub fn spartan_prove<F, PCS>(
+    r1cs: &R1CS<F>,
+    public_inputs: &[FieldElement<F>],
+    witness: &[FieldElement<F>],
+    pcs: PCS,
+) -> Result<SpartanProof<F, PCS>, SpartanError>
+where
+    F: IsField + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+    PCS: IsMultilinearPCS<F>,
+    PCS::Error: 'static,
+{
+    let prover = SpartanProver::new(pcs);
+    prover.prove(r1cs, public_inputs, witness)
+}
+
+/// Convenience function: verify a Spartan proof.
+pub fn spartan_verify<F, PCS>(
+    r1cs: &R1CS<F>,
+    public_inputs: &[FieldElement<F>],
+    proof: &SpartanProof<F, PCS>,
+    pcs: PCS,
+) -> Result<bool, SpartanError>
+where
+    F: IsField + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+    PCS: IsMultilinearPCS<F>,
+    PCS::Error: 'static,
+{
+    let verifier = SpartanVerifier::new(pcs);
+    verifier.verify(r1cs, public_inputs, proof)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lambdaworks_math::field::{element::FieldElement, fields::u64_prime_field::U64PrimeField};
+
+    const MODULUS: u64 = 101;
+    type F = U64PrimeField<MODULUS>;
+    type FE = FieldElement<F>;
+
+    fn fe(n: u64) -> FE {
+        FE::from(n)
+    }
+
+    fn zero() -> FE {
+        FE::zero()
+    }
+
+    fn one() -> FE {
+        FE::one()
+    }
+
+    /// Build the R1CS for: a * b = c
+    /// Variables: [1, c, a, b] (constant, output, left input, right input)
+    /// Constraint:
+    ///   A[0] = [0, 0, 1, 0]  (selects a)
+    ///   B[0] = [0, 0, 0, 1]  (selects b)
+    ///   C[0] = [0, 1, 0, 0]  (selects c)
+    fn mul_r1cs(a_val: u64, b_val: u64) -> (R1CS<F>, Vec<FE>) {
+        let c_val = (a_val * b_val) % MODULUS;
+
+        let a_mat = vec![vec![zero(), zero(), one(), zero()]];
+        let b_mat = vec![vec![zero(), zero(), zero(), one()]];
+        let c_mat = vec![vec![zero(), one(), zero(), zero()]];
+
+        let r1cs = R1CS::new(a_mat, b_mat, c_mat, 1).unwrap();
+
+        // witness = [1, c, a, b]
+        let witness = vec![one(), fe(c_val), fe(a_val), fe(b_val)];
+        (r1cs, witness)
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 1: R1CS satisfaction check
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_r1cs_satisfaction() {
+        let (r1cs, witness) = mul_r1cs(3, 3);
+        assert!(r1cs.is_satisfied(&witness));
+    }
+
+    #[test]
+    fn test_r1cs_not_satisfied() {
+        let (r1cs, mut witness) = mul_r1cs(3, 3);
+        witness[1] = fe(7); // wrong output
+        assert!(!r1cs.is_satisfied(&witness));
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2: MLE encoding correctness
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_mle_encoding() {
+        use crate::mle::encode_witness;
+
+        let z = vec![fe(1), fe(7), fe(3), fe(5)];
+        let z_mle = encode_witness(&z);
+
+        assert_eq!(z_mle.evaluate(vec![FE::zero(), FE::zero()]).unwrap(), fe(1));
+        assert_eq!(z_mle.evaluate(vec![FE::zero(), FE::one()]).unwrap(), fe(7));
+        assert_eq!(z_mle.evaluate(vec![FE::one(), FE::zero()]).unwrap(), fe(3));
+        assert_eq!(z_mle.evaluate(vec![FE::one(), FE::one()]).unwrap(), fe(5));
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 3: eq_poly correctness
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_eq_poly() {
+        use crate::mle::eq_poly;
+
+        let a = fe(3);
+        let b = fe(5);
+        let tau = vec![a.clone(), b.clone()];
+        let eq = eq_poly(&tau);
+
+        let evals = eq.evals();
+        let one = FE::one();
+
+        // (0,0) -> (1-a)(1-b)
+        assert_eq!(evals[0], (&one - &a) * (&one - &b));
+        // (0,1) -> (1-a)*b
+        assert_eq!(evals[1], (&one - &a) * &b);
+        // (1,0) -> a*(1-b)
+        assert_eq!(evals[2], &a * (&one - &b));
+        // (1,1) -> a*b
+        assert_eq!(evals[3], &a * &b);
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 4: Matrix-vector product MLE
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_matrix_vector_product_mle() {
+        use crate::mle::matrix_vector_product_mle;
+
+        let two = fe(2);
+        let a = vec![vec![one(), zero()], vec![zero(), two.clone()]];
+
+        // r_x = [0] -> selects row 0 weighted by eq([0], i)
+        let r_x = vec![FE::zero()];
+        let mz = matrix_vector_product_mle(&a, 2, 2, &r_x).unwrap();
+
+        // MZ([0])[0] = A[0][0]*1 + A[1][0]*0 = 1
+        assert_eq!(mz.evaluate(vec![FE::zero()]).unwrap(), one());
+        // MZ([0])[1] = A[0][1]*1 + A[1][1]*0 = 0
+        assert_eq!(mz.evaluate(vec![FE::one()]).unwrap(), zero());
+
+        // r_x = [1] -> selects row 1
+        let r_x1 = vec![FE::one()];
+        let mz1 = matrix_vector_product_mle(&a, 2, 2, &r_x1).unwrap();
+
+        // MZ([1])[0] = A[0][0]*0 + A[1][0]*1 = 0
+        assert_eq!(mz1.evaluate(vec![FE::zero()]).unwrap(), zero());
+        // MZ([1])[1] = A[0][1]*0 + A[1][1]*1 = 2
+        assert_eq!(mz1.evaluate(vec![FE::one()]).unwrap(), two);
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 5: TrivialPCS round trip
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_trivial_pcs_round_trip() {
+        use crate::pcs::zeromorph::TrivialPCS;
+        use crate::pcs::IsMultilinearPCS;
+        use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolynomial;
+
+        let pcs = TrivialPCS;
+        let poly = DenseMultilinearPolynomial::new(vec![fe(1), fe(2), fe(3), fe(4)]);
+        let commitment = pcs.commit(&poly).unwrap();
+        let point = vec![fe(5), fe(7)];
+        let (value, proof) = pcs.open(&poly, &point).unwrap();
+        let ok = pcs.verify(&commitment, &point, &value, &proof).unwrap();
+        assert!(ok);
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 6: Full Spartan prove/verify
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_spartan_prove_verify() {
+        // Circuit: a * b = c, with a=2, b=3, c=6
+        let (r1cs, witness) = mul_r1cs(2, 3);
+        assert!(r1cs.is_satisfied(&witness));
+
+        let public_inputs = vec![fe(6)]; // c is public
+
+        let proof = spartan_prove(&r1cs, &public_inputs, &witness, TrivialPCS).unwrap();
+        let ok = spartan_verify(&r1cs, &public_inputs, &proof, TrivialPCS).unwrap();
+        assert!(ok, "Valid proof should verify");
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 7: Soundness — corrupted witness
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_spartan_soundness_corrupted_witness() {
+        // Same circuit but with wrong witness (7 ≠ 2*3)
+        let (r1cs, _) = mul_r1cs(2, 3);
+
+        // Wrong witness: c=7 instead of c=6
+        let wrong_witness = vec![one(), fe(7), fe(2), fe(3)];
+        assert!(!r1cs.is_satisfied(&wrong_witness));
+
+        // The prover will produce a proof with an incorrect claimed sum for the outer sumcheck
+        // (claimed_sum != 0 because R1CS is not satisfied).
+        // The verifier should reject it.
+        let result = spartan_prove(&r1cs, &[fe(6)], &wrong_witness, TrivialPCS);
+
+        match result {
+            Ok(proof) => {
+                // If prove succeeded, verify should fail
+                let ok = spartan_verify(&r1cs, &[fe(7)], &proof, TrivialPCS).unwrap_or(false);
+                assert!(!ok, "Corrupted witness proof should not verify");
+            }
+            Err(_) => {
+                // Prover failed, which is also acceptable (won't produce valid proof)
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 8: Multiple constraints
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_spartan_multiple_constraints() {
+        // Circuit: a*b = c AND c*d = e
+        // Variables: [1, c, e, a, b, d]
+        //   index:    0  1  2  3  4  5
+        //
+        // Constraint 0: a * b = c  -> A[0]*z*B[0]*z = C[0]*z
+        //   A[0] = [0, 0, 0, 1, 0, 0]  (a)
+        //   B[0] = [0, 0, 0, 0, 1, 0]  (b)
+        //   C[0] = [0, 1, 0, 0, 0, 0]  (c)
+        //
+        // Constraint 1: c * d = e  -> A[1]*z*B[1]*z = C[1]*z
+        //   A[1] = [0, 1, 0, 0, 0, 0]  (c)
+        //   B[1] = [0, 0, 0, 0, 0, 1]  (d)
+        //   C[1] = [0, 0, 1, 0, 0, 0]  (e)
+        //
+        // With a=2, b=3, c=6, d=4, e=24
+
+        let a_val = 2u64;
+        let b_val = 3u64;
+        let c_val = (a_val * b_val) % MODULUS; // 6
+        let d_val = 4u64;
+        let e_val = (c_val * d_val) % MODULUS; // 24
+
+        let zero = zero();
+        let one = one();
+
+        // 6 variables: [1, c, e, a, b, d]
+        let a_mat = vec![
+            vec![
+                zero.clone(),
+                zero.clone(),
+                zero.clone(),
+                one.clone(),
+                zero.clone(),
+                zero.clone(),
+            ],
+            vec![
+                zero.clone(),
+                one.clone(),
+                zero.clone(),
+                zero.clone(),
+                zero.clone(),
+                zero.clone(),
+            ],
+        ];
+        let b_mat = vec![
+            vec![
+                zero.clone(),
+                zero.clone(),
+                zero.clone(),
+                zero.clone(),
+                one.clone(),
+                zero.clone(),
+            ],
+            vec![
+                zero.clone(),
+                zero.clone(),
+                zero.clone(),
+                zero.clone(),
+                zero.clone(),
+                one.clone(),
+            ],
+        ];
+        let c_mat = vec![
+            vec![
+                zero.clone(),
+                one.clone(),
+                zero.clone(),
+                zero.clone(),
+                zero.clone(),
+                zero.clone(),
+            ],
+            vec![
+                zero.clone(),
+                zero.clone(),
+                one.clone(),
+                zero.clone(),
+                zero.clone(),
+                zero.clone(),
+            ],
+        ];
+
+        let r1cs = R1CS::new(a_mat, b_mat, c_mat, 2).unwrap();
+
+        // witness = [1, c, e, a, b, d]
+        let witness = vec![
+            one.clone(),
+            fe(c_val),
+            fe(e_val),
+            fe(a_val),
+            fe(b_val),
+            fe(d_val),
+        ];
+
+        assert!(
+            r1cs.is_satisfied(&witness),
+            "Multi-constraint R1CS should be satisfied"
+        );
+
+        let public_inputs = vec![fe(c_val), fe(e_val)];
+
+        let proof = spartan_prove(&r1cs, &public_inputs, &witness, TrivialPCS).unwrap();
+        let ok = spartan_verify(&r1cs, &public_inputs, &proof, TrivialPCS).unwrap();
+        assert!(ok, "Multi-constraint proof should verify");
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 9: Wrong public inputs — transcript diverges, verification fails
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_spartan_wrong_public_inputs() {
+        let (r1cs, witness) = mul_r1cs(2, 3);
+        let correct_public_inputs = vec![fe(6)]; // c = 2*3 = 6
+        let wrong_public_inputs = vec![fe(7)]; // wrong
+
+        // Proof generated with correct public inputs
+        let proof = spartan_prove(&r1cs, &correct_public_inputs, &witness, TrivialPCS).unwrap();
+
+        // Verifying with wrong public inputs should fail: the transcripts diverge
+        // because public inputs are absorbed before drawing tau.
+        let ok = spartan_verify(&r1cs, &wrong_public_inputs, &proof, TrivialPCS).unwrap_or(false);
+        assert!(!ok, "Proof with wrong public inputs should not verify");
+    }
+
+    // -------------------------------------------------------------------------
+    // Additional: test that MLE sum = 0 for satisfied R1CS
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_outer_sum_is_zero_for_satisfied_r1cs() {
+        use crate::mle::eq_poly;
+
+        let (r1cs, witness) = mul_r1cs(2, 3);
+        assert!(r1cs.is_satisfied(&witness));
+
+        let num_constraints_padded = crate::mle::next_power_of_two(r1cs.num_constraints);
+        let log_constraints = {
+            let mut k = 0;
+            let mut n = num_constraints_padded;
+            while n > 1 {
+                k += 1;
+                n >>= 1;
+            }
+            k
+        };
+
+        // Use a fixed tau for testing
+        let tau: Vec<FE> = (0..log_constraints)
+            .map(|i| fe((i as u64 + 2) * 7 % MODULUS))
+            .collect();
+
+        // Compute combined sum: ∑_i eq(τ,i) * (AZ[i]*BZ[i] - CZ[i])
+        let eq_ev = eq_poly(&tau);
+
+        let mut sum = FE::zero();
+        for i in 0..r1cs.num_constraints {
+            let az_i: FE = r1cs.a[i]
+                .iter()
+                .zip(witness.iter())
+                .map(|(a, z)| a * z)
+                .fold(FE::zero(), |acc, x| acc + x);
+            let bz_i: FE = r1cs.b[i]
+                .iter()
+                .zip(witness.iter())
+                .map(|(b, z)| b * z)
+                .fold(FE::zero(), |acc, x| acc + x);
+            let cz_i: FE = r1cs.c[i]
+                .iter()
+                .zip(witness.iter())
+                .map(|(c, z)| c * z)
+                .fold(FE::zero(), |acc, x| acc + x);
+
+            sum = sum + &eq_ev.evals()[i] * &(az_i * bz_i - cz_i);
+        }
+
+        assert_eq!(sum, FE::zero(), "Outer sum should be 0 for satisfied R1CS");
+    }
+}

--- a/crates/provers/spartan/src/lib.rs
+++ b/crates/provers/spartan/src/lib.rs
@@ -27,7 +27,7 @@ mod transcript;
 pub mod verifier;
 
 pub use errors::SpartanError;
-pub use pcs::zeromorph::{TrivialCommitment, TrivialPCS, TrivialProof};
+pub use pcs::trivial::{TrivialCommitment, TrivialPCS, TrivialProof};
 pub use prover::{SpartanProof, SpartanProver};
 pub use r1cs::R1CS;
 pub use verifier::SpartanVerifier;
@@ -206,7 +206,7 @@ mod tests {
     // -------------------------------------------------------------------------
     #[test]
     fn test_trivial_pcs_round_trip() {
-        use crate::pcs::zeromorph::TrivialPCS;
+        use crate::pcs::trivial::TrivialPCS;
         use crate::pcs::IsMultilinearPCS;
         use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolynomial;
 

--- a/crates/provers/spartan/src/lib.rs
+++ b/crates/provers/spartan/src/lib.rs
@@ -461,7 +461,7 @@ mod tests {
     // -------------------------------------------------------------------------
     #[test]
     fn test_spartan_prove_verify_zeromorph() {
-        use crate::pcs::zeromorph::ZeromorphPCS;
+        use crate::pcs::ZeromorphPCS;
         use lambdaworks_crypto::commitments::kzg::{
             KateZaveruchaGoldberg, StructuredReferenceString,
         };
@@ -523,7 +523,7 @@ mod tests {
     // -------------------------------------------------------------------------
     #[test]
     fn test_spartan_soundness_zeromorph() {
-        use crate::pcs::zeromorph::ZeromorphPCS;
+        use crate::pcs::ZeromorphPCS;
         use lambdaworks_crypto::commitments::kzg::{
             KateZaveruchaGoldberg, StructuredReferenceString,
         };

--- a/crates/provers/spartan/src/lib.rs
+++ b/crates/provers/spartan/src/lib.rs
@@ -397,6 +397,66 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
+    // Test HIGH-001b: witness length check
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_spartan_wrong_witness_length() {
+        let (r1cs, _) = mul_r1cs(2, 3);
+
+        // Witness is 3 elements instead of the required 4 (num_variables = 4)
+        let short_witness = vec![one(), fe(6), fe(2)];
+        let result = spartan_prove(&r1cs, &[fe(6)], &short_witness, TrivialPCS);
+        assert!(
+            result.is_err(),
+            "prove() must reject witness shorter than num_variables"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test HIGH-001: public input mismatch is caught at prove time
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_spartan_public_input_mismatch() {
+        let (r1cs, _) = mul_r1cs(2, 3);
+
+        // Witness says c=6 but public_inputs claims c=7
+        let witness = vec![one(), fe(6), fe(2), fe(3)];
+        let result = spartan_prove(&r1cs, &[fe(7)], &witness, TrivialPCS);
+        assert!(
+            result.is_err(),
+            "prove() must reject witness inconsistent with public inputs"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test HIGH-001: tampered public input proof fails verification
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_spartan_tampered_public_input_proof() {
+        let (r1cs, witness) = mul_r1cs(2, 3);
+        let public_inputs = vec![fe(6)];
+
+        let mut proof = spartan_prove(&r1cs, &public_inputs, &witness, TrivialPCS).unwrap();
+
+        // Replace the public input proof point with the wrong index (index 2 instead of 1)
+        if let Some((point, _)) = proof.public_input_proofs.first_mut() {
+            // Flip the last bit of the point to produce a wrong evaluation point
+            let last = point.last_mut().unwrap();
+            *last = if *last == FE::zero() {
+                FE::one()
+            } else {
+                FE::zero()
+            };
+        }
+
+        let ok = spartan_verify(&r1cs, &public_inputs, &proof, TrivialPCS).unwrap_or(false);
+        assert!(
+            !ok,
+            "Tampered public input proof point should fail verification"
+        );
+    }
+
+    // -------------------------------------------------------------------------
     // Integration test: full Spartan prove+verify with ZeromorphPCS over BLS12-381
     // -------------------------------------------------------------------------
     #[test]

--- a/crates/provers/spartan/src/lib.rs
+++ b/crates/provers/spartan/src/lib.rs
@@ -247,9 +247,9 @@ mod tests {
         let wrong_witness = vec![one(), fe(7), fe(2), fe(3)];
         assert!(!r1cs.is_satisfied(&wrong_witness));
 
-        // The prover will produce a proof with an incorrect claimed sum for the outer sumcheck
-        // (claimed_sum != 0 because R1CS is not satisfied).
-        // The verifier should reject it.
+        // The prover rejects early because public_inputs[0]=6 ≠ witness[1]=7.
+        // Corrupted proofs with consistent (but wrong) public inputs are tested
+        // in test_spartan_soundness_zeromorph.
         let result = spartan_prove(&r1cs, &[fe(6)], &wrong_witness, TrivialPCS);
 
         match result {

--- a/crates/provers/spartan/src/lib.rs
+++ b/crates/provers/spartan/src/lib.rs
@@ -457,4 +457,68 @@ mod tests {
         let ok = spartan_verify(&r1cs, &public_inputs, &proof, pcs).unwrap();
         assert!(ok, "Spartan+Zeromorph should verify for satisfied R1CS");
     }
+
+    // -------------------------------------------------------------------------
+    // Soundness test: corrupted witness should not verify with ZeromorphPCS
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_spartan_soundness_zeromorph() {
+        use crate::pcs::zeromorph::ZeromorphPCS;
+        use lambdaworks_crypto::commitments::kzg::{
+            KateZaveruchaGoldberg, StructuredReferenceString,
+        };
+        use lambdaworks_math::cyclic_group::IsGroup;
+        use lambdaworks_math::elliptic_curve::short_weierstrass::curves::bls12_381::{
+            curve::BLS12381Curve,
+            default_types::{FrElement, FrField},
+            pairing::BLS12381AtePairing,
+            twist::BLS12381TwistCurve,
+        };
+        use lambdaworks_math::elliptic_curve::short_weierstrass::point::ShortWeierstrassJacobianPoint;
+        use lambdaworks_math::elliptic_curve::traits::IsEllipticCurve;
+        use lambdaworks_math::field::element::FieldElement;
+
+        type G1 = ShortWeierstrassJacobianPoint<BLS12381Curve>;
+        type Kzg = KateZaveruchaGoldberg<FrField, BLS12381AtePairing>;
+        type ZM = ZeromorphPCS<4, FrField, BLS12381AtePairing>;
+        type FE = FrElement;
+
+        // Same circuit as the happy-path test: x * y = z
+        let zero = FE::zero();
+        let one = FE::one();
+        let a = vec![vec![zero.clone(), zero.clone(), one.clone(), zero.clone()]];
+        let b = vec![vec![zero.clone(), zero.clone(), zero.clone(), one.clone()]];
+        let c = vec![vec![zero.clone(), one.clone(), zero.clone(), zero.clone()]];
+        let r1cs = R1CS::new(a, b, c, 1).unwrap();
+
+        // Corrupt the witness: claim 2*3=7 instead of 6
+        let wrong_witness: Vec<FE> = vec![
+            FieldElement::one(),
+            FE::from(7u64), // wrong output
+            FE::from(2u64),
+            FE::from(3u64),
+        ];
+        assert!(!r1cs.is_satisfied(&wrong_witness));
+
+        let toxic = FE::from(13u64);
+        let g1 = BLS12381Curve::generator();
+        let g2 = BLS12381TwistCurve::generator();
+        let powers: Vec<G1> = (0..8)
+            .map(|i| g1.operate_with_self(toxic.pow(i as u128).canonical()))
+            .collect();
+        let g2_powers = [g2.clone(), g2.operate_with_self(toxic.canonical())];
+        let srs = StructuredReferenceString::new(&powers, &g2_powers);
+        let pcs = ZM::new(Kzg::new(srs));
+
+        let result = spartan_prove(&r1cs, &[FE::from(7u64)], &wrong_witness, pcs.clone());
+        match result {
+            Ok(proof) => {
+                let ok = spartan_verify(&r1cs, &[FE::from(7u64)], &proof, pcs).unwrap_or(false);
+                assert!(!ok, "Corrupted witness should not verify with ZeromorphPCS");
+            }
+            Err(_) => {
+                // Prover refusing to produce a proof is also acceptable
+            }
+        }
+    }
 }

--- a/crates/provers/spartan/src/lib.rs
+++ b/crates/provers/spartan/src/lib.rs
@@ -23,6 +23,7 @@ pub mod mle;
 pub mod pcs;
 pub mod prover;
 pub mod r1cs;
+pub mod sparse_matrix;
 mod transcript;
 pub mod verifier;
 
@@ -30,6 +31,7 @@ pub use errors::SpartanError;
 pub use pcs::trivial::{TrivialCommitment, TrivialPCS, TrivialProof};
 pub use prover::{SpartanProof, SpartanProver};
 pub use r1cs::R1CS;
+pub use sparse_matrix::{SparseEntry, SparseMatrix};
 pub use verifier::SpartanVerifier;
 
 use lambdaworks_math::field::{
@@ -108,7 +110,7 @@ mod tests {
         let b_mat = vec![vec![zero(), zero(), zero(), one()]];
         let c_mat = vec![vec![zero(), one(), zero(), zero()]];
 
-        let r1cs = R1CS::new(a_mat, b_mat, c_mat, 1).unwrap();
+        let r1cs = R1CS::from_dense(a_mat, b_mat, c_mat, 1).unwrap();
 
         // witness = [1, c, a, b]
         let witness = vec![one(), fe(c_val), fe(a_val), fe(b_val)];
@@ -180,7 +182,8 @@ mod tests {
         use crate::mle::matrix_vector_product_mle;
 
         let two = fe(2);
-        let a = vec![vec![one(), zero()], vec![zero(), two]];
+        let a_dense = vec![vec![one(), zero()], vec![zero(), two]];
+        let a = SparseMatrix::from_dense(&a_dense);
 
         // r_x = [0] -> selects row 0 weighted by eq([0], i)
         let r_x = vec![FE::zero()];
@@ -308,7 +311,7 @@ mod tests {
             vec![zero, zero, one, zero, zero, zero],
         ];
 
-        let r1cs = R1CS::new(a_mat, b_mat, c_mat, 2).unwrap();
+        let r1cs = R1CS::from_dense(a_mat, b_mat, c_mat, 2).unwrap();
 
         // witness = [1, c, e, a, b, d]
         let witness = vec![one, fe(c_val), fe(e_val), fe(a_val), fe(b_val), fe(d_val)];
@@ -354,43 +357,33 @@ mod tests {
         assert!(r1cs.is_satisfied(&witness));
 
         let num_constraints_padded = crate::mle::next_power_of_two(r1cs.num_constraints);
-        let log_constraints = {
-            let mut k = 0;
-            let mut n = num_constraints_padded;
-            while n > 1 {
-                k += 1;
-                n >>= 1;
-            }
-            k
-        };
+        let log_constraints = num_constraints_padded.trailing_zeros() as usize;
 
         // Use a fixed tau for testing
         let tau: Vec<FE> = (0..log_constraints)
             .map(|i| fe((i as u64 + 2) * 7 % MODULUS))
             .collect();
 
-        // Compute combined sum: ∑_i eq(τ,i) * (AZ[i]*BZ[i] - CZ[i])
         let eq_ev = eq_poly(&tau);
+
+        // Sparse accumulation of per-row dot products
+        let accumulate = |matrix: &SparseMatrix<F>| -> Vec<FE> {
+            let mut result = vec![FE::zero(); r1cs.num_constraints];
+            for e in &matrix.entries {
+                if e.row < r1cs.num_constraints {
+                    result[e.row] += &e.val * &witness[e.col];
+                }
+            }
+            result
+        };
+
+        let az = accumulate(&r1cs.a);
+        let bz = accumulate(&r1cs.b);
+        let cz = accumulate(&r1cs.c);
 
         let mut sum = FE::zero();
         for i in 0..r1cs.num_constraints {
-            let az_i: FE = r1cs.a[i]
-                .iter()
-                .zip(witness.iter())
-                .map(|(a, z)| a * z)
-                .fold(FE::zero(), |acc, x| acc + x);
-            let bz_i: FE = r1cs.b[i]
-                .iter()
-                .zip(witness.iter())
-                .map(|(b, z)| b * z)
-                .fold(FE::zero(), |acc, x| acc + x);
-            let cz_i: FE = r1cs.c[i]
-                .iter()
-                .zip(witness.iter())
-                .map(|(c, z)| c * z)
-                .fold(FE::zero(), |acc, x| acc + x);
-
-            sum += eq_ev.evals()[i] * (az_i * bz_i - cz_i);
+            sum += &eq_ev.evals()[i] * &(&az[i] * &bz[i] - &cz[i]);
         }
 
         assert_eq!(sum, FE::zero(), "Outer sum should be 0 for satisfied R1CS");
@@ -491,7 +484,7 @@ mod tests {
         let a = vec![vec![zero.clone(), zero.clone(), one.clone(), zero.clone()]];
         let b = vec![vec![zero.clone(), zero.clone(), zero.clone(), one.clone()]];
         let c = vec![vec![zero.clone(), one.clone(), zero.clone(), zero.clone()]];
-        let r1cs = R1CS::new(a, b, c, 1).unwrap();
+        let r1cs = R1CS::from_dense(a, b, c, 1).unwrap();
 
         let witness: Vec<FE> = vec![
             FieldElement::one(),
@@ -549,7 +542,7 @@ mod tests {
         let a = vec![vec![zero.clone(), zero.clone(), one.clone(), zero.clone()]];
         let b = vec![vec![zero.clone(), zero.clone(), zero.clone(), one.clone()]];
         let c = vec![vec![zero.clone(), one.clone(), zero.clone(), zero.clone()]];
-        let r1cs = R1CS::new(a, b, c, 1).unwrap();
+        let r1cs = R1CS::from_dense(a, b, c, 1).unwrap();
 
         // Corrupt the witness: claim 2*3=7 instead of 6
         let wrong_witness: Vec<FE> = vec![

--- a/crates/provers/spartan/src/lib.rs
+++ b/crates/provers/spartan/src/lib.rs
@@ -371,7 +371,7 @@ mod tests {
             let mut result = vec![FE::zero(); r1cs.num_constraints];
             for e in &matrix.entries {
                 if e.row < r1cs.num_constraints {
-                    result[e.row] += &e.val * &witness[e.col];
+                    result[e.row] += e.val * witness[e.col];
                 }
             }
             result
@@ -383,7 +383,7 @@ mod tests {
 
         let mut sum = FE::zero();
         for i in 0..r1cs.num_constraints {
-            sum += &eq_ev.evals()[i] * &(&az[i] * &bz[i] - &cz[i]);
+            sum += eq_ev.evals()[i] * (az[i] * bz[i] - cz[i]);
         }
 
         assert_eq!(sum, FE::zero(), "Outer sum should be 0 for satisfied R1CS");

--- a/crates/provers/spartan/src/mle.rs
+++ b/crates/provers/spartan/src/mle.rs
@@ -1,0 +1,380 @@
+//! Multilinear extension (MLE) utilities for Spartan.
+//!
+//! Provides functions to encode R1CS matrices and witness vectors as MLEs,
+//! and to compute key operations like eq_poly and matrix-vector product MLEs.
+
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolynomial;
+
+use crate::errors::SpartanError;
+
+/// Returns the smallest power of 2 that is >= n.
+pub fn next_power_of_two(n: usize) -> usize {
+    if n == 0 {
+        1
+    } else if n.is_power_of_two() {
+        n
+    } else {
+        n.next_power_of_two()
+    }
+}
+
+/// Encodes a witness vector z as a dense multilinear polynomial (MLE).
+///
+/// The witness z is padded to the next power of 2 with zeros.
+/// The resulting MLE has log₂(padded_len) variables.
+///
+/// The evaluation at boolean point (b₀, b₁, ..., b_{k-1}) where bi ∈ {0,1}
+/// equals z[i] where i is the integer with binary representation b₀b₁...b_{k-1}.
+pub fn encode_witness<F: IsField>(z: &[FieldElement<F>]) -> DenseMultilinearPolynomial<F>
+where
+    F::BaseType: Send + Sync,
+{
+    let n = z.len();
+    // Ensure at least 2 evaluations so the MLE has at least 1 variable (required by sumcheck)
+    let padded_len = next_power_of_two(n).max(2);
+    let mut evals = z.to_vec();
+    evals.resize(padded_len, FieldElement::zero());
+    DenseMultilinearPolynomial::new(evals)
+}
+
+/// Encodes an m × n matrix M as a sparse-then-dense multilinear polynomial.
+///
+/// The MLE has log₂(num_rows_padded) + log₂(num_cols_padded) variables.
+/// Entry M[i][j] maps to index (i * num_cols_padded + j) in the evaluation vector.
+///
+/// Returns a DenseMultilinearPolynomial for compatibility with the sumcheck crate.
+pub fn encode_matrix_dense<F: IsField>(
+    matrix: &[Vec<FieldElement<F>>],
+    num_rows_padded: usize,
+    num_cols_padded: usize,
+) -> Result<DenseMultilinearPolynomial<F>, SpartanError>
+where
+    F::BaseType: Send + Sync,
+{
+    if !num_rows_padded.is_power_of_two() || !num_cols_padded.is_power_of_two() {
+        return Err(SpartanError::MleError(
+            "Matrix dimensions must be powers of two for MLE encoding".to_string(),
+        ));
+    }
+
+    let total = num_rows_padded * num_cols_padded;
+    let mut evals = vec![FieldElement::zero(); total];
+
+    for (i, row) in matrix.iter().enumerate() {
+        for (j, val) in row.iter().enumerate() {
+            if i < num_rows_padded && j < num_cols_padded {
+                evals[i * num_cols_padded + j] = val.clone();
+            }
+        }
+    }
+
+    Ok(DenseMultilinearPolynomial::new(evals))
+}
+
+/// Computes eq(τ, ·) multilinear polynomial evaluations on {0,1}^s.
+///
+/// The equality polynomial is:
+/// eq(τ, x) = ∏ᵢ (τᵢ·xᵢ + (1−τᵢ)·(1−xᵢ))
+///
+/// This evaluates to 1 when x = τ (over the boolean hypercube) and 0 otherwise.
+///
+/// The evaluations are computed efficiently using the "expansion" algorithm:
+/// Start with [1], then for each τᵢ expand: new[2k] = old[k] * (1-τᵢ), new[2k+1] = old[k] * τᵢ
+pub fn eq_poly<F: IsField>(tau: &[FieldElement<F>]) -> DenseMultilinearPolynomial<F>
+where
+    F::BaseType: Send + Sync,
+{
+    let s = tau.len();
+    let n = 1 << s;
+    let mut evals = vec![FieldElement::one(); 1];
+
+    for tau_i in tau.iter() {
+        let half = evals.len();
+        let mut new_evals = vec![FieldElement::zero(); half * 2];
+        for k in 0..half {
+            let one_minus_tau_i = FieldElement::<F>::one() - tau_i;
+            new_evals[2 * k] = &evals[k] * &one_minus_tau_i;
+            new_evals[2 * k + 1] = &evals[k] * tau_i;
+        }
+        evals = new_evals;
+    }
+
+    debug_assert_eq!(evals.len(), n);
+    DenseMultilinearPolynomial::new(evals)
+}
+
+/// Computes eq(r_x, binary(i)) for all i ∈ [0, num_rows).
+///
+/// This is the Lagrange basis evaluation of the equality polynomial at a fixed point r_x.
+/// Returns a vector of size num_rows_padded where entry i = ∏ⱼ (r_x[j]·b_j + (1−r_x[j])·(1−b_j))
+/// and b = binary(i).
+///
+/// Used in matrix_vector_product_mle to compute the "row selector" weights.
+pub fn eq_evals<F: IsField>(r_x: &[FieldElement<F>], size: usize) -> Vec<FieldElement<F>>
+where
+    F::BaseType: Send + Sync,
+{
+    // Build eq evaluations over {0,1}^{log(size)} using expansion algorithm
+    let eq_mle = eq_poly(r_x);
+    let eq_ev = eq_mle.evals().to_vec();
+    // Pad or truncate to `size`
+    let mut result = eq_ev;
+    result.resize(size, FieldElement::zero());
+    result
+}
+
+/// Computes the matrix-vector product MLE: M̃Z(r_x) as a function of column index.
+///
+/// Given matrix M (m × n), witness MLE z_mle (over log n variables),
+/// and a fixed point r_x (of length log m), computes:
+///
+///   MZ(r_x)[j] = ∑_{i=0}^{m_padded - 1} M[i][j] · eq(r_x, binary(i))
+///
+/// Returns a DenseMultilinearPolynomial in log(n_padded) variables
+/// whose evaluation at boolean point binary(j) equals MZ(r_x)[j].
+///
+/// This represents the "row-collapsed" version of M with the row dimension
+/// fixed at r_x via the equality polynomial.
+pub fn matrix_vector_product_mle<F: IsField>(
+    matrix: &[Vec<FieldElement<F>>],
+    num_rows_padded: usize,
+    num_cols_padded: usize,
+    r_x: &[FieldElement<F>],
+) -> Result<DenseMultilinearPolynomial<F>, SpartanError>
+where
+    F::BaseType: Send + Sync,
+{
+    // Compute eq(r_x, binary(i)) for all i
+    let eq_weights = eq_evals(r_x, num_rows_padded);
+
+    // For each column j, compute ∑_i M[i][j] * eq_weights[i]
+    let mut result = vec![FieldElement::zero(); num_cols_padded];
+
+    for (i, row) in matrix.iter().enumerate() {
+        if i >= num_rows_padded {
+            break;
+        }
+        let w = &eq_weights[i];
+        for (j, val) in row.iter().enumerate() {
+            if j < num_cols_padded {
+                result[j] = &result[j] + w * val;
+            }
+        }
+    }
+
+    Ok(DenseMultilinearPolynomial::new(result))
+}
+
+/// Computes AZ(r_x) = ∑_j A_r_x[j] * z_mle(binary(j)) where A_r_x[j] = ∑_i A[i][j]*eq(r_x, i).
+///
+/// This is the evaluation of the matrix-vector product MLE at a scalar point,
+/// i.e., the sum ∑_j (M̃Z)(r_x, binary(j)) * z_mle(binary(j)).
+///
+/// More simply: (Az)_x = ∑_j (∑_i A[i][j]*eq(r_x,i)) * z[j]
+pub fn mz_eval<F: IsField>(
+    matrix: &[Vec<FieldElement<F>>],
+    z: &[FieldElement<F>],
+    num_rows_padded: usize,
+    r_x: &[FieldElement<F>],
+) -> FieldElement<F>
+where
+    F::BaseType: Send + Sync,
+{
+    let eq_weights = eq_evals(r_x, num_rows_padded);
+
+    let mut result = FieldElement::zero();
+    for (i, row) in matrix.iter().enumerate() {
+        if i >= num_rows_padded {
+            break;
+        }
+        // Compute <A[i], z>
+        let az_i: FieldElement<F> = row
+            .iter()
+            .zip(z.iter())
+            .map(|(a_ij, z_j)| a_ij * z_j)
+            .fold(FieldElement::zero(), |acc, x| acc + x);
+
+        result += &eq_weights[i] * &az_i;
+    }
+
+    result
+}
+
+/// Evaluates a matrix MLE at (r_x, r_y).
+///
+/// Computes ∑_{i,j} M[i][j] · eq(r_x, binary(i)) · eq(r_y, binary(j))
+pub fn matrix_mle_eval<F: IsField>(
+    matrix: &[Vec<FieldElement<F>>],
+    num_rows_padded: usize,
+    num_cols_padded: usize,
+    r_x: &[FieldElement<F>],
+    r_y: &[FieldElement<F>],
+) -> FieldElement<F>
+where
+    F::BaseType: Send + Sync,
+{
+    let eq_x = eq_evals(r_x, num_rows_padded);
+    let eq_y = eq_evals(r_y, num_cols_padded);
+
+    let mut result = FieldElement::zero();
+    for (i, row) in matrix.iter().enumerate() {
+        if i >= num_rows_padded {
+            break;
+        }
+        for (j, val) in row.iter().enumerate() {
+            if j < num_cols_padded {
+                result += &eq_x[i] * &eq_y[j] * val;
+            }
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lambdaworks_math::field::fields::u64_prime_field::U64PrimeField;
+
+    const MODULUS: u64 = 101;
+    type F = U64PrimeField<MODULUS>;
+    type FE = FieldElement<F>;
+
+    #[test]
+    fn test_encode_witness_evaluations() {
+        // z = [1, 7, 3, 5], 2 variables, so:
+        // z_mle(0,0) = 1, z_mle(0,1) = 7, z_mle(1,0) = 3, z_mle(1,1) = 5
+        let z = vec![FE::from(1), FE::from(7), FE::from(3), FE::from(5)];
+        let z_mle = encode_witness(&z);
+
+        assert_eq!(z_mle.num_vars(), 2);
+        assert_eq!(
+            z_mle.evaluate(vec![FE::zero(), FE::zero()]).unwrap(),
+            FE::from(1)
+        );
+        assert_eq!(
+            z_mle.evaluate(vec![FE::zero(), FE::one()]).unwrap(),
+            FE::from(7)
+        );
+        assert_eq!(
+            z_mle.evaluate(vec![FE::one(), FE::zero()]).unwrap(),
+            FE::from(3)
+        );
+        assert_eq!(
+            z_mle.evaluate(vec![FE::one(), FE::one()]).unwrap(),
+            FE::from(5)
+        );
+    }
+
+    #[test]
+    fn test_encode_witness_padding() {
+        // Odd-length witness should be padded
+        let z = vec![FE::from(1), FE::from(2), FE::from(3)];
+        let z_mle = encode_witness(&z);
+        // Padded to length 4, so 2 variables
+        assert_eq!(z_mle.num_vars(), 2);
+        assert_eq!(
+            z_mle.evaluate(vec![FE::one(), FE::one()]).unwrap(),
+            FE::zero() // padded zero
+        );
+    }
+
+    #[test]
+    fn test_eq_poly_two_vars() {
+        // tau = [a, b]
+        // eq_poly(tau) evaluations:
+        // (0,0) -> (1-a)(1-b)
+        // (0,1) -> (1-a)*b
+        // (1,0) -> a*(1-b)
+        // (1,1) -> a*b
+        let a = FE::from(3);
+        let b = FE::from(5);
+        let tau = vec![a.clone(), b.clone()];
+        let eq = eq_poly(&tau);
+
+        assert_eq!(eq.num_vars(), 2);
+        let evals = eq.evals();
+
+        let one = FE::one();
+        let one_minus_a = &one - &a;
+        let one_minus_b = &one - &b;
+
+        assert_eq!(evals[0], &one_minus_a * &one_minus_b); // (0,0)
+        assert_eq!(evals[1], &one_minus_a * &b); // (0,1)
+        assert_eq!(evals[2], &a * &one_minus_b); // (1,0)
+        assert_eq!(evals[3], &a * &b); // (1,1)
+    }
+
+    #[test]
+    fn test_eq_poly_at_boolean_point() {
+        // eq(tau, tau) should equal 1 when tau is a boolean point
+        let tau = vec![FE::one(), FE::zero()];
+        let eq = eq_poly(&tau);
+        let val = eq.evaluate(tau.clone()).unwrap();
+        assert_eq!(val, FE::one());
+
+        // eq(tau, other) should equal 0 for other boolean points
+        let other = vec![FE::zero(), FE::zero()];
+        let val_other = eq.evaluate(other).unwrap();
+        assert_eq!(val_other, FE::zero());
+    }
+
+    #[test]
+    fn test_matrix_vector_product_mle() {
+        // A = [[1,0],[0,2]], z = [3,5], Az = [3, 10]
+        // At r_x = [0] (selects row 0): should give A[0][·]*z[·] sum weighted by eq([0], binary(i))
+        // eq([0], 0) = 1, eq([0], 1) = 0
+        // So MZ([0])[j] = A[0][j] for j=0,1
+        let zero = FE::zero();
+        let one = FE::one();
+        let two = FE::from(2u64);
+
+        let a = vec![
+            vec![one.clone(), zero.clone()],
+            vec![zero.clone(), two.clone()],
+        ];
+
+        // r_x = [0] selects row 0
+        let r_x = vec![FE::zero()];
+        let mz = matrix_vector_product_mle(&a, 2, 2, &r_x).unwrap();
+
+        // MZ([0])[0] = A[0][0]*eq([0],0) + A[1][0]*eq([0],1) = 1*1 + 0*0 = 1
+        // MZ([0])[1] = A[0][1]*eq([0],0) + A[1][1]*eq([0],1) = 0*1 + 2*0 = 0
+        assert_eq!(mz.evaluate(vec![FE::zero()]).unwrap(), one); // col 0
+        assert_eq!(mz.evaluate(vec![FE::one()]).unwrap(), zero); // col 1
+
+        // r_x = [1] selects row 1
+        let r_x1 = vec![FE::one()];
+        let mz1 = matrix_vector_product_mle(&a, 2, 2, &r_x1).unwrap();
+        // MZ([1])[0] = A[0][0]*eq([1],0) + A[1][0]*eq([1],1) = 1*0 + 0*1 = 0
+        // MZ([1])[1] = A[0][1]*eq([1],0) + A[1][1]*eq([1],1) = 0*0 + 2*1 = 2
+        assert_eq!(mz1.evaluate(vec![FE::zero()]).unwrap(), zero); // col 0
+        assert_eq!(mz1.evaluate(vec![FE::one()]).unwrap(), two); // col 1
+    }
+
+    #[test]
+    fn test_mz_eval_correctness() {
+        // A = [[1,0],[0,2]], z = [3,5], Az = [3, 10]
+        // At r_x = [0]: ∑_j MZ([0])[j] * z[j] should give the "row 0 contribution"
+        // Actually mz_eval computes ∑_i eq(r_x, i) * <A[i], z>
+        // = eq([0],0)*<A[0],z> + eq([0],1)*<A[1],z>
+        // = 1*3 + 0*10 = 3
+        let zero = FE::zero();
+        let one = FE::one();
+        let two = FE::from(2u64);
+
+        let a = vec![
+            vec![one.clone(), zero.clone()],
+            vec![zero.clone(), two.clone()],
+        ];
+        let z = vec![FE::from(3u64), FE::from(5u64)];
+
+        let r_x = vec![FE::zero()];
+        let val = mz_eval(&a, &z, 2, &r_x);
+        assert_eq!(val, FE::from(3u64)); // eq([0],0)*<A[0],z> = 1*3 = 3
+
+        let r_x1 = vec![FE::one()];
+        let val1 = mz_eval(&a, &z, 2, &r_x1);
+        assert_eq!(val1, FE::from(10u64)); // eq([1],1)*<A[1],z> = 1*10 = 10
+    }
+}

--- a/crates/provers/spartan/src/mle.rs
+++ b/crates/provers/spartan/src/mle.rs
@@ -289,20 +289,20 @@ mod tests {
         // (1,1) -> a*b
         let a = FE::from(3);
         let b = FE::from(5);
-        let tau = vec![a.clone(), b.clone()];
+        let tau = vec![a, b];
         let eq = eq_poly(&tau);
 
         assert_eq!(eq.num_vars(), 2);
         let evals = eq.evals();
 
         let one = FE::one();
-        let one_minus_a = &one - &a;
-        let one_minus_b = &one - &b;
+        let one_minus_a = one - a;
+        let one_minus_b = one - b;
 
-        assert_eq!(evals[0], &one_minus_a * &one_minus_b); // (0,0)
-        assert_eq!(evals[1], &one_minus_a * &b); // (0,1)
-        assert_eq!(evals[2], &a * &one_minus_b); // (1,0)
-        assert_eq!(evals[3], &a * &b); // (1,1)
+        assert_eq!(evals[0], one_minus_a * one_minus_b); // (0,0)
+        assert_eq!(evals[1], one_minus_a * b); // (0,1)
+        assert_eq!(evals[2], a * one_minus_b); // (1,0)
+        assert_eq!(evals[3], a * b); // (1,1)
     }
 
     #[test]
@@ -329,10 +329,7 @@ mod tests {
         let one = FE::one();
         let two = FE::from(2u64);
 
-        let a = vec![
-            vec![one.clone(), zero.clone()],
-            vec![zero.clone(), two.clone()],
-        ];
+        let a = vec![vec![one, zero], vec![zero, two]];
 
         // r_x = [0] selects row 0
         let r_x = vec![FE::zero()];
@@ -363,10 +360,7 @@ mod tests {
         let one = FE::one();
         let two = FE::from(2u64);
 
-        let a = vec![
-            vec![one.clone(), zero.clone()],
-            vec![zero.clone(), two.clone()],
-        ];
+        let a = vec![vec![one, zero], vec![zero, two]];
         let z = vec![FE::from(3u64), FE::from(5u64)];
 
         let r_x = vec![FE::zero()];

--- a/crates/provers/spartan/src/mle.rs
+++ b/crates/provers/spartan/src/mle.rs
@@ -201,6 +201,29 @@ where
     result
 }
 
+/// Converts a witness index `i` into its boolean evaluation point for the witness MLE.
+///
+/// `DenseMultilinearPolynomial` uses MSB-first ordering: the bit representation of `i`
+/// with `n` bits has the most significant bit as variable 0.
+/// That is, `point[k] = (i >> (n-1-k)) & 1`.
+///
+/// Used to open the witness MLE at specific positions, e.g. to verify that
+/// z̃(bits(i)) == public_inputs[i-1] for each public input index i.
+pub fn index_to_multilinear_point<F: IsField>(i: usize, n: usize) -> Vec<FieldElement<F>>
+where
+    F::BaseType: Send + Sync,
+{
+    (0..n)
+        .map(|k| {
+            if (i >> (n - 1 - k)) & 1 == 1 {
+                FieldElement::one()
+            } else {
+                FieldElement::zero()
+            }
+        })
+        .collect()
+}
+
 /// Evaluates a matrix MLE at (r_x, r_y).
 ///
 /// Computes ∑_{i,j} M[i][j] · eq(r_x, binary(i)) · eq(r_y, binary(j))

--- a/crates/provers/spartan/src/mle.rs
+++ b/crates/provers/spartan/src/mle.rs
@@ -116,6 +116,24 @@ where
     Ok(DenseMultilinearPolynomial::new(result))
 }
 
+/// Like `matrix_vector_product_mle`, but accepts precomputed eq weights.
+pub fn matrix_vector_product_mle_with_eq<F: IsField>(
+    matrix: &SparseMatrix<F>,
+    num_cols_padded: usize,
+    eq_weights: &[FieldElement<F>],
+) -> DenseMultilinearPolynomial<F>
+where
+    F::BaseType: Send + Sync,
+{
+    let mut result = vec![FieldElement::zero(); num_cols_padded];
+    for entry in &matrix.entries {
+        if entry.row < eq_weights.len() && entry.col < num_cols_padded {
+            result[entry.col] += &eq_weights[entry.row] * &entry.val;
+        }
+    }
+    DenseMultilinearPolynomial::new(result)
+}
+
 /// Computes AZ(r_x) = sum_i eq(r_x, i) * <A[i], z>.
 ///
 /// Iterates only non-zero entries of the sparse matrix.

--- a/crates/provers/spartan/src/mle.rs
+++ b/crates/provers/spartan/src/mle.rs
@@ -140,6 +140,24 @@ where
     result
 }
 
+/// Like `mz_eval`, but accepts precomputed eq weights to avoid recomputation.
+pub fn mz_eval_with_eq<F: IsField>(
+    matrix: &SparseMatrix<F>,
+    z: &[FieldElement<F>],
+    eq_weights: &[FieldElement<F>],
+) -> FieldElement<F>
+where
+    F::BaseType: Send + Sync,
+{
+    let mut result = FieldElement::zero();
+    for entry in &matrix.entries {
+        if entry.row < eq_weights.len() {
+            result += &eq_weights[entry.row] * &entry.val * &z[entry.col];
+        }
+    }
+    result
+}
+
 /// Converts a witness index `i` into its boolean point for the witness MLE.
 ///
 /// `DenseMultilinearPolynomial` uses MSB-first ordering: the bit representation of `i`

--- a/crates/provers/spartan/src/mle.rs
+++ b/crates/provers/spartan/src/mle.rs
@@ -7,6 +7,7 @@ use lambdaworks_math::field::{element::FieldElement, traits::IsField};
 use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolynomial;
 
 use crate::errors::SpartanError;
+use crate::sparse_matrix::SparseMatrix;
 
 /// Returns the smallest power of 2 that is >= n (returns 1 for n = 0).
 pub fn next_power_of_two(n: usize) -> usize {
@@ -20,10 +21,10 @@ pub fn next_power_of_two(n: usize) -> usize {
 /// Encodes a witness vector z as a dense multilinear polynomial (MLE).
 ///
 /// The witness z is padded to the next power of 2 with zeros.
-/// The resulting MLE has log₂(padded_len) variables.
+/// The resulting MLE has log2(padded_len) variables.
 ///
-/// The evaluation at boolean point (b₀, b₁, ..., b_{k-1}) where bi ∈ {0,1}
-/// equals z[i] where i is the integer with binary representation b₀b₁...b_{k-1}.
+/// The result at boolean point (b0, b1, ..., b_{k-1}) where bi in {0,1}
+/// equals z[i] where i is the integer with binary representation b0b1...b_{k-1}.
 pub fn encode_witness<F: IsField>(z: &[FieldElement<F>]) -> DenseMultilinearPolynomial<F>
 where
     F::BaseType: Send + Sync,
@@ -31,81 +32,47 @@ where
     let n = z.len();
     // Ensure at least 2 evaluations so the MLE has at least 1 variable (required by sumcheck)
     let padded_len = next_power_of_two(n).max(2);
-    let mut evals = z.to_vec();
-    evals.resize(padded_len, FieldElement::zero());
-    DenseMultilinearPolynomial::new(evals)
+    let mut results = z.to_vec();
+    results.resize(padded_len, FieldElement::zero());
+    DenseMultilinearPolynomial::new(results)
 }
 
-/// Encodes an m × n matrix M as a sparse-then-dense multilinear polynomial.
-///
-/// The MLE has log₂(num_rows_padded) + log₂(num_cols_padded) variables.
-/// Entry M[i][j] maps to index (i * num_cols_padded + j) in the evaluation vector.
-///
-/// Returns a DenseMultilinearPolynomial for compatibility with the sumcheck crate.
-pub fn encode_matrix_dense<F: IsField>(
-    matrix: &[Vec<FieldElement<F>>],
-    num_rows_padded: usize,
-    num_cols_padded: usize,
-) -> Result<DenseMultilinearPolynomial<F>, SpartanError>
-where
-    F::BaseType: Send + Sync,
-{
-    if !num_rows_padded.is_power_of_two() || !num_cols_padded.is_power_of_two() {
-        return Err(SpartanError::MleError(
-            "Matrix dimensions must be powers of two for MLE encoding".to_string(),
-        ));
-    }
-
-    let total = num_rows_padded * num_cols_padded;
-    let mut evals = vec![FieldElement::zero(); total];
-
-    for (i, row) in matrix.iter().enumerate() {
-        for (j, val) in row.iter().enumerate() {
-            if i < num_rows_padded && j < num_cols_padded {
-                evals[i * num_cols_padded + j] = val.clone();
-            }
-        }
-    }
-
-    Ok(DenseMultilinearPolynomial::new(evals))
-}
-
-/// Computes eq(τ, ·) multilinear polynomial evaluations on {0,1}^s.
+/// Computes eq(tau, x) multilinear polynomial evaluations on {0,1}^s.
 ///
 /// The equality polynomial is:
-/// eq(τ, x) = ∏ᵢ (τᵢ·xᵢ + (1−τᵢ)·(1−xᵢ))
+/// eq(tau, x) = prod_i (tau_i * x_i + (1 - tau_i) * (1 - x_i))
 ///
-/// This evaluates to 1 when x = τ (over the boolean hypercube) and 0 otherwise.
+/// This evaluates to 1 when x = tau (over the boolean hypercube) and 0 otherwise.
 ///
 /// The evaluations are computed efficiently using the "expansion" algorithm:
-/// Start with [1], then for each τᵢ expand: new[2k] = old[k] * (1-τᵢ), new[2k+1] = old[k] * τᵢ
+/// Start with [1], then for each tau_i expand: new[2k] = old[k] * (1-tau_i), new[2k+1] = old[k] * tau_i
 pub fn eq_poly<F: IsField>(tau: &[FieldElement<F>]) -> DenseMultilinearPolynomial<F>
 where
     F::BaseType: Send + Sync,
 {
     let s = tau.len();
     let n = 1 << s;
-    let mut evals = vec![FieldElement::one(); 1];
+    let mut current = vec![FieldElement::one(); 1];
 
     for tau_i in tau.iter() {
-        let half = evals.len();
+        let half = current.len();
         let one_minus_tau_i = FieldElement::<F>::one() - tau_i;
-        let mut new_evals = vec![FieldElement::zero(); half * 2];
+        let mut new_vals = vec![FieldElement::zero(); half * 2];
         for k in 0..half {
-            new_evals[2 * k] = &evals[k] * &one_minus_tau_i;
-            new_evals[2 * k + 1] = &evals[k] * tau_i;
+            new_vals[2 * k] = &current[k] * &one_minus_tau_i;
+            new_vals[2 * k + 1] = &current[k] * tau_i;
         }
-        evals = new_evals;
+        current = new_vals;
     }
 
-    debug_assert_eq!(evals.len(), n);
-    DenseMultilinearPolynomial::new(evals)
+    debug_assert_eq!(current.len(), n);
+    DenseMultilinearPolynomial::new(current)
 }
 
-/// Computes eq(r_x, binary(i)) for all i ∈ [0, num_rows).
+/// Computes eq(r_x, binary(i)) for all i in [0, num_rows).
 ///
-/// This is the Lagrange basis evaluation of the equality polynomial at a fixed point r_x.
-/// Returns a vector of size num_rows_padded where entry i = ∏ⱼ (r_x[j]·b_j + (1−r_x[j])·(1−b_j))
+/// This is the Lagrange basis computation of the equality polynomial at a fixed point r_x.
+/// Returns a vector of size num_rows_padded where entry i = prod_j (r_x[j]*b_j + (1-r_x[j])*(1-b_j))
 /// and b = binary(i).
 ///
 /// Used in matrix_vector_product_mle to compute the "row selector" weights.
@@ -122,20 +89,16 @@ where
     result
 }
 
-/// Computes the matrix-vector product MLE: M̃Z(r_x) as a function of column index.
+/// Computes the matrix-vector product MLE: MZ(r_x) as a function of column index.
 ///
-/// Given matrix M (m × n), witness MLE z_mle (over log n variables),
-/// and a fixed point r_x (of length log m), computes:
+/// Given sparse matrix M (m x n), a fixed point r_x (of length log m), computes:
 ///
-///   MZ(r_x)[j] = ∑_{i=0}^{m_padded - 1} M[i][j] · eq(r_x, binary(i))
+///   MZ(r_x)[j] = sum_{i=0}^{m_padded - 1} M[i][j] * eq(r_x, binary(i))
 ///
 /// Returns a DenseMultilinearPolynomial in log(n_padded) variables
-/// whose evaluation at boolean point binary(j) equals MZ(r_x)[j].
-///
-/// This represents the "row-collapsed" version of M with the row dimension
-/// fixed at r_x via the equality polynomial.
+/// whose result at boolean point binary(j) equals MZ(r_x)[j].
 pub fn matrix_vector_product_mle<F: IsField>(
-    matrix: &[Vec<FieldElement<F>>],
+    matrix: &SparseMatrix<F>,
     num_rows_padded: usize,
     num_cols_padded: usize,
     r_x: &[FieldElement<F>],
@@ -143,35 +106,23 @@ pub fn matrix_vector_product_mle<F: IsField>(
 where
     F::BaseType: Send + Sync,
 {
-    // Compute eq(r_x, binary(i)) for all i
     let eq_weights = eq_evals(r_x, num_rows_padded);
-
-    // For each column j, compute ∑_i M[i][j] * eq_weights[i]
     let mut result = vec![FieldElement::zero(); num_cols_padded];
 
-    for (i, row) in matrix.iter().enumerate() {
-        if i >= num_rows_padded {
-            break;
-        }
-        let w = &eq_weights[i];
-        for (j, val) in row.iter().enumerate() {
-            if j < num_cols_padded {
-                result[j] = &result[j] + w * val;
-            }
+    for entry in &matrix.entries {
+        if entry.row < num_rows_padded && entry.col < num_cols_padded {
+            result[entry.col] = &result[entry.col] + &eq_weights[entry.row] * &entry.val;
         }
     }
 
     Ok(DenseMultilinearPolynomial::new(result))
 }
 
-/// Computes AZ(r_x) = ∑_j A_r_x[j] * z_mle(binary(j)) where A_r_x[j] = ∑_i A[i][j]*eq(r_x, i).
+/// Computes AZ(r_x) = sum_i eq(r_x, i) * <A[i], z>.
 ///
-/// This is the evaluation of the matrix-vector product MLE at a scalar point,
-/// i.e., the sum ∑_j (M̃Z)(r_x, binary(j)) * z_mle(binary(j)).
-///
-/// More simply: (Az)_x = ∑_j (∑_i A[i][j]*eq(r_x,i)) * z[j]
+/// Iterates only non-zero entries of the sparse matrix.
 pub fn mz_eval<F: IsField>(
-    matrix: &[Vec<FieldElement<F>>],
+    matrix: &SparseMatrix<F>,
     z: &[FieldElement<F>],
     num_rows_padded: usize,
     r_x: &[FieldElement<F>],
@@ -180,33 +131,25 @@ where
     F::BaseType: Send + Sync,
 {
     let eq_weights = eq_evals(r_x, num_rows_padded);
-
     let mut result = FieldElement::zero();
-    for (i, row) in matrix.iter().enumerate() {
-        if i >= num_rows_padded {
-            break;
-        }
-        // Compute <A[i], z>
-        let az_i: FieldElement<F> = row
-            .iter()
-            .zip(z.iter())
-            .map(|(a_ij, z_j)| a_ij * z_j)
-            .fold(FieldElement::zero(), |acc, x| acc + x);
 
-        result += &eq_weights[i] * &az_i;
+    for entry in &matrix.entries {
+        if entry.row < num_rows_padded {
+            result += &eq_weights[entry.row] * &entry.val * &z[entry.col];
+        }
     }
 
     result
 }
 
-/// Converts a witness index `i` into its boolean evaluation point for the witness MLE.
+/// Converts a witness index `i` into its boolean point for the witness MLE.
 ///
 /// `DenseMultilinearPolynomial` uses MSB-first ordering: the bit representation of `i`
 /// with `n` bits has the most significant bit as variable 0.
 /// That is, `point[k] = (i >> (n-1-k)) & 1`.
 ///
 /// Used to open the witness MLE at specific positions, e.g. to verify that
-/// z̃(bits(i)) == public_inputs[i-1] for each public input index i.
+/// z_tilde(bits(i)) == public_inputs[i-1] for each public input index i.
 pub fn index_to_multilinear_point<F: IsField>(i: usize, n: usize) -> Vec<FieldElement<F>>
 where
     F::BaseType: Send + Sync,
@@ -222,11 +165,13 @@ where
         .collect()
 }
 
-/// Evaluates a matrix MLE at (r_x, r_y).
+/// Computes a matrix MLE at (r_x, r_y).
 ///
-/// Computes ∑_{i,j} M[i][j] · eq(r_x, binary(i)) · eq(r_y, binary(j))
+/// Computes sum_{i,j} M[i][j] * eq(r_x, binary(i)) * eq(r_y, binary(j))
+///
+/// Iterates only non-zero entries of the sparse matrix.
 pub fn matrix_mle_eval<F: IsField>(
-    matrix: &[Vec<FieldElement<F>>],
+    matrix: &SparseMatrix<F>,
     num_rows_padded: usize,
     num_cols_padded: usize,
     r_x: &[FieldElement<F>],
@@ -237,16 +182,11 @@ where
 {
     let eq_x = eq_evals(r_x, num_rows_padded);
     let eq_y = eq_evals(r_y, num_cols_padded);
-
     let mut result = FieldElement::zero();
-    for (i, row) in matrix.iter().enumerate() {
-        if i >= num_rows_padded {
-            break;
-        }
-        for (j, val) in row.iter().enumerate() {
-            if j < num_cols_padded {
-                result += &eq_x[i] * &eq_y[j] * val;
-            }
+
+    for entry in &matrix.entries {
+        if entry.row < num_rows_padded && entry.col < num_cols_padded {
+            result += &eq_x[entry.row] * &eq_y[entry.col] * &entry.val;
         }
     }
     result
@@ -263,8 +203,6 @@ mod tests {
 
     #[test]
     fn test_encode_witness_evaluations() {
-        // z = [1, 7, 3, 5], 2 variables, so:
-        // z_mle(0,0) = 1, z_mle(0,1) = 7, z_mle(1,0) = 3, z_mle(1,1) = 5
         let z = vec![FE::from(1), FE::from(7), FE::from(3), FE::from(5)];
         let z_mle = encode_witness(&z);
 
@@ -289,52 +227,42 @@ mod tests {
 
     #[test]
     fn test_encode_witness_padding() {
-        // Odd-length witness should be padded
         let z = vec![FE::from(1), FE::from(2), FE::from(3)];
         let z_mle = encode_witness(&z);
-        // Padded to length 4, so 2 variables
         assert_eq!(z_mle.num_vars(), 2);
         assert_eq!(
             z_mle.evaluate(vec![FE::one(), FE::one()]).unwrap(),
-            FE::zero() // padded zero
+            FE::zero()
         );
     }
 
     #[test]
     fn test_eq_poly_two_vars() {
-        // tau = [a, b]
-        // eq_poly(tau) evaluations:
-        // (0,0) -> (1-a)(1-b)
-        // (0,1) -> (1-a)*b
-        // (1,0) -> a*(1-b)
-        // (1,1) -> a*b
         let a = FE::from(3);
         let b = FE::from(5);
         let tau = vec![a, b];
         let eq = eq_poly(&tau);
 
         assert_eq!(eq.num_vars(), 2);
-        let evals = eq.evals();
+        let vals = eq.evals();
 
         let one = FE::one();
         let one_minus_a = one - a;
         let one_minus_b = one - b;
 
-        assert_eq!(evals[0], one_minus_a * one_minus_b); // (0,0)
-        assert_eq!(evals[1], one_minus_a * b); // (0,1)
-        assert_eq!(evals[2], a * one_minus_b); // (1,0)
-        assert_eq!(evals[3], a * b); // (1,1)
+        assert_eq!(vals[0], one_minus_a * one_minus_b);
+        assert_eq!(vals[1], one_minus_a * b);
+        assert_eq!(vals[2], a * one_minus_b);
+        assert_eq!(vals[3], a * b);
     }
 
     #[test]
     fn test_eq_poly_at_boolean_point() {
-        // eq(tau, tau) should equal 1 when tau is a boolean point
         let tau = vec![FE::one(), FE::zero()];
         let eq = eq_poly(&tau);
         let val = eq.evaluate(tau.clone()).unwrap();
         assert_eq!(val, FE::one());
 
-        // eq(tau, other) should equal 0 for other boolean points
         let other = vec![FE::zero(), FE::zero()];
         let val_other = eq.evaluate(other).unwrap();
         assert_eq!(val_other, FE::zero());
@@ -342,54 +270,40 @@ mod tests {
 
     #[test]
     fn test_matrix_vector_product_mle() {
-        // A = [[1,0],[0,2]], z = [3,5], Az = [3, 10]
-        // At r_x = [0] (selects row 0): should give A[0][·]*z[·] sum weighted by eq([0], binary(i))
-        // eq([0], 0) = 1, eq([0], 1) = 0
-        // So MZ([0])[j] = A[0][j] for j=0,1
         let zero = FE::zero();
         let one = FE::one();
         let two = FE::from(2u64);
 
-        let a = vec![vec![one, zero], vec![zero, two]];
+        let a_dense = vec![vec![one, zero], vec![zero, two]];
+        let a = SparseMatrix::from_dense(&a_dense);
 
-        // r_x = [0] selects row 0
         let r_x = vec![FE::zero()];
         let mz = matrix_vector_product_mle(&a, 2, 2, &r_x).unwrap();
+        assert_eq!(mz.evaluate(vec![FE::zero()]).unwrap(), one);
+        assert_eq!(mz.evaluate(vec![FE::one()]).unwrap(), zero);
 
-        // MZ([0])[0] = A[0][0]*eq([0],0) + A[1][0]*eq([0],1) = 1*1 + 0*0 = 1
-        // MZ([0])[1] = A[0][1]*eq([0],0) + A[1][1]*eq([0],1) = 0*1 + 2*0 = 0
-        assert_eq!(mz.evaluate(vec![FE::zero()]).unwrap(), one); // col 0
-        assert_eq!(mz.evaluate(vec![FE::one()]).unwrap(), zero); // col 1
-
-        // r_x = [1] selects row 1
         let r_x1 = vec![FE::one()];
         let mz1 = matrix_vector_product_mle(&a, 2, 2, &r_x1).unwrap();
-        // MZ([1])[0] = A[0][0]*eq([1],0) + A[1][0]*eq([1],1) = 1*0 + 0*1 = 0
-        // MZ([1])[1] = A[0][1]*eq([1],0) + A[1][1]*eq([1],1) = 0*0 + 2*1 = 2
-        assert_eq!(mz1.evaluate(vec![FE::zero()]).unwrap(), zero); // col 0
-        assert_eq!(mz1.evaluate(vec![FE::one()]).unwrap(), two); // col 1
+        assert_eq!(mz1.evaluate(vec![FE::zero()]).unwrap(), zero);
+        assert_eq!(mz1.evaluate(vec![FE::one()]).unwrap(), two);
     }
 
     #[test]
     fn test_mz_eval_correctness() {
-        // A = [[1,0],[0,2]], z = [3,5], Az = [3, 10]
-        // At r_x = [0]: ∑_j MZ([0])[j] * z[j] should give the "row 0 contribution"
-        // Actually mz_eval computes ∑_i eq(r_x, i) * <A[i], z>
-        // = eq([0],0)*<A[0],z> + eq([0],1)*<A[1],z>
-        // = 1*3 + 0*10 = 3
         let zero = FE::zero();
         let one = FE::one();
         let two = FE::from(2u64);
 
-        let a = vec![vec![one, zero], vec![zero, two]];
+        let a_dense = vec![vec![one, zero], vec![zero, two]];
+        let a = SparseMatrix::from_dense(&a_dense);
         let z = vec![FE::from(3u64), FE::from(5u64)];
 
         let r_x = vec![FE::zero()];
         let val = mz_eval(&a, &z, 2, &r_x);
-        assert_eq!(val, FE::from(3u64)); // eq([0],0)*<A[0],z> = 1*3 = 3
+        assert_eq!(val, FE::from(3u64));
 
         let r_x1 = vec![FE::one()];
         let val1 = mz_eval(&a, &z, 2, &r_x1);
-        assert_eq!(val1, FE::from(10u64)); // eq([1],1)*<A[1],z> = 1*10 = 10
+        assert_eq!(val1, FE::from(10u64));
     }
 }

--- a/crates/provers/spartan/src/mle.rs
+++ b/crates/provers/spartan/src/mle.rs
@@ -52,15 +52,15 @@ where
 {
     let s = tau.len();
     let n = 1 << s;
-    let mut current = vec![FieldElement::one(); 1];
+    let mut current = vec![FieldElement::one()];
 
     for tau_i in tau.iter() {
         let half = current.len();
         let one_minus_tau_i = FieldElement::<F>::one() - tau_i;
-        let mut new_vals = vec![FieldElement::zero(); half * 2];
-        for k in 0..half {
-            new_vals[2 * k] = &current[k] * &one_minus_tau_i;
-            new_vals[2 * k + 1] = &current[k] * tau_i;
+        let mut new_vals = Vec::with_capacity(half * 2);
+        for val in current.iter() {
+            new_vals.push(val * &one_minus_tau_i);
+            new_vals.push(val * tau_i);
         }
         current = new_vals;
     }
@@ -82,9 +82,7 @@ where
 {
     // Build eq evaluations over {0,1}^{log(size)} using expansion algorithm
     let eq_mle = eq_poly(r_x);
-    let eq_ev = eq_mle.evals().to_vec();
-    // Pad or truncate to `size`
-    let mut result = eq_ev;
+    let mut result = eq_mle.evals().to_vec();
     result.resize(size, FieldElement::zero());
     result
 }
@@ -111,7 +109,7 @@ where
 
     for entry in &matrix.entries {
         if entry.row < num_rows_padded && entry.col < num_cols_padded {
-            result[entry.col] = &result[entry.col] + &eq_weights[entry.row] * &entry.val;
+            result[entry.col] += &eq_weights[entry.row] * &entry.val;
         }
     }
 

--- a/crates/provers/spartan/src/mle.rs
+++ b/crates/provers/spartan/src/mle.rs
@@ -8,12 +8,10 @@ use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolyno
 
 use crate::errors::SpartanError;
 
-/// Returns the smallest power of 2 that is >= n.
+/// Returns the smallest power of 2 that is >= n (returns 1 for n = 0).
 pub fn next_power_of_two(n: usize) -> usize {
     if n == 0 {
         1
-    } else if n.is_power_of_two() {
-        n
     } else {
         n.next_power_of_two()
     }
@@ -91,9 +89,9 @@ where
 
     for tau_i in tau.iter() {
         let half = evals.len();
+        let one_minus_tau_i = FieldElement::<F>::one() - tau_i;
         let mut new_evals = vec![FieldElement::zero(); half * 2];
         for k in 0..half {
-            let one_minus_tau_i = FieldElement::<F>::one() - tau_i;
             new_evals[2 * k] = &evals[k] * &one_minus_tau_i;
             new_evals[2 * k + 1] = &evals[k] * tau_i;
         }

--- a/crates/provers/spartan/src/mle.rs
+++ b/crates/provers/spartan/src/mle.rs
@@ -226,6 +226,38 @@ where
     result
 }
 
+/// Evaluates multiple matrix MLEs at the same (r_x, r_y) point, sharing eq computation.
+///
+/// Returns (A_eval, B_eval, C_eval) using a single pair of eq_evals calls
+/// instead of one per matrix.
+pub fn batch_matrix_mle_eval<F: IsField>(
+    a: &SparseMatrix<F>,
+    b: &SparseMatrix<F>,
+    c: &SparseMatrix<F>,
+    num_rows_padded: usize,
+    num_cols_padded: usize,
+    r_x: &[FieldElement<F>],
+    r_y: &[FieldElement<F>],
+) -> (FieldElement<F>, FieldElement<F>, FieldElement<F>)
+where
+    F::BaseType: Send + Sync,
+{
+    let eq_x = eq_evals(r_x, num_rows_padded);
+    let eq_y = eq_evals(r_y, num_cols_padded);
+
+    let eval_matrix = |matrix: &SparseMatrix<F>| -> FieldElement<F> {
+        let mut result = FieldElement::zero();
+        for entry in &matrix.entries {
+            if entry.row < num_rows_padded && entry.col < num_cols_padded {
+                result += &eq_x[entry.row] * &eq_y[entry.col] * &entry.val;
+            }
+        }
+        result
+    };
+
+    (eval_matrix(a), eval_matrix(b), eval_matrix(c))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/provers/spartan/src/pcs/mod.rs
+++ b/crates/provers/spartan/src/pcs/mod.rs
@@ -2,61 +2,13 @@
 //!
 //! Provides the IsMultilinearPCS trait for committing to multilinear polynomials,
 //! the TrivialPCS implementation for testing, and the ZeromorphPCS implementation
-//! backed by KZG for production use.
+//! backed by KZG (re-exported from lambdaworks-crypto).
 
-use lambdaworks_math::field::{element::FieldElement, traits::IsField};
-use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolynomial;
-
-/// Error type for PCS operations.
-#[derive(Debug, thiserror::Error)]
-#[error("PCS error: {0}")]
-pub struct PcsError(pub String);
-
-/// Trait for multilinear polynomial commitment schemes.
-///
-/// Defines the interface for committing to a multilinear polynomial,
-/// opening it at a point, and verifying the opening.
-///
-/// All implementations must also implement `serialize_commitment` so that
-/// the Fiat-Shamir transcript can absorb the commitment before challenges
-/// are drawn — a requirement for protocol soundness.
-pub trait IsMultilinearPCS<F: IsField>
-where
-    F::BaseType: Send + Sync,
-{
-    type Commitment: Clone;
-    type Proof: Clone;
-    type Error: std::error::Error;
-
-    /// Commit to a multilinear polynomial.
-    fn commit(&self, poly: &DenseMultilinearPolynomial<F>)
-        -> Result<Self::Commitment, Self::Error>;
-
-    /// Open the polynomial at a point, returning the value and a proof.
-    fn open(
-        &self,
-        poly: &DenseMultilinearPolynomial<F>,
-        point: &[FieldElement<F>],
-    ) -> Result<(FieldElement<F>, Self::Proof), Self::Error>;
-
-    /// Verify an opening proof.
-    fn verify(
-        &self,
-        commitment: &Self::Commitment,
-        point: &[FieldElement<F>],
-        value: &FieldElement<F>,
-        proof: &Self::Proof,
-    ) -> Result<bool, Self::Error>;
-
-    /// Serialize a commitment to bytes for Fiat-Shamir transcript absorption.
-    ///
-    /// Must be implemented so that the prover and verifier can both absorb the
-    /// commitment into the transcript before drawing challenges.
-    fn serialize_commitment(commitment: &Self::Commitment) -> Vec<u8>;
-}
+pub use lambdaworks_crypto::commitments::multilinear::{IsMultilinearPCS, PcsError};
+pub use lambdaworks_crypto::commitments::zeromorph::{
+    ZeromorphCommitment, ZeromorphPCS, ZeromorphProof,
+};
 
 pub mod trivial;
-pub mod zeromorph;
 
 pub use trivial::{TrivialCommitment, TrivialPCS, TrivialProof};
-pub use zeromorph::{ZeromorphCommitment, ZeromorphPCS, ZeromorphProof};

--- a/crates/provers/spartan/src/pcs/mod.rs
+++ b/crates/provers/spartan/src/pcs/mod.rs
@@ -1,0 +1,60 @@
+//! Polynomial commitment scheme (PCS) traits and implementations.
+//!
+//! Provides the IsMultilinearPCS trait for committing to multilinear polynomials
+//! and the TrivialPCS implementation for testing.
+
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolynomial;
+
+/// Error type for PCS operations.
+#[derive(Debug, thiserror::Error)]
+#[error("PCS error: {0}")]
+pub struct PcsError(pub String);
+
+/// Trait for multilinear polynomial commitment schemes.
+///
+/// Defines the interface for committing to a multilinear polynomial,
+/// opening it at a point, and verifying the opening.
+///
+/// All implementations must also implement `serialize_commitment` so that
+/// the Fiat-Shamir transcript can absorb the commitment before challenges
+/// are drawn — a requirement for protocol soundness.
+pub trait IsMultilinearPCS<F: IsField>
+where
+    F::BaseType: Send + Sync,
+{
+    type Commitment: Clone;
+    type Proof: Clone;
+    type Error: std::error::Error;
+
+    /// Commit to a multilinear polynomial.
+    fn commit(&self, poly: &DenseMultilinearPolynomial<F>)
+        -> Result<Self::Commitment, Self::Error>;
+
+    /// Open the polynomial at a point, returning the value and a proof.
+    fn open(
+        &self,
+        poly: &DenseMultilinearPolynomial<F>,
+        point: &[FieldElement<F>],
+    ) -> Result<(FieldElement<F>, Self::Proof), Self::Error>;
+
+    /// Verify an opening proof.
+    fn verify(
+        &self,
+        commitment: &Self::Commitment,
+        point: &[FieldElement<F>],
+        value: &FieldElement<F>,
+        proof: &Self::Proof,
+    ) -> Result<bool, Self::Error>;
+
+    /// Serialize a commitment to bytes for Fiat-Shamir transcript absorption.
+    ///
+    /// Must be implemented so that the prover and verifier can both absorb the
+    /// commitment into the transcript before drawing challenges.
+    fn serialize_commitment(commitment: &Self::Commitment) -> Vec<u8>;
+}
+
+// TODO: rename this module to `trivial` to reflect that it contains TrivialPCS,
+// not an actual Zeromorph implementation. The Zeromorph PCS (KZG-based) should
+// be added as a separate module when implementing production-grade proving.
+pub mod zeromorph;

--- a/crates/provers/spartan/src/pcs/mod.rs
+++ b/crates/provers/spartan/src/pcs/mod.rs
@@ -1,7 +1,8 @@
 //! Polynomial commitment scheme (PCS) traits and implementations.
 //!
-//! Provides the IsMultilinearPCS trait for committing to multilinear polynomials
-//! and the TrivialPCS implementation for testing.
+//! Provides the IsMultilinearPCS trait for committing to multilinear polynomials,
+//! the TrivialPCS implementation for testing, and the ZeromorphPCS implementation
+//! backed by KZG for production use.
 
 use lambdaworks_math::field::{element::FieldElement, traits::IsField};
 use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolynomial;
@@ -54,7 +55,8 @@ where
     fn serialize_commitment(commitment: &Self::Commitment) -> Vec<u8>;
 }
 
-// TODO: rename this module to `trivial` to reflect that it contains TrivialPCS,
-// not an actual Zeromorph implementation. The Zeromorph PCS (KZG-based) should
-// be added as a separate module when implementing production-grade proving.
+pub mod trivial;
 pub mod zeromorph;
+
+pub use trivial::{TrivialCommitment, TrivialPCS, TrivialProof};
+pub use zeromorph::{ZeromorphCommitment, ZeromorphPCS, ZeromorphProof};

--- a/crates/provers/spartan/src/pcs/trivial.rs
+++ b/crates/provers/spartan/src/pcs/trivial.rs
@@ -128,7 +128,7 @@ mod tests {
         let commitment = pcs.commit(&poly).unwrap();
         let point = vec![FE::from(5), FE::from(7)];
         let (value, proof) = pcs.open(&poly, &point).unwrap();
-        let wrong_value = value.clone() + FE::one();
+        let wrong_value = value + FE::one();
         let ok = pcs
             .verify(&commitment, &point, &wrong_value, &proof)
             .unwrap();

--- a/crates/provers/spartan/src/pcs/trivial.rs
+++ b/crates/provers/spartan/src/pcs/trivial.rs
@@ -1,0 +1,137 @@
+//! Trivial PCS for testing Spartan correctness.
+//!
+//! TrivialPCS is NOT hiding or succinct — it simply stores all evaluations
+//! as the commitment and re-evaluates for verification.
+//! Used for unit testing the Spartan sumcheck protocol independently of PCS security.
+
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolynomial;
+use lambdaworks_math::traits::ByteConversion;
+
+use super::{IsMultilinearPCS, PcsError};
+
+/// Trivial PCS: commitment = all evaluations of the polynomial.
+///
+/// Proof = just the claimed evaluation value.
+/// Verification re-evaluates from the stored evals.
+#[derive(Clone, Debug, Default)]
+pub struct TrivialPCS;
+
+/// Commitment for TrivialPCS: stores the full evaluation vector.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrivialCommitment<F: IsField>
+where
+    F::BaseType: Send + Sync,
+{
+    pub evals: Vec<FieldElement<F>>,
+    pub num_vars: usize,
+}
+
+/// Opening proof for TrivialPCS: just the claimed value.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrivialProof<F: IsField>
+where
+    F::BaseType: Send + Sync,
+{
+    pub value: FieldElement<F>,
+}
+
+impl<F: IsField> IsMultilinearPCS<F> for TrivialPCS
+where
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+{
+    type Commitment = TrivialCommitment<F>;
+    type Proof = TrivialProof<F>;
+    type Error = PcsError;
+
+    fn commit(
+        &self,
+        poly: &DenseMultilinearPolynomial<F>,
+    ) -> Result<Self::Commitment, Self::Error> {
+        Ok(TrivialCommitment {
+            evals: poly.evals().to_vec(),
+            num_vars: poly.num_vars(),
+        })
+    }
+
+    fn open(
+        &self,
+        poly: &DenseMultilinearPolynomial<F>,
+        point: &[FieldElement<F>],
+    ) -> Result<(FieldElement<F>, Self::Proof), Self::Error> {
+        let value = poly
+            .evaluate(point.to_vec())
+            .map_err(|e| PcsError(format!("{e:?}")))?;
+        Ok((value.clone(), TrivialProof { value }))
+    }
+
+    fn verify(
+        &self,
+        commitment: &Self::Commitment,
+        point: &[FieldElement<F>],
+        value: &FieldElement<F>,
+        proof: &Self::Proof,
+    ) -> Result<bool, Self::Error> {
+        // Recompute from commitment's evals
+        let poly = DenseMultilinearPolynomial::new(commitment.evals.clone());
+        let computed = poly
+            .evaluate(point.to_vec())
+            .map_err(|e| PcsError(format!("{e:?}")))?;
+        Ok(&computed == value && &proof.value == value)
+    }
+
+    /// Serialize the commitment by concatenating all evaluation bytes (big-endian).
+    fn serialize_commitment(commitment: &Self::Commitment) -> Vec<u8> {
+        commitment
+            .evals
+            .iter()
+            .flat_map(|e| e.to_bytes_be())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lambdaworks_math::field::fields::u64_prime_field::U64PrimeField;
+
+    const MODULUS: u64 = 101;
+    type F = U64PrimeField<MODULUS>;
+    type FE = FieldElement<F>;
+
+    #[test]
+    fn test_trivial_pcs_round_trip() {
+        let pcs = TrivialPCS;
+        let poly = DenseMultilinearPolynomial::new(vec![
+            FE::from(1),
+            FE::from(2),
+            FE::from(3),
+            FE::from(4),
+        ]);
+        let commitment = pcs.commit(&poly).unwrap();
+        let point = vec![FE::from(5), FE::from(7)];
+        let (value, proof) = pcs.open(&poly, &point).unwrap();
+        let ok = pcs.verify(&commitment, &point, &value, &proof).unwrap();
+        assert!(ok);
+    }
+
+    #[test]
+    fn test_trivial_pcs_wrong_value() {
+        let pcs = TrivialPCS;
+        let poly = DenseMultilinearPolynomial::new(vec![
+            FE::from(1),
+            FE::from(2),
+            FE::from(3),
+            FE::from(4),
+        ]);
+        let commitment = pcs.commit(&poly).unwrap();
+        let point = vec![FE::from(5), FE::from(7)];
+        let (value, proof) = pcs.open(&poly, &point).unwrap();
+        let wrong_value = value.clone() + FE::one();
+        let ok = pcs
+            .verify(&commitment, &point, &wrong_value, &proof)
+            .unwrap();
+        assert!(!ok);
+    }
+}

--- a/crates/provers/spartan/src/pcs/zeromorph.rs
+++ b/crates/provers/spartan/src/pcs/zeromorph.rs
@@ -321,7 +321,7 @@ mod tests {
     use lambdaworks_math::elliptic_curve::traits::IsEllipticCurve;
 
     type G1 = ShortWeierstrassJacobianPoint<BLS12381Curve>;
-    type KZG = KateZaveruchaGoldberg<FrField, BLS12381AtePairing>;
+    type Kzg = KateZaveruchaGoldberg<FrField, BLS12381AtePairing>;
     type Zeromorph = ZeromorphPCS<4, FrField, BLS12381AtePairing>;
     type FE = FrElement;
 
@@ -343,7 +343,7 @@ mod tests {
 
     fn new_zeromorph(num_vars: usize) -> Zeromorph {
         let srs = create_srs(1 << num_vars);
-        ZeromorphPCS::new(KZG::new(srs))
+        ZeromorphPCS::new(Kzg::new(srs))
     }
 
     #[test]

--- a/crates/provers/spartan/src/pcs/zeromorph.rs
+++ b/crates/provers/spartan/src/pcs/zeromorph.rs
@@ -1,65 +1,213 @@
-//! Trivial PCS for testing Spartan correctness.
-//!
-//! TrivialPCS is NOT hiding or succinct — it simply stores all evaluations
-//! as the commitment and re-evaluates for verification.
-//!
-//! This lets us test the Spartan protocol logic independently of
-//! any particular polynomial commitment scheme.
-//!
-//! A real Zeromorph-based PCS would reduce multilinear opening claims
-//! to univariate KZG openings. See: https://eprint.iacr.org/2023/917
-//!
-//! TODO: Move this to a `trivial.rs` module and implement Zeromorph here.
+//! Zeromorph PCS: reduces multilinear evaluation to univariate KZG opening.
+//! Reference: Kohrita & Towa, "Zeromorph" (2023), https://eprint.iacr.org/2023/917
 
-use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+use lambdaworks_crypto::commitments::kzg::KateZaveruchaGoldberg;
+use lambdaworks_crypto::commitments::traits::IsCommitmentScheme;
+use lambdaworks_crypto::fiat_shamir::default_transcript::DefaultTranscript;
+use lambdaworks_crypto::fiat_shamir::is_transcript::IsTranscript;
+use lambdaworks_math::elliptic_curve::traits::IsPairing;
+use lambdaworks_math::field::element::FieldElement;
+use lambdaworks_math::field::traits::{HasDefaultTranscript, IsField, IsPrimeField};
 use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolynomial;
-use lambdaworks_math::traits::ByteConversion;
+use lambdaworks_math::polynomial::Polynomial;
+use lambdaworks_math::traits::{AsBytes, ByteConversion};
+use lambdaworks_math::unsigned_integer::element::UnsignedInteger;
 
 use super::{IsMultilinearPCS, PcsError};
 
-/// Trivial PCS: commitment = all evaluations of the polynomial.
+/// Zeromorph PCS backed by KZG over an elliptic pairing.
+pub struct ZeromorphPCS<const N: usize, F, P>
+where
+    F: IsPrimeField<CanonicalType = UnsignedInteger<N>>,
+    P: IsPairing,
+{
+    kzg: KateZaveruchaGoldberg<F, P>,
+}
+
+/// Commitment for ZeromorphPCS: a single G1 point (the KZG commitment to f̂).
+#[derive(Clone, Debug)]
+pub struct ZeromorphCommitment<P: IsPairing> {
+    pub g1: P::G1Point,
+}
+
+/// Opening proof for ZeromorphPCS.
+#[derive(Clone, Debug)]
+pub struct ZeromorphProof<const N: usize, F, P>
+where
+    F: IsPrimeField<CanonicalType = UnsignedInteger<N>>,
+    F::BaseType: Send + Sync,
+    P: IsPairing,
+{
+    /// KZG commitments to each quotient polynomial q̂_k.
+    pub q_commitments: Vec<P::G1Point>,
+    /// Evaluation of f̂ at the random challenge x.
+    pub z_f: FieldElement<F>,
+    /// Evaluations of each q̂_k at the random challenge x.
+    pub z_qs: Vec<FieldElement<F>>,
+    /// Batched KZG opening proof.
+    pub kzg_proof: P::G1Point,
+}
+
+impl<const N: usize, F, P> ZeromorphPCS<N, F, P>
+where
+    F: IsPrimeField<CanonicalType = UnsignedInteger<N>>,
+    P: IsPairing,
+{
+    pub fn new(kzg: KateZaveruchaGoldberg<F, P>) -> Self {
+        Self { kzg }
+    }
+}
+
+/// Compute quotient polynomials via the halving algorithm.
 ///
-/// Proof = just the claimed evaluation value.
-/// Verification re-evaluates from the stored evals.
-#[derive(Clone, Debug, Default)]
-pub struct TrivialPCS;
+/// For a multilinear polynomial with evaluations `evals` and evaluation point
+/// `point = (u_0, ..., u_{n-1})`, returns [q̂_0, ..., q̂_{n-1}] where q̂_k
+/// has degree 2^k - 1.
+///
+/// The algorithm processes from k = n-1 downto 0, halving the current evaluation
+/// vector at each step.
+///
+/// **Why Lagrange evaluations = univariate coefficients:** The Zeromorph protocol
+/// uses the bijection between the boolean hypercube {0,1}^n and indices 0..2^n-1
+/// to "unroll" a multilinear polynomial into a univariate: f̂(X) = Σ_i evals[i]·X^i.
+/// The same convention applies to each quotient q̃_k — its boolean-hypercube
+/// evaluations are used directly as the coefficients of q̂_k(X).
+fn compute_zeromorph_quotients<F>(
+    evals: &[FieldElement<F>],
+    point: &[FieldElement<F>],
+) -> Vec<Polynomial<FieldElement<F>>>
+where
+    F: IsField,
+    F::BaseType: Send + Sync,
+{
+    let n = point.len();
+    let mut current = evals.to_vec();
+    let mut quotients = vec![Polynomial::zero(); n];
 
-/// Commitment for TrivialPCS: stores the full evaluation vector.
-#[derive(Clone, Debug, PartialEq)]
-pub struct TrivialCommitment<F: IsField>
+    for k in (0..n).rev() {
+        let half = 1usize << k;
+        // In lambdaworks, bit k of the eval index corresponds to variable r[n-1-k],
+        // so we use point[n-1-k] (not point[k]) to match the paper's convention.
+        let u_k = &point[n - 1 - k];
+        let q_evals: Vec<FieldElement<F>> = (0..half)
+            .map(|i| &current[i + half] - &current[i])
+            .collect();
+        let one_minus_u = FieldElement::<F>::one() - u_k;
+        let new_current: Vec<FieldElement<F>> = (0..half)
+            .map(|i| &one_minus_u * &current[i] + u_k * &current[i + half])
+            .collect();
+        current = new_current;
+        quotients[k] = Polynomial::new(&q_evals);
+    }
+    debug_assert_eq!(
+        current.len(),
+        1,
+        "halving loop should reduce to a single element (v)"
+    );
+    quotients
+}
+
+/// Compute Φ_m(y) = Π_{i=0}^{m-1}(1 + y^{2^i}).
+///
+/// This equals 1 + y + y^2 + ... + y^{2^m - 1}.
+/// Φ_0(y) = 1 (empty product).
+fn phi_eval<F: IsField>(y: &FieldElement<F>, m: usize) -> FieldElement<F>
 where
     F::BaseType: Send + Sync,
 {
-    pub evals: Vec<FieldElement<F>>,
-    pub num_vars: usize,
+    if m == 0 {
+        return FieldElement::one();
+    }
+    let mut result = FieldElement::<F>::one();
+    let mut y_pow = y.clone();
+    for _ in 0..m {
+        result = &result * &(FieldElement::<F>::one() + &y_pow);
+        y_pow = &y_pow * &y_pow;
+    }
+    result
 }
 
-/// Opening proof for TrivialPCS: just the claimed value.
-#[derive(Clone, Debug, PartialEq)]
-pub struct TrivialProof<F: IsField>
+/// Compute Ψ_{n,k}(x) = x^{2^k} * Φ_{n-k-1}(x^{2^{k+1}}) - u_k * Φ_{n-k}(x^{2^k}).
+fn psi_eval<F: IsField>(
+    x: &FieldElement<F>,
+    u_k: &FieldElement<F>,
+    n: usize,
+    k: usize,
+) -> FieldElement<F>
 where
     F::BaseType: Send + Sync,
 {
-    pub value: FieldElement<F>,
+    // x^{2^k} via k squarings
+    let mut x_2k = x.clone();
+    for _ in 0..k {
+        x_2k = &x_2k * &x_2k;
+    }
+    // x^{2^{k+1}} = (x^{2^k})^2
+    let x_2k1 = &x_2k * &x_2k;
+    let phi_nk1 = phi_eval(&x_2k1, n - k - 1); // Φ_{n-k-1}(x^{2^{k+1}})
+    let phi_nk = phi_eval(&x_2k, n - k); // Φ_{n-k}(x^{2^k})
+    &x_2k * &phi_nk1 - u_k * &phi_nk
 }
 
-impl<F: IsField> IsMultilinearPCS<F> for TrivialPCS
+/// Derive internal Fiat-Shamir challenges for Zeromorph.
+///
+/// Absorbs the f commitment, evaluation point, claimed value, and quotient
+/// commitments, then samples the evaluation challenge x and batching factor upsilon.
+// TODO(security): The Zeromorph internal transcript is independent of the outer
+// Spartan transcript. In a standalone Spartan, the evaluation point r_y is derived
+// from the Spartan transcript (which binds R1CS + public inputs + commitment), so
+// proof transplant attacks are hard in practice. For recursive/IVC settings, the
+// `IsMultilinearPCS::open` and `verify` signatures should be extended to accept an
+// outer transcript binding (e.g., a hash of the current Spartan transcript state).
+fn derive_zeromorph_challenges<F, P>(
+    f_commitment: &P::G1Point,
+    point: &[FieldElement<F>],
+    value: &FieldElement<F>,
+    q_commitments: &[P::G1Point],
+) -> (FieldElement<F>, FieldElement<F>)
 where
+    F: IsPrimeField + HasDefaultTranscript,
     F::BaseType: Send + Sync,
     FieldElement<F>: ByteConversion,
+    P: IsPairing,
+    P::G1Point: AsBytes,
 {
-    type Commitment = TrivialCommitment<F>;
-    type Proof = TrivialProof<F>;
+    let mut transcript = DefaultTranscript::<F>::default();
+    transcript.append_bytes(b"zeromorph_v1");
+    transcript.append_bytes(&f_commitment.as_bytes());
+    transcript.append_bytes(&(point.len() as u64).to_be_bytes());
+    for u_i in point {
+        transcript.append_field_element(u_i);
+    }
+    transcript.append_field_element(value);
+    transcript.append_bytes(&(q_commitments.len() as u64).to_be_bytes());
+    for c in q_commitments {
+        transcript.append_bytes(&c.as_bytes());
+    }
+    let x = transcript.sample_field_element();
+    let upsilon = transcript.sample_field_element();
+    (x, upsilon)
+}
+
+impl<const N: usize, F, P> IsMultilinearPCS<F> for ZeromorphPCS<N, F, P>
+where
+    F: IsPrimeField<CanonicalType = UnsignedInteger<N>> + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+    P: IsPairing + Clone,
+    P::G1Point: AsBytes + Clone,
+{
+    type Commitment = ZeromorphCommitment<P>;
+    type Proof = ZeromorphProof<N, F, P>;
     type Error = PcsError;
 
     fn commit(
         &self,
         poly: &DenseMultilinearPolynomial<F>,
     ) -> Result<Self::Commitment, Self::Error> {
-        Ok(TrivialCommitment {
-            evals: poly.evals().to_vec(),
-            num_vars: poly.num_vars(),
-        })
+        let f_hat = Polynomial::new(poly.evals());
+        let g1 = self.kzg.commit(&f_hat);
+        Ok(ZeromorphCommitment { g1 })
     }
 
     fn open(
@@ -67,10 +215,48 @@ where
         poly: &DenseMultilinearPolynomial<F>,
         point: &[FieldElement<F>],
     ) -> Result<(FieldElement<F>, Self::Proof), Self::Error> {
+        let n = poly.num_vars();
+        if point.len() != n {
+            return Err(PcsError(format!(
+                "point length {} != num_vars {}",
+                point.len(),
+                n
+            )));
+        }
+
         let value = poly
             .evaluate(point.to_vec())
             .map_err(|e| PcsError(format!("{e:?}")))?;
-        Ok((value.clone(), TrivialProof { value }))
+
+        let q_hats = compute_zeromorph_quotients(poly.evals(), point);
+
+        let q_commitments: Vec<P::G1Point> = q_hats.iter().map(|q| self.kzg.commit(q)).collect();
+
+        // Recompute f commitment for FS transcript (open() doesn't receive commitment)
+        let f_hat = Polynomial::new(poly.evals());
+        let f_commitment = self.kzg.commit(&f_hat);
+
+        let (x, upsilon) =
+            derive_zeromorph_challenges::<F, P>(&f_commitment, point, &value, &q_commitments);
+
+        let z_f = f_hat.evaluate(&x);
+        let z_qs: Vec<FieldElement<F>> = q_hats.iter().map(|q| q.evaluate(&x)).collect();
+
+        let all_polys: Vec<Polynomial<FieldElement<F>>> =
+            std::iter::once(f_hat).chain(q_hats).collect();
+        let all_ys: Vec<FieldElement<F>> =
+            std::iter::once(z_f.clone()).chain(z_qs.clone()).collect();
+        let kzg_proof = self.kzg.open_batch(&x, &all_ys, &all_polys, &upsilon);
+
+        Ok((
+            value,
+            ZeromorphProof {
+                q_commitments,
+                z_f,
+                z_qs,
+                kzg_proof,
+            },
+        ))
     }
 
     fn verify(
@@ -80,65 +266,210 @@ where
         value: &FieldElement<F>,
         proof: &Self::Proof,
     ) -> Result<bool, Self::Error> {
-        // Recompute from commitment's evals
-        let poly = DenseMultilinearPolynomial::new(commitment.evals.clone());
-        let computed = poly
-            .evaluate(point.to_vec())
-            .map_err(|e| PcsError(format!("{e:?}")))?;
-        Ok(&computed == value && &proof.value == value)
+        let n = point.len();
+
+        let (x, upsilon) =
+            derive_zeromorph_challenges::<F, P>(&commitment.g1, point, value, &proof.q_commitments);
+
+        // Check Zeromorph identity: z_f - v*Φ_n(x) == Σ_k z_qs[k] * Ψ_{n,k}(x)
+        let phi_n_x = phi_eval(&x, n);
+        let lhs = &proof.z_f - value * &phi_n_x;
+        // Use point[n-1-k] because in lambdaworks, bit k of the eval index corresponds
+        // to variable r[n-1-k], matching the Zeromorph paper's variable convention.
+        let rhs = proof
+            .z_qs
+            .iter()
+            .enumerate()
+            .map(|(k, z_k)| z_k * &psi_eval(&x, &point[n - 1 - k], n, k))
+            .fold(FieldElement::<F>::zero(), |acc, t| acc + t);
+
+        if lhs != rhs {
+            return Ok(false);
+        }
+
+        // Batch KZG verify
+        let all_commitments: Vec<P::G1Point> = std::iter::once(commitment.g1.clone())
+            .chain(proof.q_commitments.clone())
+            .collect();
+        let all_ys: Vec<FieldElement<F>> = std::iter::once(proof.z_f.clone())
+            .chain(proof.z_qs.clone())
+            .collect();
+
+        Ok(self
+            .kzg
+            .verify_batch(&x, &all_ys, &all_commitments, &proof.kzg_proof, &upsilon))
     }
 
-    /// Serialize the commitment by concatenating all evaluation bytes (big-endian).
     fn serialize_commitment(commitment: &Self::Commitment) -> Vec<u8> {
-        commitment
-            .evals
-            .iter()
-            .flat_map(|e| e.to_bytes_be())
-            .collect()
+        commitment.g1.as_bytes()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lambdaworks_math::field::fields::u64_prime_field::U64PrimeField;
+    use lambdaworks_crypto::commitments::kzg::StructuredReferenceString;
+    use lambdaworks_math::cyclic_group::IsGroup;
+    use lambdaworks_math::elliptic_curve::short_weierstrass::curves::bls12_381::{
+        curve::BLS12381Curve,
+        default_types::{FrElement, FrField},
+        pairing::BLS12381AtePairing,
+        twist::BLS12381TwistCurve,
+    };
+    use lambdaworks_math::elliptic_curve::short_weierstrass::point::ShortWeierstrassJacobianPoint;
+    use lambdaworks_math::elliptic_curve::traits::IsEllipticCurve;
 
-    const MODULUS: u64 = 101;
-    type F = U64PrimeField<MODULUS>;
-    type FE = FieldElement<F>;
+    type G1 = ShortWeierstrassJacobianPoint<BLS12381Curve>;
+    type KZG = KateZaveruchaGoldberg<FrField, BLS12381AtePairing>;
+    type Zeromorph = ZeromorphPCS<4, FrField, BLS12381AtePairing>;
+    type FE = FrElement;
 
-    #[test]
-    fn test_trivial_pcs_round_trip() {
-        let pcs = TrivialPCS;
-        let poly = DenseMultilinearPolynomial::new(vec![
-            FE::from(1),
-            FE::from(2),
-            FE::from(3),
-            FE::from(4),
-        ]);
-        let commitment = pcs.commit(&poly).unwrap();
-        let point = vec![FE::from(5), FE::from(7)];
-        let (value, proof) = pcs.open(&poly, &point).unwrap();
-        let ok = pcs.verify(&commitment, &point, &value, &proof).unwrap();
-        assert!(ok);
+    fn create_srs(
+        size: usize,
+    ) -> StructuredReferenceString<
+        <BLS12381AtePairing as IsPairing>::G1Point,
+        <BLS12381AtePairing as IsPairing>::G2Point,
+    > {
+        let toxic = FE::from(7u64);
+        let g1 = BLS12381Curve::generator();
+        let g2 = BLS12381TwistCurve::generator();
+        let powers: Vec<G1> = (0..size)
+            .map(|i| g1.operate_with_self(toxic.pow(i as u128).canonical()))
+            .collect();
+        let g2_powers = [g2.clone(), g2.operate_with_self(toxic.canonical())];
+        StructuredReferenceString::new(&powers, &g2_powers)
+    }
+
+    fn new_zeromorph(num_vars: usize) -> Zeromorph {
+        let srs = create_srs(1 << num_vars);
+        ZeromorphPCS::new(KZG::new(srs))
     }
 
     #[test]
-    fn test_trivial_pcs_wrong_value() {
-        let pcs = TrivialPCS;
-        let poly = DenseMultilinearPolynomial::new(vec![
-            FE::from(1),
-            FE::from(2),
-            FE::from(3),
-            FE::from(4),
-        ]);
+    fn test_zeromorph_pcs_1_var() {
+        // f̃(x_0) with evals [a, b]: f̃(0) = a, f̃(1) = b
+        let pcs = new_zeromorph(1);
+        let evals = vec![FE::from(3u64), FE::from(7u64)];
+        let poly = DenseMultilinearPolynomial::new(evals);
         let commitment = pcs.commit(&poly).unwrap();
-        let point = vec![FE::from(5), FE::from(7)];
+        let point = vec![FE::from(5u64)];
         let (value, proof) = pcs.open(&poly, &point).unwrap();
-        let wrong_value = value.clone() + FE::one();
+        let ok = pcs.verify(&commitment, &point, &value, &proof).unwrap();
+        assert!(ok, "1-var Zeromorph proof should verify");
+    }
+
+    #[test]
+    fn test_zeromorph_pcs_2_vars() {
+        // f̃(x_0, x_1) with evals [1, 2, 3, 4]
+        let pcs = new_zeromorph(2);
+        let evals = vec![
+            FE::from(1u64),
+            FE::from(2u64),
+            FE::from(3u64),
+            FE::from(4u64),
+        ];
+        let poly = DenseMultilinearPolynomial::new(evals);
+        let commitment = pcs.commit(&poly).unwrap();
+        let point = vec![FE::from(2u64), FE::from(5u64)];
+        let (value, proof) = pcs.open(&poly, &point).unwrap();
+        let ok = pcs.verify(&commitment, &point, &value, &proof).unwrap();
+        assert!(ok, "2-var Zeromorph proof should verify");
+    }
+
+    #[test]
+    fn test_zeromorph_pcs_wrong_value() {
+        // Verifier should reject a tampered claimed value
+        let pcs = new_zeromorph(2);
+        let evals = vec![
+            FE::from(1u64),
+            FE::from(2u64),
+            FE::from(3u64),
+            FE::from(4u64),
+        ];
+        let poly = DenseMultilinearPolynomial::new(evals);
+        let commitment = pcs.commit(&poly).unwrap();
+        let point = vec![FE::from(2u64), FE::from(5u64)];
+        let (value, proof) = pcs.open(&poly, &point).unwrap();
+        let wrong_value = value + FE::from(1u64);
         let ok = pcs
             .verify(&commitment, &point, &wrong_value, &proof)
             .unwrap();
-        assert!(!ok);
+        assert!(!ok, "Zeromorph should reject wrong value");
+    }
+
+    #[test]
+    fn test_zeromorph_pcs_3_vars() {
+        // f̃(x_0, x_1, x_2) with 8 evaluations
+        let pcs = new_zeromorph(3);
+        let evals: Vec<FE> = (1u64..=8).map(FE::from).collect();
+        let poly = DenseMultilinearPolynomial::new(evals);
+        let commitment = pcs.commit(&poly).unwrap();
+        let point = vec![FE::from(2u64), FE::from(3u64), FE::from(4u64)];
+        let (value, proof) = pcs.open(&poly, &point).unwrap();
+        let ok = pcs.verify(&commitment, &point, &value, &proof).unwrap();
+        assert!(ok, "3-var Zeromorph proof should verify");
+    }
+
+    #[test]
+    fn test_zeromorph_pcs_tampered_commitment() {
+        // A proof generated for commitment C should not verify under a different C'.
+        let pcs = new_zeromorph(2);
+        let evals = vec![
+            FE::from(1u64),
+            FE::from(2u64),
+            FE::from(3u64),
+            FE::from(4u64),
+        ];
+        let poly = DenseMultilinearPolynomial::new(evals);
+        let commitment = pcs.commit(&poly).unwrap();
+        let point = vec![FE::from(2u64), FE::from(5u64)];
+        let (value, proof) = pcs.open(&poly, &point).unwrap();
+
+        // Tamper: use commitment from a different polynomial
+        let other_evals = vec![
+            FE::from(9u64),
+            FE::from(9u64),
+            FE::from(9u64),
+            FE::from(9u64),
+        ];
+        let other_poly = DenseMultilinearPolynomial::new(other_evals);
+        let wrong_commitment = pcs.commit(&other_poly).unwrap();
+
+        let ok = pcs
+            .verify(&wrong_commitment, &point, &value, &proof)
+            .unwrap();
+        assert!(!ok, "Zeromorph should reject proof under wrong commitment");
+    }
+
+    #[test]
+    fn test_zeromorph_pcs_constant_poly() {
+        // f̃ = constant 42: all evals are 42, so f̃(u) = 42 for any u.
+        let pcs = new_zeromorph(2);
+        let evals = vec![FE::from(42u64); 4];
+        let poly = DenseMultilinearPolynomial::new(evals);
+        let commitment = pcs.commit(&poly).unwrap();
+        let point = vec![FE::from(3u64), FE::from(7u64)];
+        let (value, proof) = pcs.open(&poly, &point).unwrap();
+        assert_eq!(value, FE::from(42u64));
+        let ok = pcs.verify(&commitment, &point, &value, &proof).unwrap();
+        assert!(ok, "Zeromorph should verify constant polynomial");
+    }
+
+    #[test]
+    fn test_zeromorph_pcs_4_vars() {
+        // f̃(x_0,...,x_3) with 16 evaluations
+        let pcs = new_zeromorph(4);
+        let evals: Vec<FE> = (1u64..=16).map(FE::from).collect();
+        let poly = DenseMultilinearPolynomial::new(evals);
+        let commitment = pcs.commit(&poly).unwrap();
+        let point = vec![
+            FE::from(2u64),
+            FE::from(3u64),
+            FE::from(4u64),
+            FE::from(5u64),
+        ];
+        let (value, proof) = pcs.open(&poly, &point).unwrap();
+        let ok = pcs.verify(&commitment, &point, &value, &proof).unwrap();
+        assert!(ok, "4-var Zeromorph proof should verify");
     }
 }

--- a/crates/provers/spartan/src/pcs/zeromorph.rs
+++ b/crates/provers/spartan/src/pcs/zeromorph.rs
@@ -1,0 +1,144 @@
+//! Trivial PCS for testing Spartan correctness.
+//!
+//! TrivialPCS is NOT hiding or succinct — it simply stores all evaluations
+//! as the commitment and re-evaluates for verification.
+//!
+//! This lets us test the Spartan protocol logic independently of
+//! any particular polynomial commitment scheme.
+//!
+//! A real Zeromorph-based PCS would reduce multilinear opening claims
+//! to univariate KZG openings. See: https://eprint.iacr.org/2023/917
+//!
+//! TODO: Move this to a `trivial.rs` module and implement Zeromorph here.
+
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+use lambdaworks_math::polynomial::dense_multilinear_poly::DenseMultilinearPolynomial;
+use lambdaworks_math::traits::ByteConversion;
+
+use super::{IsMultilinearPCS, PcsError};
+
+/// Trivial PCS: commitment = all evaluations of the polynomial.
+///
+/// Proof = just the claimed evaluation value.
+/// Verification re-evaluates from the stored evals.
+#[derive(Clone, Debug, Default)]
+pub struct TrivialPCS;
+
+/// Commitment for TrivialPCS: stores the full evaluation vector.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrivialCommitment<F: IsField>
+where
+    F::BaseType: Send + Sync,
+{
+    pub evals: Vec<FieldElement<F>>,
+    pub num_vars: usize,
+}
+
+/// Opening proof for TrivialPCS: just the claimed value.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrivialProof<F: IsField>
+where
+    F::BaseType: Send + Sync,
+{
+    pub value: FieldElement<F>,
+}
+
+impl<F: IsField> IsMultilinearPCS<F> for TrivialPCS
+where
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+{
+    type Commitment = TrivialCommitment<F>;
+    type Proof = TrivialProof<F>;
+    type Error = PcsError;
+
+    fn commit(
+        &self,
+        poly: &DenseMultilinearPolynomial<F>,
+    ) -> Result<Self::Commitment, Self::Error> {
+        Ok(TrivialCommitment {
+            evals: poly.evals().to_vec(),
+            num_vars: poly.num_vars(),
+        })
+    }
+
+    fn open(
+        &self,
+        poly: &DenseMultilinearPolynomial<F>,
+        point: &[FieldElement<F>],
+    ) -> Result<(FieldElement<F>, Self::Proof), Self::Error> {
+        let value = poly
+            .evaluate(point.to_vec())
+            .map_err(|e| PcsError(format!("{e:?}")))?;
+        Ok((value.clone(), TrivialProof { value }))
+    }
+
+    fn verify(
+        &self,
+        commitment: &Self::Commitment,
+        point: &[FieldElement<F>],
+        value: &FieldElement<F>,
+        proof: &Self::Proof,
+    ) -> Result<bool, Self::Error> {
+        // Recompute from commitment's evals
+        let poly = DenseMultilinearPolynomial::new(commitment.evals.clone());
+        let computed = poly
+            .evaluate(point.to_vec())
+            .map_err(|e| PcsError(format!("{e:?}")))?;
+        Ok(&computed == value && &proof.value == value)
+    }
+
+    /// Serialize the commitment by concatenating all evaluation bytes (big-endian).
+    fn serialize_commitment(commitment: &Self::Commitment) -> Vec<u8> {
+        commitment
+            .evals
+            .iter()
+            .flat_map(|e| e.to_bytes_be())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lambdaworks_math::field::fields::u64_prime_field::U64PrimeField;
+
+    const MODULUS: u64 = 101;
+    type F = U64PrimeField<MODULUS>;
+    type FE = FieldElement<F>;
+
+    #[test]
+    fn test_trivial_pcs_round_trip() {
+        let pcs = TrivialPCS;
+        let poly = DenseMultilinearPolynomial::new(vec![
+            FE::from(1),
+            FE::from(2),
+            FE::from(3),
+            FE::from(4),
+        ]);
+        let commitment = pcs.commit(&poly).unwrap();
+        let point = vec![FE::from(5), FE::from(7)];
+        let (value, proof) = pcs.open(&poly, &point).unwrap();
+        let ok = pcs.verify(&commitment, &point, &value, &proof).unwrap();
+        assert!(ok);
+    }
+
+    #[test]
+    fn test_trivial_pcs_wrong_value() {
+        let pcs = TrivialPCS;
+        let poly = DenseMultilinearPolynomial::new(vec![
+            FE::from(1),
+            FE::from(2),
+            FE::from(3),
+            FE::from(4),
+        ]);
+        let commitment = pcs.commit(&poly).unwrap();
+        let point = vec![FE::from(5), FE::from(7)];
+        let (value, proof) = pcs.open(&poly, &point).unwrap();
+        let wrong_value = value.clone() + FE::one();
+        let ok = pcs
+            .verify(&commitment, &point, &wrong_value, &proof)
+            .unwrap();
+        assert!(!ok);
+    }
+}

--- a/crates/provers/spartan/src/pcs/zeromorph.rs
+++ b/crates/provers/spartan/src/pcs/zeromorph.rs
@@ -16,10 +16,11 @@ use lambdaworks_math::unsigned_integer::element::UnsignedInteger;
 use super::{IsMultilinearPCS, PcsError};
 
 /// Zeromorph PCS backed by KZG over an elliptic pairing.
+#[derive(Clone)]
 pub struct ZeromorphPCS<const N: usize, F, P>
 where
     F: IsPrimeField<CanonicalType = UnsignedInteger<N>>,
-    P: IsPairing,
+    P: IsPairing + Clone,
 {
     kzg: KateZaveruchaGoldberg<F, P>,
 }
@@ -51,7 +52,7 @@ where
 impl<const N: usize, F, P> ZeromorphPCS<N, F, P>
 where
     F: IsPrimeField<CanonicalType = UnsignedInteger<N>>,
-    P: IsPairing,
+    P: IsPairing + Clone,
 {
     pub fn new(kzg: KateZaveruchaGoldberg<F, P>) -> Self {
         Self { kzg }
@@ -421,7 +422,7 @@ mod tests {
             FE::from(4u64),
         ];
         let poly = DenseMultilinearPolynomial::new(evals);
-        let commitment = pcs.commit(&poly).unwrap();
+        let _commitment = pcs.commit(&poly).unwrap();
         let point = vec![FE::from(2u64), FE::from(5u64)];
         let (value, proof) = pcs.open(&poly, &point).unwrap();
 

--- a/crates/provers/spartan/src/prover.rs
+++ b/crates/provers/spartan/src/prover.rs
@@ -1,0 +1,436 @@
+//! Spartan prover.
+//!
+//! Implements the Spartan zkSNARK prover following the paper by Setty (2019).
+//! The proof consists of:
+//! 1. Committing to the witness polynomial z̃
+//! 2. Outer sumcheck to reduce R1CS satisfiability to a claim about AZ, BZ, CZ
+//! 3. Inner sumcheck to reduce the matrix-vector product claims to z̃ evaluation
+//! 4. PCS opening of z̃ at the inner sumcheck challenges
+
+use std::marker::PhantomData;
+
+use lambdaworks_crypto::fiat_shamir::default_transcript::DefaultTranscript;
+use lambdaworks_crypto::fiat_shamir::is_transcript::IsTranscript;
+use lambdaworks_math::field::{
+    element::FieldElement,
+    traits::{HasDefaultTranscript, IsField},
+};
+use lambdaworks_math::polynomial::{
+    dense_multilinear_poly::DenseMultilinearPolynomial, Polynomial,
+};
+use lambdaworks_math::traits::ByteConversion;
+use lambdaworks_sumcheck::Prover as SumcheckProver;
+
+use crate::errors::SpartanError;
+use crate::mle::{encode_witness, eq_poly, matrix_vector_product_mle, mz_eval, next_power_of_two};
+use crate::pcs::IsMultilinearPCS;
+use crate::r1cs::R1CS;
+use crate::transcript::{
+    append_public_inputs, append_r1cs_instance, append_round_poly_to_transcript, draw_challenges,
+};
+
+/// A Spartan proof.
+///
+/// Contains all data needed for verification:
+/// - The witness commitment
+/// - Outer sumcheck round polynomials and challenges (r_x)
+/// - Claimed values AZ(r_x), BZ(r_x), CZ(r_x)
+/// - Inner sumcheck round polynomials and challenges (r_y)
+/// - PCS opening of z̃ at r_y
+#[derive(Clone, Debug)]
+pub struct SpartanProof<F, PCS>
+where
+    F: IsField,
+    F::BaseType: Send + Sync,
+    PCS: IsMultilinearPCS<F>,
+{
+    /// Commitment to the witness polynomial z̃
+    pub witness_commitment: PCS::Commitment,
+    /// Outer sumcheck round polynomials (cubic-quadratic combined)
+    pub outer_sumcheck_polys: Vec<Polynomial<FieldElement<F>>>,
+    /// Outer sumcheck challenges (r_x), one per constraint variable
+    pub outer_challenges: Vec<FieldElement<F>>,
+    /// AZ(r_x) = ∑_j A(r_x, j) · z̃(j)  (MLE of AZ evaluated at r_x)
+    pub v_a: FieldElement<F>,
+    /// BZ(r_x) = ∑_j B(r_x, j) · z̃(j)
+    pub v_b: FieldElement<F>,
+    /// CZ(r_x) = ∑_j C(r_x, j) · z̃(j)
+    pub v_c: FieldElement<F>,
+    /// Inner sumcheck round polynomials
+    pub inner_sumcheck_polys: Vec<Polynomial<FieldElement<F>>>,
+    /// Inner sumcheck challenges (r_y), one per witness variable
+    pub inner_challenges: Vec<FieldElement<F>>,
+    /// z̃(r_y): PCS-opening value
+    pub witness_eval: FieldElement<F>,
+    /// PCS proof for z̃(r_y)
+    pub witness_proof: PCS::Proof,
+}
+
+/// The Spartan prover.
+pub struct SpartanProver<F, PCS>
+where
+    F: IsField,
+    F::BaseType: Send + Sync,
+    PCS: IsMultilinearPCS<F>,
+{
+    pcs: PCS,
+    _f: PhantomData<F>,
+}
+
+impl<F, PCS> SpartanProver<F, PCS>
+where
+    F: IsField + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+    PCS: IsMultilinearPCS<F>,
+    PCS::Error: 'static,
+{
+    /// Creates a new SpartanProver with the given PCS.
+    pub fn new(pcs: PCS) -> Self {
+        Self {
+            pcs,
+            _f: PhantomData,
+        }
+    }
+
+    /// Proves R1CS satisfiability for the given instance and witness.
+    ///
+    /// `public_inputs` are the public values `x` in `z = (1, x, w)`.
+    /// `witness_z` is the full witness vector including the leading 1.
+    pub fn prove(
+        &self,
+        r1cs: &R1CS<F>,
+        public_inputs: &[FieldElement<F>],
+        witness_z: &[FieldElement<F>],
+    ) -> Result<SpartanProof<F, PCS>, SpartanError> {
+        // -----------------------------------------------------------------------
+        // Step 1: Encode witness and commit
+        // -----------------------------------------------------------------------
+        let z_mle = encode_witness(witness_z);
+        // Derive column count from R1CS, not from the (possibly shorter) witness slice,
+        // so prover and verifier agree on the same padded dimension.
+        let num_cols_padded = next_power_of_two(r1cs.num_variables).max(2);
+
+        let witness_commitment = self
+            .pcs
+            .commit(&z_mle)
+            .map_err(|e| SpartanError::PcsError(e.to_string()))?;
+
+        // -----------------------------------------------------------------------
+        // Step 2: Initialize Fiat-Shamir transcript
+        //
+        // Transcript order (must match verifier exactly):
+        //   domain separator → R1CS instance → public inputs → witness commitment → tau
+        // -----------------------------------------------------------------------
+        let mut transcript = DefaultTranscript::<F>::default();
+        // Domain separator prevents cross-protocol transcript collisions.
+        transcript.append_bytes(b"lambdaworks-spartan-v1");
+        append_r1cs_instance(&mut transcript, r1cs);
+        append_public_inputs(&mut transcript, public_inputs);
+        // Bind the witness commitment to the transcript before drawing challenges,
+        // so that the Fiat-Shamir challenges depend on the committed witness.
+        transcript.append_bytes(b"witness_commitment");
+        transcript.append_bytes(&PCS::serialize_commitment(&witness_commitment));
+
+        // -----------------------------------------------------------------------
+        // Step 3: Draw tau for the outer sumcheck
+        // -----------------------------------------------------------------------
+        // Ensure at least 2 constraints so sumcheck has at least 1 variable
+        let num_constraints_padded = next_power_of_two(r1cs.num_constraints).max(2);
+        let log_constraints = {
+            let mut k = 0;
+            let mut n = num_constraints_padded;
+            while n > 1 {
+                k += 1;
+                n >>= 1;
+            }
+            k
+        };
+
+        transcript.append_bytes(b"tau_challenge");
+        let tau = draw_challenges(&mut transcript, log_constraints);
+
+        // -----------------------------------------------------------------------
+        // Step 4: Build outer sumcheck
+        //
+        // We prove: ∑_{x ∈ {0,1}^s} [eq(τ,x)·AZ(x)·BZ(x) - eq(τ,x)·CZ(x)] = 0
+        //
+        // Use two-term product sumcheck (like GKR):
+        //   Term 1: [eq_mle, az_mle, bz_mle]  (product of 3 MLEs)
+        //   Term 2: [eq_mle, neg_cz_mle]       (product of 2 MLEs with CZ negated)
+        //
+        // Oracle check at r_x:
+        //   eq(τ,r_x)·v_a·v_b - eq(τ,r_x)·v_c = g_outer_final(r_x_last)
+        // -----------------------------------------------------------------------
+
+        // Compute eq(τ, ·) evaluations
+        let eq_mle = eq_poly(&tau);
+
+        // Compute AZ(x), BZ(x), CZ(x) for all x ∈ {0,1}^s (boolean constraint indices)
+        let mut az_evals = vec![FieldElement::zero(); num_constraints_padded];
+        let mut bz_evals = vec![FieldElement::zero(); num_constraints_padded];
+        let mut cz_evals = vec![FieldElement::zero(); num_constraints_padded];
+
+        for i in 0..r1cs.num_constraints {
+            az_evals[i] = r1cs.a[i]
+                .iter()
+                .zip(witness_z.iter())
+                .map(|(a_ij, z_j)| a_ij * z_j)
+                .fold(FieldElement::zero(), |acc, x| acc + x);
+
+            bz_evals[i] = r1cs.b[i]
+                .iter()
+                .zip(witness_z.iter())
+                .map(|(b_ij, z_j)| b_ij * z_j)
+                .fold(FieldElement::zero(), |acc, x| acc + x);
+
+            cz_evals[i] = r1cs.c[i]
+                .iter()
+                .zip(witness_z.iter())
+                .map(|(c_ij, z_j)| c_ij * z_j)
+                .fold(FieldElement::zero(), |acc, x| acc + x);
+        }
+
+        let az_mle = DenseMultilinearPolynomial::new(az_evals);
+        let bz_mle = DenseMultilinearPolynomial::new(bz_evals);
+
+        // Negate CZ for term 2: neg_cz[i] = -cz[i]
+        let neg_cz_evals: Vec<FieldElement<F>> = cz_evals
+            .iter()
+            .map(|v| FieldElement::<F>::zero() - v)
+            .collect();
+        let neg_cz_mle = DenseMultilinearPolynomial::new(neg_cz_evals);
+
+        // Run two-term product sumcheck following GKR pattern
+        transcript.append_bytes(b"outer_sumcheck");
+        let claimed_sum_term1 =
+            compute_sum_of_product(&[eq_mle.evals(), az_mle.evals(), bz_mle.evals()]);
+        let claimed_sum_term2 = compute_sum_of_product(&[eq_mle.evals(), neg_cz_mle.evals()]);
+        let outer_claimed_sum = &claimed_sum_term1 + &claimed_sum_term2;
+
+        let (outer_sumcheck_polys, outer_challenges) = run_two_term_sumcheck(
+            vec![eq_mle.clone(), az_mle.clone(), bz_mle.clone()],
+            vec![eq_mle.clone(), neg_cz_mle.clone()],
+            outer_claimed_sum,
+            &mut transcript,
+        )?;
+
+        let r_x = &outer_challenges;
+
+        // -----------------------------------------------------------------------
+        // Step 5: Compute v_a, v_b, v_c at r_x
+        // -----------------------------------------------------------------------
+        let v_a = mz_eval(&r1cs.a, witness_z, num_constraints_padded, r_x);
+        let v_b = mz_eval(&r1cs.b, witness_z, num_constraints_padded, r_x);
+        let v_c = mz_eval(&r1cs.c, witness_z, num_constraints_padded, r_x);
+
+        // Append v_a, v_b, v_c to transcript
+        transcript.append_bytes(b"v_a");
+        transcript.append_field_element(&v_a);
+        transcript.append_bytes(b"v_b");
+        transcript.append_field_element(&v_b);
+        transcript.append_bytes(b"v_c");
+        transcript.append_field_element(&v_c);
+
+        // -----------------------------------------------------------------------
+        // Step 6: Draw batching challenges and run inner sumcheck
+        //
+        // Inner sumcheck proves: rho_a*v_a + rho_b*v_b + rho_c*v_c
+        //   = ∑_y (rho_a*A(r_x,y) + rho_b*B(r_x,y) + rho_c*C(r_x,y)) * z̃(y)
+        // -----------------------------------------------------------------------
+        transcript.append_bytes(b"inner_challenges");
+        let rho = draw_challenges(&mut transcript, 3);
+        let (rho_a, rho_b, rho_c) = (&rho[0], &rho[1], &rho[2]);
+
+        // Build combined matrix MLE at (r_x, y): rho_a*A(r_x,y) + rho_b*B(r_x,y) + rho_c*C(r_x,y)
+        let az_row =
+            matrix_vector_product_mle(&r1cs.a, num_constraints_padded, num_cols_padded, r_x)
+                .map_err(|e| SpartanError::MleError(e.to_string()))?;
+        let bz_row =
+            matrix_vector_product_mle(&r1cs.b, num_constraints_padded, num_cols_padded, r_x)
+                .map_err(|e| SpartanError::MleError(e.to_string()))?;
+        let cz_row =
+            matrix_vector_product_mle(&r1cs.c, num_constraints_padded, num_cols_padded, r_x)
+                .map_err(|e| SpartanError::MleError(e.to_string()))?;
+
+        // combined_matrix[y] = rho_a * az_row[y] + rho_b * bz_row[y] + rho_c * cz_row[y]
+        let combined_matrix_evals: Vec<FieldElement<F>> = (0..num_cols_padded)
+            .map(|j| {
+                rho_a * &az_row.evals()[j] + rho_b * &bz_row.evals()[j] + rho_c * &cz_row.evals()[j]
+            })
+            .collect();
+        let combined_matrix_mle = DenseMultilinearPolynomial::new(combined_matrix_evals);
+
+        // Inner sumcheck: prove ∑_y combined_matrix(y) * z̃(y) = rho_a*v_a + rho_b*v_b + rho_c*v_c
+        let inner_claimed_sum = rho_a * &v_a + rho_b * &v_b + rho_c * &v_c;
+
+        transcript.append_bytes(b"inner_sumcheck");
+        let (inner_sumcheck_polys, inner_challenges) = run_sumcheck_with_transcript_quadratic(
+            combined_matrix_mle,
+            z_mle.clone(),
+            inner_claimed_sum,
+            &mut transcript,
+        )?;
+
+        let r_y = &inner_challenges;
+
+        // -----------------------------------------------------------------------
+        // Step 7: PCS open z̃ at r_y
+        // -----------------------------------------------------------------------
+        let (witness_eval, witness_proof) = self
+            .pcs
+            .open(&z_mle, r_y)
+            .map_err(|e| SpartanError::PcsError(e.to_string()))?;
+
+        // Absorb witness_eval into transcript for composability.
+        transcript.append_bytes(b"witness_eval");
+        transcript.append_field_element(&witness_eval);
+
+        Ok(SpartanProof {
+            witness_commitment,
+            outer_sumcheck_polys,
+            outer_challenges,
+            v_a,
+            v_b,
+            v_c,
+            inner_sumcheck_polys,
+            inner_challenges,
+            witness_eval,
+            witness_proof,
+        })
+    }
+}
+
+/// Computes ∑_i ∏_j factor_evals[j][i] over all boolean points.
+fn compute_sum_of_product<F: IsField>(factor_evals: &[&[FieldElement<F>]]) -> FieldElement<F>
+where
+    F::BaseType: Send + Sync,
+{
+    if factor_evals.is_empty() {
+        return FieldElement::zero();
+    }
+    let n = factor_evals[0].len();
+    let mut sum = FieldElement::zero();
+    for i in 0..n {
+        let product = factor_evals
+            .iter()
+            .map(|evals| evals[i].clone())
+            .fold(FieldElement::<F>::one(), |acc, v| acc * v);
+        sum += product;
+    }
+    sum
+}
+
+/// Runs the two-term sumcheck following the GKR pattern.
+///
+/// Proves ∑_x [∏ term1_factors(x) + ∏ term2_factors(x)] = claimed_sum.
+/// Returns (round_polynomials, challenges).
+#[allow(clippy::type_complexity)]
+fn run_two_term_sumcheck<F>(
+    term1_factors: Vec<DenseMultilinearPolynomial<F>>,
+    term2_factors: Vec<DenseMultilinearPolynomial<F>>,
+    claimed_sum: FieldElement<F>,
+    transcript: &mut DefaultTranscript<F>,
+) -> Result<(Vec<Polynomial<FieldElement<F>>>, Vec<FieldElement<F>>), SpartanError>
+where
+    F: IsField + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+{
+    let num_vars = term1_factors[0].num_vars();
+
+    let mut prover1 = SumcheckProver::new(term1_factors)
+        .map_err(|e| SpartanError::SumcheckError(e.to_string()))?;
+    let mut prover2 = SumcheckProver::new(term2_factors)
+        .map_err(|e| SpartanError::SumcheckError(e.to_string()))?;
+
+    // Append the initial sum to transcript (same as GKR)
+    transcript.append_bytes(b"initial_sum");
+    transcript.append_field_element(&FieldElement::from(num_vars as u64));
+    transcript.append_field_element(&FieldElement::from(1u64));
+    transcript.append_field_element(&claimed_sum);
+
+    let mut round_polys = Vec::with_capacity(num_vars);
+    let mut challenges = Vec::with_capacity(num_vars);
+    let mut current_challenge: Option<FieldElement<F>> = None;
+
+    for round in 0..num_vars {
+        let g_j1 = prover1
+            .round(current_challenge.as_ref())
+            .map_err(|e| SpartanError::SumcheckError(e.to_string()))?;
+        let g_j2 = prover2
+            .round(current_challenge.as_ref())
+            .map_err(|e| SpartanError::SumcheckError(e.to_string()))?;
+
+        // Combine: g_j = g_j1 + g_j2
+        let g_j = g_j1 + g_j2;
+
+        // Append to transcript using GKR-style format
+        let round_label = format!("round_{round}_poly");
+        transcript.append_bytes(round_label.as_bytes());
+        let coeffs = g_j.coefficients();
+        transcript.append_bytes(&(coeffs.len() as u64).to_be_bytes());
+        if coeffs.is_empty() {
+            transcript.append_field_element(&FieldElement::zero());
+        } else {
+            for coeff in coeffs {
+                transcript.append_field_element(coeff);
+            }
+        }
+
+        round_polys.push(g_j);
+
+        let r = transcript.sample_field_element();
+        challenges.push(r.clone());
+        current_challenge = Some(r);
+    }
+
+    Ok((round_polys, challenges))
+}
+
+/// Runs the sumcheck protocol on a product of two polynomials (quadratic) using an external transcript.
+///
+/// Returns (round_polynomials, challenges).
+#[allow(clippy::type_complexity)]
+fn run_sumcheck_with_transcript_quadratic<F>(
+    poly1: DenseMultilinearPolynomial<F>,
+    poly2: DenseMultilinearPolynomial<F>,
+    claimed_sum: FieldElement<F>,
+    transcript: &mut DefaultTranscript<F>,
+) -> Result<(Vec<Polynomial<FieldElement<F>>>, Vec<FieldElement<F>>), SpartanError>
+where
+    F: IsField + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+{
+    let num_vars = poly1.num_vars();
+    let mut prover = SumcheckProver::new(vec![poly1, poly2])
+        .map_err(|e| SpartanError::SumcheckError(e.to_string()))?;
+
+    // Bind the inner claimed sum to the transcript (same format as outer sumcheck),
+    // so that inner sumcheck challenges depend on the declared sum value.
+    transcript.append_bytes(b"initial_sum");
+    transcript.append_field_element(&FieldElement::from(num_vars as u64));
+    transcript.append_field_element(&FieldElement::from(1u64));
+    transcript.append_field_element(&claimed_sum);
+
+    let mut round_polys = Vec::with_capacity(num_vars);
+    let mut challenges = Vec::with_capacity(num_vars);
+    let mut current_challenge: Option<FieldElement<F>> = None;
+
+    for round in 0..num_vars {
+        let g_j = prover
+            .round(current_challenge.as_ref())
+            .map_err(|e| SpartanError::SumcheckError(e.to_string()))?;
+
+        append_round_poly_to_transcript(transcript, round, &g_j);
+
+        round_polys.push(g_j);
+
+        let r = transcript.sample_field_element();
+        challenges.push(r.clone());
+        current_challenge = Some(r);
+    }
+
+    Ok((round_polys, challenges))
+}

--- a/crates/provers/spartan/src/prover.rs
+++ b/crates/provers/spartan/src/prover.rs
@@ -22,7 +22,10 @@ use lambdaworks_math::traits::ByteConversion;
 use lambdaworks_sumcheck::Prover as SumcheckProver;
 
 use crate::errors::SpartanError;
-use crate::mle::{encode_witness, eq_poly, matrix_vector_product_mle, mz_eval, next_power_of_two};
+use crate::mle::{
+    encode_witness, eq_poly, index_to_multilinear_point, matrix_vector_product_mle, mz_eval,
+    next_power_of_two,
+};
 use crate::pcs::IsMultilinearPCS;
 use crate::r1cs::R1CS;
 use crate::transcript::{
@@ -64,6 +67,11 @@ where
     pub witness_eval: FieldElement<F>,
     /// PCS proof for z̃(r_y)
     pub witness_proof: PCS::Proof,
+    /// Public input consistency proofs: for each i in 1..=num_public_inputs,
+    /// an opening of z̃ at the boolean point corresponding to index i,
+    /// proving z̃(bits(i)) == public_inputs[i-1].
+    /// Each entry is (evaluation_point, pcs_proof).
+    pub public_input_proofs: Vec<(Vec<FieldElement<F>>, PCS::Proof)>,
 }
 
 /// The Spartan prover.
@@ -103,6 +111,39 @@ where
         public_inputs: &[FieldElement<F>],
         witness_z: &[FieldElement<F>],
     ) -> Result<SpartanProof<F, PCS>, SpartanError> {
+        // -----------------------------------------------------------------------
+        // Guard: witness length must equal num_variables.
+        // A shorter witness would silently zero-pad via .zip(), producing a proof
+        // for a different statement (where trailing variables are treated as 0).
+        // -----------------------------------------------------------------------
+        if witness_z.len() != r1cs.num_variables {
+            return Err(SpartanError::R1CSError(format!(
+                "witness length {} != num_variables {}",
+                witness_z.len(),
+                r1cs.num_variables
+            )));
+        }
+
+        // -----------------------------------------------------------------------
+        // Guard: public inputs must match the corresponding witness entries.
+        // z = (1, public_inputs..., private_witness...) so z[i+1] == public_inputs[i].
+        // Without this check the prover could commit to a witness that disagrees
+        // with the claimed public inputs while all sumcheck/PCS checks still pass.
+        // -----------------------------------------------------------------------
+        if public_inputs.len() + 1 > r1cs.num_variables {
+            return Err(SpartanError::R1CSError(
+                "more public inputs than witness variables".to_string(),
+            ));
+        }
+        for (i, pi) in public_inputs.iter().enumerate() {
+            if &witness_z[i + 1] != pi {
+                return Err(SpartanError::R1CSError(format!(
+                    "public_inputs[{i}] does not match witness[{}]",
+                    i + 1
+                )));
+            }
+        }
+
         // -----------------------------------------------------------------------
         // Step 1: Encode witness and commit
         // -----------------------------------------------------------------------
@@ -286,6 +327,29 @@ where
         transcript.append_bytes(b"witness_eval");
         transcript.append_field_element(&witness_eval);
 
+        // -----------------------------------------------------------------------
+        // Step 8: Open z̃ at each public input position.
+        //
+        // z = (1, x_1, ..., x_l, w_1, ...) so x_i = z[i] for i in 1..=l.
+        // We open z̃ at the boolean hypercube point for index i, allowing the
+        // verifier to confirm z̃(bits(i)) == public_inputs[i-1].
+        // -----------------------------------------------------------------------
+        let n_witness_vars = z_mle.num_vars();
+        let mut public_input_proofs = Vec::with_capacity(public_inputs.len());
+        for i in 1..=public_inputs.len() {
+            let point = index_to_multilinear_point::<F>(i, n_witness_vars);
+            let (eval, proof) = self
+                .pcs
+                .open(&z_mle, &point)
+                .map_err(|e| SpartanError::PcsError(e.to_string()))?;
+            debug_assert_eq!(
+                eval,
+                public_inputs[i - 1],
+                "public input opening mismatch at index {i}"
+            );
+            public_input_proofs.push((point, proof));
+        }
+
         Ok(SpartanProof {
             witness_commitment,
             outer_sumcheck_polys,
@@ -297,6 +361,7 @@ where
             inner_challenges,
             witness_eval,
             witness_proof,
+            public_input_proofs,
         })
     }
 }

--- a/crates/provers/spartan/src/prover.rs
+++ b/crates/provers/spartan/src/prover.rs
@@ -205,7 +205,7 @@ where
             let mut evals = vec![FieldElement::zero(); num_constraints_padded];
             for entry in &matrix.entries {
                 if entry.row < r1cs.num_constraints {
-                    evals[entry.row] = &evals[entry.row] + &entry.val * &witness_z[entry.col];
+                    evals[entry.row] += &entry.val * &witness_z[entry.col];
                 }
             }
             evals
@@ -218,7 +218,7 @@ where
         let bz_mle = DenseMultilinearPolynomial::new(bz_evals);
 
         // Negate CZ for term 2: neg_cz[i] = -cz[i]
-        let neg_cz_evals: Vec<FieldElement<F>> = cz_evals.iter().map(|v| -v).collect();
+        let neg_cz_evals: Vec<FieldElement<F>> = cz_evals.into_iter().map(|v| -v).collect();
         let neg_cz_mle = DenseMultilinearPolynomial::new(neg_cz_evals);
 
         // Run two-term product sumcheck following GKR pattern
@@ -229,8 +229,8 @@ where
         let outer_claimed_sum = &claimed_sum_term1 + &claimed_sum_term2;
 
         let (outer_sumcheck_polys, outer_challenges) = run_two_term_sumcheck(
-            vec![eq_mle.clone(), az_mle.clone(), bz_mle.clone()],
-            vec![eq_mle.clone(), neg_cz_mle.clone()],
+            vec![eq_mle.clone(), az_mle, bz_mle],
+            vec![eq_mle, neg_cz_mle],
             outer_claimed_sum,
             &mut transcript,
         )?;
@@ -420,8 +420,8 @@ where
         round_polys.push(g_j);
 
         let r = transcript.sample_field_element();
-        challenges.push(r.clone());
-        current_challenge = Some(r);
+        current_challenge = Some(r.clone());
+        challenges.push(r);
     }
 
     Ok((round_polys, challenges))
@@ -467,8 +467,8 @@ where
         round_polys.push(g_j);
 
         let r = transcript.sample_field_element();
-        challenges.push(r.clone());
-        current_challenge = Some(r);
+        current_challenge = Some(r.clone());
+        challenges.push(r);
     }
 
     Ok((round_polys, challenges))

--- a/crates/provers/spartan/src/prover.rs
+++ b/crates/provers/spartan/src/prover.rs
@@ -23,8 +23,8 @@ use lambdaworks_sumcheck::Prover as SumcheckProver;
 
 use crate::errors::SpartanError;
 use crate::mle::{
-    encode_witness, eq_poly, index_to_multilinear_point, matrix_vector_product_mle, mz_eval,
-    next_power_of_two,
+    encode_witness, eq_evals, eq_poly, index_to_multilinear_point, matrix_vector_product_mle,
+    mz_eval_with_eq, next_power_of_two,
 };
 use crate::pcs::IsMultilinearPCS;
 use crate::r1cs::R1CS;
@@ -250,9 +250,10 @@ where
         // -----------------------------------------------------------------------
         // Step 5: Compute v_a, v_b, v_c at r_x
         // -----------------------------------------------------------------------
-        let v_a = mz_eval(&r1cs.a, witness_z, num_constraints_padded, r_x);
-        let v_b = mz_eval(&r1cs.b, witness_z, num_constraints_padded, r_x);
-        let v_c = mz_eval(&r1cs.c, witness_z, num_constraints_padded, r_x);
+        let eq_rx = eq_evals(r_x, num_constraints_padded);
+        let v_a = mz_eval_with_eq(&r1cs.a, witness_z, &eq_rx);
+        let v_b = mz_eval_with_eq(&r1cs.b, witness_z, &eq_rx);
+        let v_c = mz_eval_with_eq(&r1cs.c, witness_z, &eq_rx);
 
         // Append v_a, v_b, v_c to transcript
         transcript.append_bytes(b"v_a");

--- a/crates/provers/spartan/src/prover.rs
+++ b/crates/provers/spartan/src/prover.rs
@@ -179,15 +179,7 @@ where
         // -----------------------------------------------------------------------
         // Ensure at least 2 constraints so sumcheck has at least 1 variable
         let num_constraints_padded = next_power_of_two(r1cs.num_constraints).max(2);
-        let log_constraints = {
-            let mut k = 0;
-            let mut n = num_constraints_padded;
-            while n > 1 {
-                k += 1;
-                n >>= 1;
-            }
-            k
-        };
+        let log_constraints = num_constraints_padded.trailing_zeros() as usize;
 
         transcript.append_bytes(b"tau_challenge");
         let tau = draw_challenges(&mut transcript, log_constraints);
@@ -209,38 +201,22 @@ where
         let eq_mle = eq_poly(&tau);
 
         // Compute AZ(x), BZ(x), CZ(x) for all x ∈ {0,1}^s (boolean constraint indices)
-        let mut az_evals = vec![FieldElement::zero(); num_constraints_padded];
-        let mut bz_evals = vec![FieldElement::zero(); num_constraints_padded];
-        let mut cz_evals = vec![FieldElement::zero(); num_constraints_padded];
-
-        for i in 0..r1cs.num_constraints {
-            az_evals[i] = r1cs.a[i]
-                .iter()
-                .zip(witness_z.iter())
-                .map(|(a_ij, z_j)| a_ij * z_j)
-                .fold(FieldElement::zero(), |acc, x| acc + x);
-
-            bz_evals[i] = r1cs.b[i]
-                .iter()
-                .zip(witness_z.iter())
-                .map(|(b_ij, z_j)| b_ij * z_j)
-                .fold(FieldElement::zero(), |acc, x| acc + x);
-
-            cz_evals[i] = r1cs.c[i]
-                .iter()
-                .zip(witness_z.iter())
-                .map(|(c_ij, z_j)| c_ij * z_j)
-                .fold(FieldElement::zero(), |acc, x| acc + x);
-        }
+        let compute_mz = |matrix: &[Vec<FieldElement<F>>]| -> Vec<FieldElement<F>> {
+            let mut evals = vec![FieldElement::zero(); num_constraints_padded];
+            for (i, row) in matrix.iter().enumerate().take(r1cs.num_constraints) {
+                evals[i] = dot_product(row, witness_z);
+            }
+            evals
+        };
+        let az_evals = compute_mz(&r1cs.a);
+        let bz_evals = compute_mz(&r1cs.b);
+        let cz_evals = compute_mz(&r1cs.c);
 
         let az_mle = DenseMultilinearPolynomial::new(az_evals);
         let bz_mle = DenseMultilinearPolynomial::new(bz_evals);
 
         // Negate CZ for term 2: neg_cz[i] = -cz[i]
-        let neg_cz_evals: Vec<FieldElement<F>> = cz_evals
-            .iter()
-            .map(|v| FieldElement::<F>::zero() - v)
-            .collect();
+        let neg_cz_evals: Vec<FieldElement<F>> = cz_evals.iter().map(|v| -v).collect();
         let neg_cz_mle = DenseMultilinearPolynomial::new(neg_cz_evals);
 
         // Run two-term product sumcheck following GKR pattern
@@ -393,6 +369,16 @@ where
     sum
 }
 
+/// Dot product of two field element slices.
+fn dot_product<F: IsField>(a: &[FieldElement<F>], b: &[FieldElement<F>]) -> FieldElement<F>
+where
+    F::BaseType: Send + Sync,
+{
+    a.iter()
+        .zip(b.iter())
+        .fold(FieldElement::zero(), |acc, (ai, bi)| acc + ai * bi)
+}
+
 /// Runs the two-term sumcheck following the GKR pattern.
 ///
 /// Proves ∑_x [∏ term1_factors(x) + ∏ term2_factors(x)] = claimed_sum.
@@ -437,18 +423,7 @@ where
         // Combine: g_j = g_j1 + g_j2
         let g_j = g_j1 + g_j2;
 
-        // Append to transcript using GKR-style format
-        let round_label = format!("round_{round}_poly");
-        transcript.append_bytes(round_label.as_bytes());
-        let coeffs = g_j.coefficients();
-        transcript.append_bytes(&(coeffs.len() as u64).to_be_bytes());
-        if coeffs.is_empty() {
-            transcript.append_field_element(&FieldElement::zero());
-        } else {
-            for coeff in coeffs {
-                transcript.append_field_element(coeff);
-            }
-        }
+        append_round_poly_to_transcript(transcript, round, &g_j);
 
         round_polys.push(g_j);
 

--- a/crates/provers/spartan/src/prover.rs
+++ b/crates/provers/spartan/src/prover.rs
@@ -67,14 +67,12 @@ where
     pub witness_eval: FieldElement<F>,
     /// PCS proof for z̃(r_y)
     pub witness_proof: PCS::Proof,
-    /// Public input consistency proofs: for each i in 1..=num_public_inputs,
-    /// an opening of z̃ at the boolean point corresponding to index i,
-    /// proving z̃(bits(i)) == public_inputs[i-1].
+    /// Public input consistency proofs including the constant term z[0] = 1.
+    ///
+    /// Entry 0 proves z̃(bits(0)) = 1 (the R1CS constant).
+    /// Entries 1..=num_public_inputs prove z̃(bits(i)) = public_inputs[i-1].
     /// Each entry is (evaluation_point, pcs_proof).
     pub public_input_proofs: Vec<(Vec<FieldElement<F>>, PCS::Proof)>,
-    /// PCS proof that z̃(0,...,0) = 1, confirming the R1CS constant term.
-    /// Without this, a malicious prover could set z[0] ≠ 1.
-    pub constant_proof: PCS::Proof,
 }
 
 /// The Spartan prover.
@@ -334,41 +332,30 @@ where
         // Step 8: Open z̃ at each public input position.
         //
         // z = (1, x_1, ..., x_l, w_1, ...) so x_i = z[i] for i in 1..=l.
-        // We open z̃ at the boolean hypercube point for index i, allowing the
-        // verifier to confirm z̃(bits(i)) == public_inputs[i-1].
+        // Open z̃ at boolean points for the constant z[0]=1 and each public input.
+        // z = (1, x_1, ..., x_l, w_1, ...) so:
+        //   index 0: z[0] = 1 (R1CS constant)
+        //   index i: z[i] = public_inputs[i-1] for i in 1..=l
         // -----------------------------------------------------------------------
         let n_witness_vars = z_mle.num_vars();
-        let mut public_input_proofs = Vec::with_capacity(public_inputs.len());
-        for i in 1..=public_inputs.len() {
+        // Build the expected values: [1, x_1, ..., x_l]
+        let expected_public: Vec<FieldElement<F>> = core::iter::once(FieldElement::one())
+            .chain(public_inputs.iter().cloned())
+            .collect();
+
+        let mut public_input_proofs = Vec::with_capacity(expected_public.len());
+        for (i, expected_val) in expected_public.iter().enumerate() {
             let point = index_to_multilinear_point::<F>(i, n_witness_vars);
             let (eval, proof) = self
                 .pcs
                 .open(&z_mle, &point)
                 .map_err(|e| SpartanError::PcsError(e.to_string()))?;
             debug_assert_eq!(
-                eval,
-                public_inputs[i - 1],
-                "public input opening mismatch at index {i}"
+                eval, *expected_val,
+                "public witness opening mismatch at index {i}"
             );
             public_input_proofs.push((point, proof));
         }
-
-        // -----------------------------------------------------------------------
-        // Step 9: Open z̃ at the all-zeros boolean point to prove z[0] = 1.
-        //
-        // The R1CS convention requires z = (1, x, w), so z[0] = 1 always.
-        // Without this opening, a malicious prover could commit z[0] ≠ 1.
-        // -----------------------------------------------------------------------
-        let zero_point = vec![FieldElement::<F>::zero(); n_witness_vars];
-        let (constant_eval, constant_proof) = self
-            .pcs
-            .open(&z_mle, &zero_point)
-            .map_err(|e| SpartanError::PcsError(e.to_string()))?;
-        debug_assert_eq!(
-            constant_eval,
-            FieldElement::one(),
-            "z̃(0) must equal 1 (R1CS constant term)"
-        );
 
         Ok(SpartanProof {
             witness_commitment,
@@ -382,7 +369,6 @@ where
             witness_eval,
             witness_proof,
             public_input_proofs,
-            constant_proof,
         })
     }
 }

--- a/crates/provers/spartan/src/prover.rs
+++ b/crates/provers/spartan/src/prover.rs
@@ -201,10 +201,12 @@ where
         let eq_mle = eq_poly(&tau);
 
         // Compute AZ(x), BZ(x), CZ(x) for all x ∈ {0,1}^s (boolean constraint indices)
-        let compute_mz = |matrix: &[Vec<FieldElement<F>>]| -> Vec<FieldElement<F>> {
+        let compute_mz = |matrix: &crate::sparse_matrix::SparseMatrix<F>| -> Vec<FieldElement<F>> {
             let mut evals = vec![FieldElement::zero(); num_constraints_padded];
-            for (i, row) in matrix.iter().enumerate().take(r1cs.num_constraints) {
-                evals[i] = dot_product(row, witness_z);
+            for entry in &matrix.entries {
+                if entry.row < r1cs.num_constraints {
+                    evals[entry.row] = &evals[entry.row] + &entry.val * &witness_z[entry.col];
+                }
             }
             evals
         };
@@ -367,16 +369,6 @@ where
         sum += product;
     }
     sum
-}
-
-/// Dot product of two field element slices.
-fn dot_product<F: IsField>(a: &[FieldElement<F>], b: &[FieldElement<F>]) -> FieldElement<F>
-where
-    F::BaseType: Send + Sync,
-{
-    a.iter()
-        .zip(b.iter())
-        .fold(FieldElement::zero(), |acc, (ai, bi)| acc + ai * bi)
 }
 
 /// Runs the two-term sumcheck following the GKR pattern.

--- a/crates/provers/spartan/src/prover.rs
+++ b/crates/provers/spartan/src/prover.rs
@@ -51,7 +51,7 @@ where
     pub witness_commitment: PCS::Commitment,
     /// Outer sumcheck round polynomials (cubic-quadratic combined)
     pub outer_sumcheck_polys: Vec<Polynomial<FieldElement<F>>>,
-    /// Outer sumcheck challenges (r_x), one per constraint variable
+    /// Outer sumcheck challenges (r_x), one per sumcheck round (log2 of padded constraint count)
     pub outer_challenges: Vec<FieldElement<F>>,
     /// AZ(r_x) = ∑_j A(r_x, j) · z̃(j)  (MLE of AZ evaluated at r_x)
     pub v_a: FieldElement<F>,
@@ -61,7 +61,7 @@ where
     pub v_c: FieldElement<F>,
     /// Inner sumcheck round polynomials
     pub inner_sumcheck_polys: Vec<Polynomial<FieldElement<F>>>,
-    /// Inner sumcheck challenges (r_y), one per witness variable
+    /// Inner sumcheck challenges (r_y), one per sumcheck round (log2 of padded column count)
     pub inner_challenges: Vec<FieldElement<F>>,
     /// z̃(r_y): PCS-opening value
     pub witness_eval: FieldElement<F>,
@@ -123,6 +123,16 @@ where
                 witness_z.len(),
                 r1cs.num_variables
             )));
+        }
+
+        // -----------------------------------------------------------------------
+        // Guard: R1CS constant term z[0] must be 1.
+        // Without this the prover silently produces an invalid proof.
+        // -----------------------------------------------------------------------
+        if witness_z[0] != FieldElement::one() {
+            return Err(SpartanError::R1CSError(
+                "witness_z[0] must be 1 (R1CS constant term)".to_string(),
+            ));
         }
 
         // -----------------------------------------------------------------------

--- a/crates/provers/spartan/src/prover.rs
+++ b/crates/provers/spartan/src/prover.rs
@@ -23,8 +23,8 @@ use lambdaworks_sumcheck::Prover as SumcheckProver;
 
 use crate::errors::SpartanError;
 use crate::mle::{
-    encode_witness, eq_evals, eq_poly, index_to_multilinear_point, matrix_vector_product_mle,
-    mz_eval_with_eq, next_power_of_two,
+    encode_witness, eq_evals, eq_poly, index_to_multilinear_point,
+    matrix_vector_product_mle_with_eq, mz_eval_with_eq, next_power_of_two,
 };
 use crate::pcs::IsMultilinearPCS;
 use crate::r1cs::R1CS;
@@ -274,15 +274,9 @@ where
         let (rho_a, rho_b, rho_c) = (&rho[0], &rho[1], &rho[2]);
 
         // Build combined matrix MLE at (r_x, y): rho_a*A(r_x,y) + rho_b*B(r_x,y) + rho_c*C(r_x,y)
-        let az_row =
-            matrix_vector_product_mle(&r1cs.a, num_constraints_padded, num_cols_padded, r_x)
-                .map_err(|e| SpartanError::MleError(e.to_string()))?;
-        let bz_row =
-            matrix_vector_product_mle(&r1cs.b, num_constraints_padded, num_cols_padded, r_x)
-                .map_err(|e| SpartanError::MleError(e.to_string()))?;
-        let cz_row =
-            matrix_vector_product_mle(&r1cs.c, num_constraints_padded, num_cols_padded, r_x)
-                .map_err(|e| SpartanError::MleError(e.to_string()))?;
+        let az_row = matrix_vector_product_mle_with_eq(&r1cs.a, num_cols_padded, &eq_rx);
+        let bz_row = matrix_vector_product_mle_with_eq(&r1cs.b, num_cols_padded, &eq_rx);
+        let cz_row = matrix_vector_product_mle_with_eq(&r1cs.c, num_cols_padded, &eq_rx);
 
         // combined_matrix[y] = rho_a * az_row[y] + rho_b * bz_row[y] + rho_c * cz_row[y]
         let combined_matrix_evals: Vec<FieldElement<F>> = (0..num_cols_padded)

--- a/crates/provers/spartan/src/prover.rs
+++ b/crates/provers/spartan/src/prover.rs
@@ -304,7 +304,7 @@ where
         // -----------------------------------------------------------------------
         let (witness_eval, witness_proof) = self
             .pcs
-            .open(&z_mle, r_y)
+            .open_with_commitment(&z_mle, r_y, &witness_commitment)
             .map_err(|e| SpartanError::PcsError(e.to_string()))?;
 
         // Note: witness_eval is NOT absorbed into the transcript because no further
@@ -331,7 +331,7 @@ where
             let point = index_to_multilinear_point::<F>(i, n_witness_vars);
             let (eval, proof) = self
                 .pcs
-                .open(&z_mle, &point)
+                .open_with_commitment(&z_mle, &point, &witness_commitment)
                 .map_err(|e| SpartanError::PcsError(e.to_string()))?;
             debug_assert_eq!(
                 eval, *expected_val,

--- a/crates/provers/spartan/src/prover.rs
+++ b/crates/provers/spartan/src/prover.rs
@@ -72,6 +72,9 @@ where
     /// proving z̃(bits(i)) == public_inputs[i-1].
     /// Each entry is (evaluation_point, pcs_proof).
     pub public_input_proofs: Vec<(Vec<FieldElement<F>>, PCS::Proof)>,
+    /// PCS proof that z̃(0,...,0) = 1, confirming the R1CS constant term.
+    /// Without this, a malicious prover could set z[0] ≠ 1.
+    pub constant_proof: PCS::Proof,
 }
 
 /// The Spartan prover.
@@ -323,9 +326,9 @@ where
             .open(&z_mle, r_y)
             .map_err(|e| SpartanError::PcsError(e.to_string()))?;
 
-        // Absorb witness_eval into transcript for composability.
-        transcript.append_bytes(b"witness_eval");
-        transcript.append_field_element(&witness_eval);
+        // Note: witness_eval is NOT absorbed into the transcript because no further
+        // Fiat-Shamir challenges are drawn after this point. The PCS opening proof
+        // binds witness_eval cryptographically.
 
         // -----------------------------------------------------------------------
         // Step 8: Open z̃ at each public input position.
@@ -350,6 +353,23 @@ where
             public_input_proofs.push((point, proof));
         }
 
+        // -----------------------------------------------------------------------
+        // Step 9: Open z̃ at the all-zeros boolean point to prove z[0] = 1.
+        //
+        // The R1CS convention requires z = (1, x, w), so z[0] = 1 always.
+        // Without this opening, a malicious prover could commit z[0] ≠ 1.
+        // -----------------------------------------------------------------------
+        let zero_point = vec![FieldElement::<F>::zero(); n_witness_vars];
+        let (constant_eval, constant_proof) = self
+            .pcs
+            .open(&z_mle, &zero_point)
+            .map_err(|e| SpartanError::PcsError(e.to_string()))?;
+        debug_assert_eq!(
+            constant_eval,
+            FieldElement::one(),
+            "z̃(0) must equal 1 (R1CS constant term)"
+        );
+
         Ok(SpartanProof {
             witness_commitment,
             outer_sumcheck_polys,
@@ -362,6 +382,7 @@ where
             witness_eval,
             witness_proof,
             public_input_proofs,
+            constant_proof,
         })
     }
 }
@@ -412,7 +433,7 @@ where
     // Append the initial sum to transcript (same as GKR)
     transcript.append_bytes(b"initial_sum");
     transcript.append_field_element(&FieldElement::from(num_vars as u64));
-    transcript.append_field_element(&FieldElement::from(1u64));
+    transcript.append_field_element(&FieldElement::from(2u64)); // two-term product sumcheck
     transcript.append_field_element(&claimed_sum);
 
     let mut round_polys = Vec::with_capacity(num_vars);
@@ -476,7 +497,7 @@ where
     // so that inner sumcheck challenges depend on the declared sum value.
     transcript.append_bytes(b"initial_sum");
     transcript.append_field_element(&FieldElement::from(num_vars as u64));
-    transcript.append_field_element(&FieldElement::from(1u64));
+    transcript.append_field_element(&FieldElement::from(2u64)); // quadratic (2-factor) sumcheck
     transcript.append_field_element(&claimed_sum);
 
     let mut round_polys = Vec::with_capacity(num_vars);

--- a/crates/provers/spartan/src/prover.rs
+++ b/crates/provers/spartan/src/prover.rs
@@ -237,6 +237,10 @@ where
             compute_sum_of_product(&[eq_mle.evals(), az_mle.evals(), bz_mle.evals()]);
         let claimed_sum_term2 = compute_sum_of_product(&[eq_mle.evals(), neg_cz_mle.evals()]);
         let outer_claimed_sum = &claimed_sum_term1 + &claimed_sum_term2;
+        debug_assert!(
+            !r1cs.is_satisfied(witness_z) || outer_claimed_sum == FieldElement::zero(),
+            "outer sum must be 0 for satisfied R1CS"
+        );
 
         let (outer_sumcheck_polys, outer_challenges) = run_two_term_sumcheck(
             vec![eq_mle.clone(), az_mle, bz_mle],
@@ -314,8 +318,6 @@ where
         // -----------------------------------------------------------------------
         // Step 8: Open z̃ at each public input position.
         //
-        // z = (1, x_1, ..., x_l, w_1, ...) so x_i = z[i] for i in 1..=l.
-        // Open z̃ at boolean points for the constant z[0]=1 and each public input.
         // z = (1, x_1, ..., x_l, w_1, ...) so:
         //   index 0: z[0] = 1 (R1CS constant)
         //   index i: z[i] = public_inputs[i-1] for i in 1..=l

--- a/crates/provers/spartan/src/r1cs.rs
+++ b/crates/provers/spartan/src/r1cs.rs
@@ -1,0 +1,211 @@
+//! Generic Rank-1 Constraint System (R1CS).
+//!
+//! Unlike the Groth16-specific R1CS in crates/provers/groth16/src/r1cs.rs,
+//! this version is generic over any field F.
+
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+
+use crate::errors::SpartanError;
+
+/// A Rank-1 Constraint System over a generic field F.
+///
+/// An R1CS instance consists of matrices A, B, C ∈ F^{m×n} and a witness z ∈ F^n
+/// such that (Az) ∘ (Bz) = Cz (element-wise product of the matrix-vector products).
+///
+/// The witness z = (1, x, w) where:
+/// - 1 is the constant (always the first element)
+/// - x are the public inputs
+/// - w are the private witness values
+#[derive(Clone, Debug)]
+pub struct R1CS<F: IsField>
+where
+    F::BaseType: Send + Sync,
+{
+    /// Left input matrix (m × n, row = constraint, col = variable)
+    pub a: Vec<Vec<FieldElement<F>>>,
+    /// Right input matrix (m × n)
+    pub b: Vec<Vec<FieldElement<F>>>,
+    /// Output matrix (m × n)
+    pub c: Vec<Vec<FieldElement<F>>>,
+    /// Number of constraints (m)
+    pub num_constraints: usize,
+    /// Number of variables including the constant 1 (n)
+    pub num_variables: usize,
+    /// Number of public inputs (x in the witness z = (1, x, w))
+    pub num_public_inputs: usize,
+}
+
+impl<F: IsField> R1CS<F>
+where
+    F::BaseType: Send + Sync,
+{
+    /// Creates a new R1CS from matrices A, B, C and the number of public inputs.
+    ///
+    /// Validates that all three matrices have the same dimensions.
+    pub fn new(
+        a: Vec<Vec<FieldElement<F>>>,
+        b: Vec<Vec<FieldElement<F>>>,
+        c: Vec<Vec<FieldElement<F>>>,
+        num_public_inputs: usize,
+    ) -> Result<Self, SpartanError> {
+        let num_constraints = a.len();
+        if b.len() != num_constraints || c.len() != num_constraints {
+            return Err(SpartanError::R1CSError(format!(
+                "R1CS matrices have inconsistent row counts: a={}, b={}, c={}",
+                a.len(),
+                b.len(),
+                c.len()
+            )));
+        }
+
+        if num_constraints == 0 {
+            return Err(SpartanError::R1CSError(
+                "R1CS must have at least one constraint".to_string(),
+            ));
+        }
+
+        let num_variables = a[0].len();
+        if num_variables == 0 {
+            return Err(SpartanError::R1CSError(
+                "R1CS must have at least one variable".to_string(),
+            ));
+        }
+
+        for (i, (row_a, (row_b, row_c))) in a.iter().zip(b.iter().zip(c.iter())).enumerate() {
+            if row_a.len() != num_variables
+                || row_b.len() != num_variables
+                || row_c.len() != num_variables
+            {
+                return Err(SpartanError::R1CSError(format!(
+                    "R1CS row {} has inconsistent column counts: a={}, b={}, c={}",
+                    i,
+                    row_a.len(),
+                    row_b.len(),
+                    row_c.len()
+                )));
+            }
+        }
+
+        // z = (1, x, w): the constant 1 always occupies variable 0, so public inputs
+        // can use at most num_variables - 1 slots.
+        if num_public_inputs >= num_variables {
+            return Err(SpartanError::R1CSError(format!(
+                "num_public_inputs ({num_public_inputs}) must be less than num_variables \
+                 ({num_variables}): variable 0 is reserved for the constant 1 in z = (1, x, w)"
+            )));
+        }
+
+        Ok(Self {
+            a,
+            b,
+            c,
+            num_constraints,
+            num_variables,
+            num_public_inputs,
+        })
+    }
+
+    /// Checks whether the witness z satisfies the R1CS constraints.
+    ///
+    /// Returns true if (Az) ∘ (Bz) = Cz for all constraints.
+    pub fn is_satisfied(&self, z: &[FieldElement<F>]) -> bool {
+        if z.len() != self.num_variables {
+            return false;
+        }
+
+        for i in 0..self.num_constraints {
+            // Compute <A[i], z>
+            let az_i: FieldElement<F> = self.a[i]
+                .iter()
+                .zip(z.iter())
+                .map(|(a_ij, z_j)| a_ij * z_j)
+                .fold(FieldElement::zero(), |acc, x| acc + x);
+
+            // Compute <B[i], z>
+            let bz_i: FieldElement<F> = self.b[i]
+                .iter()
+                .zip(z.iter())
+                .map(|(b_ij, z_j)| b_ij * z_j)
+                .fold(FieldElement::zero(), |acc, x| acc + x);
+
+            // Compute <C[i], z>
+            let cz_i: FieldElement<F> = self.c[i]
+                .iter()
+                .zip(z.iter())
+                .map(|(c_ij, z_j)| c_ij * z_j)
+                .fold(FieldElement::zero(), |acc, x| acc + x);
+
+            if az_i * bz_i != cz_i {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lambdaworks_math::field::fields::u64_prime_field::U64PrimeField;
+
+    const MODULUS: u64 = 101;
+    type F = U64PrimeField<MODULUS>;
+    type FE = FieldElement<F>;
+
+    /// Build a simple circuit: x * y = z
+    /// witness z = [1, 9, 3, 3]  (constant=1, output=9, x=3, y=3)
+    /// A[0] = [0, 0, 1, 0]  (picks x=3)
+    /// B[0] = [0, 0, 0, 1]  (picks y=3)
+    /// C[0] = [0, 1, 0, 0]  (picks output=9)
+    fn multiplication_r1cs() -> (R1CS<F>, Vec<FE>) {
+        let zero = FE::zero();
+        let one = FE::one();
+
+        let a = vec![vec![zero.clone(), zero.clone(), one.clone(), zero.clone()]];
+        let b = vec![vec![zero.clone(), zero.clone(), zero.clone(), one.clone()]];
+        let c = vec![vec![zero.clone(), one.clone(), zero.clone(), zero.clone()]];
+
+        let r1cs = R1CS::new(a, b, c, 1).unwrap();
+
+        // witness: [1, 9, 3, 3]
+        let witness = vec![FE::one(), FE::from(9u64), FE::from(3u64), FE::from(3u64)];
+
+        (r1cs, witness)
+    }
+
+    #[test]
+    fn test_r1cs_satisfied() {
+        let (r1cs, witness) = multiplication_r1cs();
+        assert!(r1cs.is_satisfied(&witness));
+    }
+
+    #[test]
+    fn test_r1cs_not_satisfied_wrong_witness() {
+        let (r1cs, mut witness) = multiplication_r1cs();
+        // Set output to wrong value
+        witness[1] = FE::from(7u64);
+        assert!(!r1cs.is_satisfied(&witness));
+    }
+
+    #[test]
+    fn test_r1cs_wrong_witness_length() {
+        let (r1cs, _) = multiplication_r1cs();
+        let short_witness = vec![FE::one(), FE::from(2u64)];
+        assert!(!r1cs.is_satisfied(&short_witness));
+    }
+
+    #[test]
+    fn test_r1cs_new_dimension_mismatch() {
+        let zero = FE::zero();
+        let one = FE::one();
+
+        let a = vec![vec![zero.clone(), one.clone()]];
+        let b = vec![vec![zero.clone()]]; // wrong column count
+        let c = vec![vec![zero.clone(), one.clone()]];
+
+        // This should fail because row 0 of b has wrong length
+        let result = R1CS::new(a, b, c, 0);
+        assert!(result.is_err());
+    }
+}

--- a/crates/provers/spartan/src/r1cs.rs
+++ b/crates/provers/spartan/src/r1cs.rs
@@ -162,9 +162,9 @@ mod tests {
         let zero = FE::zero();
         let one = FE::one();
 
-        let a = vec![vec![zero.clone(), zero.clone(), one.clone(), zero.clone()]];
-        let b = vec![vec![zero.clone(), zero.clone(), zero.clone(), one.clone()]];
-        let c = vec![vec![zero.clone(), one.clone(), zero.clone(), zero.clone()]];
+        let a = vec![vec![zero, zero, one, zero]];
+        let b = vec![vec![zero, zero, zero, one]];
+        let c = vec![vec![zero, one, zero, zero]];
 
         let r1cs = R1CS::new(a, b, c, 1).unwrap();
 
@@ -200,9 +200,9 @@ mod tests {
         let zero = FE::zero();
         let one = FE::one();
 
-        let a = vec![vec![zero.clone(), one.clone()]];
-        let b = vec![vec![zero.clone()]]; // wrong column count
-        let c = vec![vec![zero.clone(), one.clone()]];
+        let a = vec![vec![zero, one]];
+        let b = vec![vec![zero]]; // wrong column count
+        let c = vec![vec![zero, one]];
 
         // This should fail because row 0 of b has wrong length
         let result = R1CS::new(a, b, c, 0);

--- a/crates/provers/spartan/src/r1cs.rs
+++ b/crates/provers/spartan/src/r1cs.rs
@@ -227,7 +227,7 @@ mod tests {
             vec![SparseEntry {
                 row: 0,
                 col: 2,
-                val: one.clone(),
+                val: one,
             }],
             1,
             4,
@@ -237,7 +237,7 @@ mod tests {
             vec![SparseEntry {
                 row: 0,
                 col: 3,
-                val: one.clone(),
+                val: one,
             }],
             1,
             4,

--- a/crates/provers/spartan/src/r1cs.rs
+++ b/crates/provers/spartan/src/r1cs.rs
@@ -6,6 +6,7 @@
 use lambdaworks_math::field::{element::FieldElement, traits::IsField};
 
 use crate::errors::SpartanError;
+use crate::sparse_matrix::SparseMatrix;
 
 /// A Rank-1 Constraint System over a generic field F.
 ///
@@ -22,11 +23,11 @@ where
     F::BaseType: Send + Sync,
 {
     /// Left input matrix (m × n, row = constraint, col = variable)
-    pub a: Vec<Vec<FieldElement<F>>>,
+    pub a: SparseMatrix<F>,
     /// Right input matrix (m × n)
-    pub b: Vec<Vec<FieldElement<F>>>,
+    pub b: SparseMatrix<F>,
     /// Output matrix (m × n)
-    pub c: Vec<Vec<FieldElement<F>>>,
+    pub c: SparseMatrix<F>,
     /// Number of constraints (m)
     pub num_constraints: usize,
     /// Number of variables including the constant 1 (n)
@@ -39,10 +40,54 @@ impl<F: IsField> R1CS<F>
 where
     F::BaseType: Send + Sync,
 {
-    /// Creates a new R1CS from matrices A, B, C and the number of public inputs.
-    ///
-    /// Validates that all three matrices have the same dimensions.
+    /// Creates a new R1CS from sparse matrices.
     pub fn new(
+        a: SparseMatrix<F>,
+        b: SparseMatrix<F>,
+        c: SparseMatrix<F>,
+        num_public_inputs: usize,
+    ) -> Result<Self, SpartanError> {
+        let num_constraints = a.num_rows;
+        let num_variables = a.num_cols;
+
+        if b.num_rows != num_constraints
+            || c.num_rows != num_constraints
+            || b.num_cols != num_variables
+            || c.num_cols != num_variables
+        {
+            return Err(SpartanError::R1CSError(format!(
+                "R1CS matrices have inconsistent dimensions: a={}x{}, b={}x{}, c={}x{}",
+                a.num_rows, a.num_cols, b.num_rows, b.num_cols, c.num_rows, c.num_cols
+            )));
+        }
+        if num_constraints == 0 {
+            return Err(SpartanError::R1CSError(
+                "R1CS must have at least one constraint".to_string(),
+            ));
+        }
+        if num_variables == 0 {
+            return Err(SpartanError::R1CSError(
+                "R1CS must have at least one variable".to_string(),
+            ));
+        }
+        if num_public_inputs >= num_variables {
+            return Err(SpartanError::R1CSError(format!(
+                "num_public_inputs ({num_public_inputs}) must be less than num_variables \
+                 ({num_variables}): variable 0 is reserved for the constant 1 in z = (1, x, w)"
+            )));
+        }
+        Ok(Self {
+            a,
+            b,
+            c,
+            num_constraints,
+            num_variables,
+            num_public_inputs,
+        })
+    }
+
+    /// Creates R1CS from dense matrices (backward compatibility).
+    pub fn from_dense(
         a: Vec<Vec<FieldElement<F>>>,
         b: Vec<Vec<FieldElement<F>>>,
         c: Vec<Vec<FieldElement<F>>>,
@@ -57,20 +102,12 @@ where
                 c.len()
             )));
         }
-
         if num_constraints == 0 {
             return Err(SpartanError::R1CSError(
                 "R1CS must have at least one constraint".to_string(),
             ));
         }
-
         let num_variables = a[0].len();
-        if num_variables == 0 {
-            return Err(SpartanError::R1CSError(
-                "R1CS must have at least one variable".to_string(),
-            ));
-        }
-
         for (i, (row_a, (row_b, row_c))) in a.iter().zip(b.iter().zip(c.iter())).enumerate() {
             if row_a.len() != num_variables
                 || row_b.len() != num_variables
@@ -85,24 +122,10 @@ where
                 )));
             }
         }
-
-        // z = (1, x, w): the constant 1 always occupies variable 0, so public inputs
-        // can use at most num_variables - 1 slots.
-        if num_public_inputs >= num_variables {
-            return Err(SpartanError::R1CSError(format!(
-                "num_public_inputs ({num_public_inputs}) must be less than num_variables \
-                 ({num_variables}): variable 0 is reserved for the constant 1 in z = (1, x, w)"
-            )));
-        }
-
-        Ok(Self {
-            a,
-            b,
-            c,
-            num_constraints,
-            num_variables,
-            num_public_inputs,
-        })
+        let sa = SparseMatrix::from_dense(&a);
+        let sb = SparseMatrix::from_dense(&b);
+        let sc = SparseMatrix::from_dense(&c);
+        Self::new(sa, sb, sc, num_public_inputs)
     }
 
     /// Checks whether the witness z satisfies the R1CS constraints.
@@ -113,40 +136,27 @@ where
             return false;
         }
 
-        for i in 0..self.num_constraints {
-            // Compute <A[i], z>
-            let az_i: FieldElement<F> = self.a[i]
-                .iter()
-                .zip(z.iter())
-                .map(|(a_ij, z_j)| a_ij * z_j)
-                .fold(FieldElement::zero(), |acc, x| acc + x);
+        let mut az = vec![FieldElement::<F>::zero(); self.num_constraints];
+        let mut bz = vec![FieldElement::<F>::zero(); self.num_constraints];
+        let mut cz = vec![FieldElement::<F>::zero(); self.num_constraints];
 
-            // Compute <B[i], z>
-            let bz_i: FieldElement<F> = self.b[i]
-                .iter()
-                .zip(z.iter())
-                .map(|(b_ij, z_j)| b_ij * z_j)
-                .fold(FieldElement::zero(), |acc, x| acc + x);
-
-            // Compute <C[i], z>
-            let cz_i: FieldElement<F> = self.c[i]
-                .iter()
-                .zip(z.iter())
-                .map(|(c_ij, z_j)| c_ij * z_j)
-                .fold(FieldElement::zero(), |acc, x| acc + x);
-
-            if az_i * bz_i != cz_i {
-                return false;
-            }
+        for e in &self.a.entries {
+            az[e.row] += &e.val * &z[e.col];
         }
-
-        true
+        for e in &self.b.entries {
+            bz[e.row] += &e.val * &z[e.col];
+        }
+        for e in &self.c.entries {
+            cz[e.row] += &e.val * &z[e.col];
+        }
+        (0..self.num_constraints).all(|i| &az[i] * &bz[i] == cz[i])
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sparse_matrix::SparseEntry;
     use lambdaworks_math::field::fields::u64_prime_field::U64PrimeField;
 
     const MODULUS: u64 = 101;
@@ -166,7 +176,7 @@ mod tests {
         let b = vec![vec![zero, zero, zero, one]];
         let c = vec![vec![zero, one, zero, zero]];
 
-        let r1cs = R1CS::new(a, b, c, 1).unwrap();
+        let r1cs = R1CS::from_dense(a, b, c, 1).unwrap();
 
         // witness: [1, 9, 3, 3]
         let witness = vec![FE::one(), FE::from(9u64), FE::from(3u64), FE::from(3u64)];
@@ -205,7 +215,46 @@ mod tests {
         let c = vec![vec![zero, one]];
 
         // This should fail because row 0 of b has wrong length
-        let result = R1CS::new(a, b, c, 0);
+        let result = R1CS::from_dense(a, b, c, 0);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_sparse_r1cs_satisfied() {
+        let one = FE::one();
+        // x * y = z: A picks x (col 2), B picks y (col 3), C picks output (col 1)
+        let a = SparseMatrix::new(
+            vec![SparseEntry {
+                row: 0,
+                col: 2,
+                val: one.clone(),
+            }],
+            1,
+            4,
+        )
+        .unwrap();
+        let b = SparseMatrix::new(
+            vec![SparseEntry {
+                row: 0,
+                col: 3,
+                val: one.clone(),
+            }],
+            1,
+            4,
+        )
+        .unwrap();
+        let c = SparseMatrix::new(
+            vec![SparseEntry {
+                row: 0,
+                col: 1,
+                val: one,
+            }],
+            1,
+            4,
+        )
+        .unwrap();
+        let r1cs = R1CS::new(a, b, c, 1).unwrap();
+        let witness = vec![FE::one(), FE::from(9u64), FE::from(3u64), FE::from(3u64)];
+        assert!(r1cs.is_satisfied(&witness));
     }
 }

--- a/crates/provers/spartan/src/sparse_matrix.rs
+++ b/crates/provers/spartan/src/sparse_matrix.rs
@@ -101,10 +101,7 @@ mod tests {
         let z = FE::zero();
         let one = FE::one();
         let two = FE::from(2u64);
-        let dense = vec![
-            vec![one.clone(), z.clone(), two.clone()],
-            vec![z.clone(), z.clone(), one.clone()],
-        ];
+        let dense = vec![vec![one, z, two], vec![z, z, one]];
         let sparse = SparseMatrix::from_dense(&dense);
         assert_eq!(sparse.num_rows, 2);
         assert_eq!(sparse.num_cols, 3);
@@ -120,7 +117,7 @@ mod tests {
     #[test]
     fn test_from_dense_all_zeros() {
         let z = FE::zero();
-        let dense = vec![vec![z.clone(), z.clone()], vec![z.clone(), z.clone()]];
+        let dense = vec![vec![z, z], vec![z, z]];
         let sparse = SparseMatrix::from_dense(&dense);
         assert!(sparse.entries.is_empty());
     }

--- a/crates/provers/spartan/src/sparse_matrix.rs
+++ b/crates/provers/spartan/src/sparse_matrix.rs
@@ -1,0 +1,165 @@
+//! Sparse matrix in COO (Coordinate) format for R1CS.
+
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+
+use crate::errors::SpartanError;
+
+/// A single non-zero entry in a sparse matrix.
+#[derive(Clone, Debug)]
+pub struct SparseEntry<F: IsField>
+where
+    F::BaseType: Send + Sync,
+{
+    pub row: usize,
+    pub col: usize,
+    pub val: FieldElement<F>,
+}
+
+/// Sparse matrix in COO (Coordinate) format, sorted by (row, col).
+#[derive(Clone, Debug)]
+pub struct SparseMatrix<F: IsField>
+where
+    F::BaseType: Send + Sync,
+{
+    pub entries: Vec<SparseEntry<F>>,
+    pub num_rows: usize,
+    pub num_cols: usize,
+}
+
+impl<F: IsField> SparseMatrix<F>
+where
+    F::BaseType: Send + Sync,
+{
+    /// Creates a new sparse matrix from COO entries.
+    ///
+    /// Filters out zero entries, sorts by (row, col), and validates bounds.
+    pub fn new(
+        entries: Vec<SparseEntry<F>>,
+        num_rows: usize,
+        num_cols: usize,
+    ) -> Result<Self, SpartanError> {
+        let mut filtered: Vec<SparseEntry<F>> = entries
+            .into_iter()
+            .filter(|e| e.val != FieldElement::zero())
+            .collect();
+
+        for e in &filtered {
+            if e.row >= num_rows || e.col >= num_cols {
+                return Err(SpartanError::R1CSError(format!(
+                    "sparse entry ({}, {}) out of bounds for {}x{} matrix",
+                    e.row, e.col, num_rows, num_cols
+                )));
+            }
+        }
+
+        filtered.sort_by(|a, b| a.row.cmp(&b.row).then(a.col.cmp(&b.col)));
+
+        Ok(Self {
+            entries: filtered,
+            num_rows,
+            num_cols,
+        })
+    }
+
+    /// Creates a sparse matrix from a dense `Vec<Vec<FieldElement<F>>>`.
+    pub fn from_dense(dense: &[Vec<FieldElement<F>>]) -> Self {
+        let num_rows = dense.len();
+        let num_cols = if num_rows > 0 { dense[0].len() } else { 0 };
+        let mut entries = Vec::new();
+
+        for (i, row) in dense.iter().enumerate() {
+            for (j, val) in row.iter().enumerate() {
+                if *val != FieldElement::zero() {
+                    entries.push(SparseEntry {
+                        row: i,
+                        col: j,
+                        val: val.clone(),
+                    });
+                }
+            }
+        }
+        // Already sorted by (row, col) due to iteration order.
+        Self {
+            entries,
+            num_rows,
+            num_cols,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lambdaworks_math::field::fields::u64_prime_field::U64PrimeField;
+
+    const MODULUS: u64 = 101;
+    type F = U64PrimeField<MODULUS>;
+    type FE = FieldElement<F>;
+
+    #[test]
+    fn test_from_dense_extracts_nonzeros() {
+        let z = FE::zero();
+        let one = FE::one();
+        let two = FE::from(2u64);
+        let dense = vec![
+            vec![one.clone(), z.clone(), two.clone()],
+            vec![z.clone(), z.clone(), one.clone()],
+        ];
+        let sparse = SparseMatrix::from_dense(&dense);
+        assert_eq!(sparse.num_rows, 2);
+        assert_eq!(sparse.num_cols, 3);
+        assert_eq!(sparse.entries.len(), 3); // (0,0,1), (0,2,2), (1,2,1)
+        assert_eq!(sparse.entries[0].row, 0);
+        assert_eq!(sparse.entries[0].col, 0);
+        assert_eq!(sparse.entries[1].row, 0);
+        assert_eq!(sparse.entries[1].col, 2);
+        assert_eq!(sparse.entries[2].row, 1);
+        assert_eq!(sparse.entries[2].col, 2);
+    }
+
+    #[test]
+    fn test_from_dense_all_zeros() {
+        let z = FE::zero();
+        let dense = vec![vec![z.clone(), z.clone()], vec![z.clone(), z.clone()]];
+        let sparse = SparseMatrix::from_dense(&dense);
+        assert!(sparse.entries.is_empty());
+    }
+
+    #[test]
+    fn test_new_filters_zeros_and_sorts() {
+        let one = FE::one();
+        let two = FE::from(2u64);
+        let entries = vec![
+            SparseEntry {
+                row: 1,
+                col: 0,
+                val: two,
+            },
+            SparseEntry {
+                row: 0,
+                col: 1,
+                val: FE::zero(),
+            }, // should be filtered
+            SparseEntry {
+                row: 0,
+                col: 0,
+                val: one,
+            },
+        ];
+        let m = SparseMatrix::new(entries, 2, 2).unwrap();
+        assert_eq!(m.entries.len(), 2);
+        assert_eq!(m.entries[0].row, 0); // sorted first
+        assert_eq!(m.entries[1].row, 1);
+    }
+
+    #[test]
+    fn test_new_validates_bounds() {
+        let one = FE::one();
+        let entries = vec![SparseEntry {
+            row: 5,
+            col: 0,
+            val: one,
+        }];
+        assert!(SparseMatrix::new(entries, 2, 2).is_err());
+    }
+}

--- a/crates/provers/spartan/src/transcript.rs
+++ b/crates/provers/spartan/src/transcript.rs
@@ -1,0 +1,136 @@
+//! Fiat-Shamir transcript helpers for Spartan.
+//!
+//! Provides functions for appending Spartan-specific data to the transcript
+//! and drawing challenges deterministically.
+
+use lambdaworks_crypto::fiat_shamir::default_transcript::DefaultTranscript;
+use lambdaworks_crypto::fiat_shamir::is_transcript::IsTranscript;
+use lambdaworks_math::field::traits::HasDefaultTranscript;
+use lambdaworks_math::field::{element::FieldElement, traits::IsField};
+use lambdaworks_math::traits::ByteConversion;
+
+use crate::r1cs::R1CS;
+
+/// Append R1CS instance parameters to the transcript.
+///
+/// Appends the dimensions (num_constraints, num_variables, num_public_inputs)
+/// and all non-zero entries from A, B, C.
+pub fn append_r1cs_instance<F>(transcript: &mut DefaultTranscript<F>, r1cs: &R1CS<F>)
+where
+    F: IsField + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+{
+    transcript.append_bytes(b"r1cs_instance");
+    transcript.append_bytes(&(r1cs.num_constraints as u64).to_be_bytes());
+    transcript.append_bytes(&(r1cs.num_variables as u64).to_be_bytes());
+    transcript.append_bytes(&(r1cs.num_public_inputs as u64).to_be_bytes());
+
+    // Append non-zero entries from A, prefixed with NNZ count for unambiguous encoding
+    transcript.append_bytes(b"matrix_A");
+    let nnz_a = r1cs
+        .a
+        .iter()
+        .flatten()
+        .filter(|v| **v != FieldElement::zero())
+        .count();
+    transcript.append_bytes(&(nnz_a as u64).to_be_bytes());
+    for (i, row) in r1cs.a.iter().enumerate() {
+        for (j, val) in row.iter().enumerate() {
+            if *val != FieldElement::zero() {
+                transcript.append_bytes(&(i as u64).to_be_bytes());
+                transcript.append_bytes(&(j as u64).to_be_bytes());
+                transcript.append_field_element(val);
+            }
+        }
+    }
+
+    // Append non-zero entries from B
+    transcript.append_bytes(b"matrix_B");
+    let nnz_b = r1cs
+        .b
+        .iter()
+        .flatten()
+        .filter(|v| **v != FieldElement::zero())
+        .count();
+    transcript.append_bytes(&(nnz_b as u64).to_be_bytes());
+    for (i, row) in r1cs.b.iter().enumerate() {
+        for (j, val) in row.iter().enumerate() {
+            if *val != FieldElement::zero() {
+                transcript.append_bytes(&(i as u64).to_be_bytes());
+                transcript.append_bytes(&(j as u64).to_be_bytes());
+                transcript.append_field_element(val);
+            }
+        }
+    }
+
+    // Append non-zero entries from C
+    transcript.append_bytes(b"matrix_C");
+    let nnz_c = r1cs
+        .c
+        .iter()
+        .flatten()
+        .filter(|v| **v != FieldElement::zero())
+        .count();
+    transcript.append_bytes(&(nnz_c as u64).to_be_bytes());
+    for (i, row) in r1cs.c.iter().enumerate() {
+        for (j, val) in row.iter().enumerate() {
+            if *val != FieldElement::zero() {
+                transcript.append_bytes(&(i as u64).to_be_bytes());
+                transcript.append_bytes(&(j as u64).to_be_bytes());
+                transcript.append_field_element(val);
+            }
+        }
+    }
+}
+
+/// Append public inputs to the transcript.
+pub fn append_public_inputs<F>(
+    transcript: &mut DefaultTranscript<F>,
+    public_inputs: &[FieldElement<F>],
+) where
+    F: IsField + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+{
+    transcript.append_bytes(b"public_inputs");
+    for x in public_inputs {
+        transcript.append_field_element(x);
+    }
+}
+
+/// Draw n field element challenges from the transcript.
+pub fn draw_challenges<F>(transcript: &mut DefaultTranscript<F>, n: usize) -> Vec<FieldElement<F>>
+where
+    F: IsField + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+{
+    (0..n).map(|_| transcript.sample_field_element()).collect()
+}
+
+/// Append round polynomials to the transcript using the same format as the GKR sumcheck.
+///
+/// This ensures the prover and verifier produce the same challenges.
+pub fn append_round_poly_to_transcript<F>(
+    transcript: &mut DefaultTranscript<F>,
+    round: usize,
+    poly: &lambdaworks_math::polynomial::Polynomial<FieldElement<F>>,
+) where
+    F: IsField + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+{
+    let round_label = format!("round_{round}_poly");
+    transcript.append_bytes(round_label.as_bytes());
+
+    let coeffs = poly.coefficients();
+    transcript.append_bytes(&(coeffs.len() as u64).to_be_bytes());
+    if coeffs.is_empty() {
+        transcript.append_field_element(&FieldElement::zero());
+    } else {
+        for coeff in coeffs {
+            transcript.append_field_element(coeff);
+        }
+    }
+}

--- a/crates/provers/spartan/src/transcript.rs
+++ b/crates/provers/spartan/src/transcript.rs
@@ -94,6 +94,7 @@ pub fn append_public_inputs<F>(
     FieldElement<F>: ByteConversion,
 {
     transcript.append_bytes(b"public_inputs");
+    transcript.append_bytes(&(public_inputs.len() as u64).to_be_bytes());
     for x in public_inputs {
         transcript.append_field_element(x);
     }

--- a/crates/provers/spartan/src/transcript.rs
+++ b/crates/provers/spartan/src/transcript.rs
@@ -10,6 +10,7 @@ use lambdaworks_math::field::{element::FieldElement, traits::IsField};
 use lambdaworks_math::traits::ByteConversion;
 
 use crate::r1cs::R1CS;
+use crate::sparse_matrix::SparseMatrix;
 
 /// Append R1CS instance parameters to the transcript.
 ///
@@ -32,30 +33,24 @@ where
 }
 
 /// Append non-zero entries of a sparse matrix to the transcript.
+///
+/// COO entries are sorted by (row, col), matching the row-major scan order
+/// of the previous dense implementation. This preserves Fiat-Shamir compatibility.
 fn append_sparse_matrix<F>(
     transcript: &mut DefaultTranscript<F>,
     label: &[u8],
-    matrix: &[Vec<FieldElement<F>>],
+    matrix: &SparseMatrix<F>,
 ) where
     F: IsField + HasDefaultTranscript,
     F::BaseType: Send + Sync,
     FieldElement<F>: ByteConversion,
 {
     transcript.append_bytes(label);
-    let nnz: usize = matrix
-        .iter()
-        .flatten()
-        .filter(|v| **v != FieldElement::zero())
-        .count();
-    transcript.append_bytes(&(nnz as u64).to_be_bytes());
-    for (i, row) in matrix.iter().enumerate() {
-        for (j, val) in row.iter().enumerate() {
-            if *val != FieldElement::zero() {
-                transcript.append_bytes(&(i as u64).to_be_bytes());
-                transcript.append_bytes(&(j as u64).to_be_bytes());
-                transcript.append_field_element(val);
-            }
-        }
+    transcript.append_bytes(&(matrix.entries.len() as u64).to_be_bytes());
+    for entry in &matrix.entries {
+        transcript.append_bytes(&(entry.row as u64).to_be_bytes());
+        transcript.append_bytes(&(entry.col as u64).to_be_bytes());
+        transcript.append_field_element(&entry.val);
     }
 }
 

--- a/crates/provers/spartan/src/transcript.rs
+++ b/crates/provers/spartan/src/transcript.rs
@@ -26,54 +26,29 @@ where
     transcript.append_bytes(&(r1cs.num_variables as u64).to_be_bytes());
     transcript.append_bytes(&(r1cs.num_public_inputs as u64).to_be_bytes());
 
-    // Append non-zero entries from A, prefixed with NNZ count for unambiguous encoding
-    transcript.append_bytes(b"matrix_A");
-    let nnz_a = r1cs
-        .a
-        .iter()
-        .flatten()
-        .filter(|v| **v != FieldElement::zero())
-        .count();
-    transcript.append_bytes(&(nnz_a as u64).to_be_bytes());
-    for (i, row) in r1cs.a.iter().enumerate() {
-        for (j, val) in row.iter().enumerate() {
-            if *val != FieldElement::zero() {
-                transcript.append_bytes(&(i as u64).to_be_bytes());
-                transcript.append_bytes(&(j as u64).to_be_bytes());
-                transcript.append_field_element(val);
-            }
-        }
-    }
+    append_sparse_matrix(transcript, b"matrix_A", &r1cs.a);
+    append_sparse_matrix(transcript, b"matrix_B", &r1cs.b);
+    append_sparse_matrix(transcript, b"matrix_C", &r1cs.c);
+}
 
-    // Append non-zero entries from B
-    transcript.append_bytes(b"matrix_B");
-    let nnz_b = r1cs
-        .b
+/// Append non-zero entries of a sparse matrix to the transcript.
+fn append_sparse_matrix<F>(
+    transcript: &mut DefaultTranscript<F>,
+    label: &[u8],
+    matrix: &[Vec<FieldElement<F>>],
+) where
+    F: IsField + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+{
+    transcript.append_bytes(label);
+    let nnz: usize = matrix
         .iter()
         .flatten()
         .filter(|v| **v != FieldElement::zero())
         .count();
-    transcript.append_bytes(&(nnz_b as u64).to_be_bytes());
-    for (i, row) in r1cs.b.iter().enumerate() {
-        for (j, val) in row.iter().enumerate() {
-            if *val != FieldElement::zero() {
-                transcript.append_bytes(&(i as u64).to_be_bytes());
-                transcript.append_bytes(&(j as u64).to_be_bytes());
-                transcript.append_field_element(val);
-            }
-        }
-    }
-
-    // Append non-zero entries from C
-    transcript.append_bytes(b"matrix_C");
-    let nnz_c = r1cs
-        .c
-        .iter()
-        .flatten()
-        .filter(|v| **v != FieldElement::zero())
-        .count();
-    transcript.append_bytes(&(nnz_c as u64).to_be_bytes());
-    for (i, row) in r1cs.c.iter().enumerate() {
+    transcript.append_bytes(&(nnz as u64).to_be_bytes());
+    for (i, row) in matrix.iter().enumerate() {
         for (j, val) in row.iter().enumerate() {
             if *val != FieldElement::zero() {
                 transcript.append_bytes(&(i as u64).to_be_bytes());

--- a/crates/provers/spartan/src/verifier.rs
+++ b/crates/provers/spartan/src/verifier.rs
@@ -15,7 +15,7 @@ use lambdaworks_math::polynomial::Polynomial;
 use lambdaworks_math::traits::ByteConversion;
 
 use crate::errors::SpartanError;
-use crate::mle::{eq_poly, matrix_mle_eval, next_power_of_two};
+use crate::mle::{eq_poly, index_to_multilinear_point, matrix_mle_eval, next_power_of_two};
 use crate::pcs::IsMultilinearPCS;
 use crate::prover::SpartanProof;
 use crate::r1cs::R1CS;
@@ -217,7 +217,7 @@ where
         transcript.append_field_element(&proof.witness_eval);
 
         // -----------------------------------------------------------------------
-        // Step 9: Verify PCS opening
+        // Step 9: Verify PCS opening of z̃ at r_y
         // -----------------------------------------------------------------------
         let pcs_ok = self
             .pcs
@@ -231,6 +231,41 @@ where
 
         if !pcs_ok {
             return Ok(false);
+        }
+
+        // -----------------------------------------------------------------------
+        // Step 10: Verify public input consistency.
+        //
+        // Each proof entry (point, pi_proof) asserts z̃(point) == public_inputs[i-1].
+        // Without this step a malicious prover can commit to a witness that
+        // disagrees with the claimed public inputs while all sumcheck checks pass.
+        // -----------------------------------------------------------------------
+        if proof.public_input_proofs.len() != public_inputs.len() {
+            return Ok(false);
+        }
+
+        // num_cols_padded is already computed above; derive the witness variable count.
+        let n_witness_vars = num_cols_padded.trailing_zeros() as usize;
+
+        for (i, (pi, (point, pi_proof))) in public_inputs
+            .iter()
+            .zip(proof.public_input_proofs.iter())
+            .enumerate()
+        {
+            // Verify the evaluation point matches the expected boolean point for index i+1.
+            let expected_point = index_to_multilinear_point::<F>(i + 1, n_witness_vars);
+            if *point != expected_point {
+                return Ok(false);
+            }
+
+            let pi_ok = self
+                .pcs
+                .verify(&proof.witness_commitment, point, pi, pi_proof)
+                .map_err(|e| SpartanError::PcsError(e.to_string()))?;
+
+            if !pi_ok {
+                return Ok(false);
+            }
         }
 
         Ok(true)

--- a/crates/provers/spartan/src/verifier.rs
+++ b/crates/provers/spartan/src/verifier.rs
@@ -1,0 +1,351 @@
+//! Spartan verifier.
+//!
+//! Verifies a Spartan proof by replaying the Fiat-Shamir transcript and
+//! checking the sumcheck and PCS proofs.
+
+use std::marker::PhantomData;
+
+use lambdaworks_crypto::fiat_shamir::default_transcript::DefaultTranscript;
+use lambdaworks_crypto::fiat_shamir::is_transcript::IsTranscript;
+use lambdaworks_math::field::{
+    element::FieldElement,
+    traits::{HasDefaultTranscript, IsField},
+};
+use lambdaworks_math::polynomial::Polynomial;
+use lambdaworks_math::traits::ByteConversion;
+
+use crate::errors::SpartanError;
+use crate::mle::{eq_poly, matrix_mle_eval, next_power_of_two};
+use crate::pcs::IsMultilinearPCS;
+use crate::prover::SpartanProof;
+use crate::r1cs::R1CS;
+use crate::transcript::{
+    append_public_inputs, append_r1cs_instance, append_round_poly_to_transcript, draw_challenges,
+};
+
+/// The Spartan verifier.
+pub struct SpartanVerifier<F, PCS>
+where
+    F: IsField,
+    F::BaseType: Send + Sync,
+    PCS: IsMultilinearPCS<F>,
+{
+    pcs: PCS,
+    _f: PhantomData<F>,
+}
+
+impl<F, PCS> SpartanVerifier<F, PCS>
+where
+    F: IsField + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+    PCS: IsMultilinearPCS<F>,
+    PCS::Error: 'static,
+{
+    /// Creates a new SpartanVerifier with the given PCS.
+    pub fn new(pcs: PCS) -> Self {
+        Self {
+            pcs,
+            _f: PhantomData,
+        }
+    }
+
+    /// Verifies a Spartan proof.
+    ///
+    /// Returns Ok(true) if the proof is valid, Ok(false) if it's invalid but
+    /// structurally sound, or Err if there's a structural error.
+    pub fn verify(
+        &self,
+        r1cs: &R1CS<F>,
+        public_inputs: &[FieldElement<F>],
+        proof: &SpartanProof<F, PCS>,
+    ) -> Result<bool, SpartanError> {
+        // -----------------------------------------------------------------------
+        // Step 1: Initialize transcript identically to prover
+        // -----------------------------------------------------------------------
+        let mut transcript = DefaultTranscript::<F>::default();
+        transcript.append_bytes(b"lambdaworks-spartan-v1");
+        append_r1cs_instance(&mut transcript, r1cs);
+        append_public_inputs(&mut transcript, public_inputs);
+        // Absorb the witness commitment (same step as prover).
+        transcript.append_bytes(b"witness_commitment");
+        transcript.append_bytes(&PCS::serialize_commitment(&proof.witness_commitment));
+
+        // -----------------------------------------------------------------------
+        // Step 2: Draw tau (same as prover)
+        // -----------------------------------------------------------------------
+        let num_constraints_padded = next_power_of_two(r1cs.num_constraints).max(2);
+        let log_constraints = {
+            let mut k = 0;
+            let mut n = num_constraints_padded;
+            while n > 1 {
+                k += 1;
+                n >>= 1;
+            }
+            k
+        };
+        let num_cols_padded = next_power_of_two(r1cs.num_variables).max(2);
+
+        transcript.append_bytes(b"tau_challenge");
+        let tau = draw_challenges(&mut transcript, log_constraints);
+
+        // -----------------------------------------------------------------------
+        // Step 3: Verify outer sumcheck
+        //
+        // Claimed sum = 0 (R1CS is satisfied).
+        // The outer sumcheck uses a two-term GKR-style sumcheck.
+        // Round polynomials have degree ≤ 3 (term1 is cubic, term2 is quadratic).
+        // -----------------------------------------------------------------------
+        transcript.append_bytes(b"outer_sumcheck");
+
+        let outer_claimed_sum = FieldElement::<F>::zero();
+
+        let (outer_ok, r_x) = verify_two_term_sumcheck_round_polys(
+            outer_claimed_sum,
+            &proof.outer_sumcheck_polys,
+            3, // max degree for cubic sumcheck
+            &mut transcript,
+        )?;
+
+        if !outer_ok {
+            return Ok(false);
+        }
+
+        // Verify that the claimed outer challenges match the transcript-derived ones
+        if r_x != proof.outer_challenges {
+            return Ok(false);
+        }
+
+        // -----------------------------------------------------------------------
+        // Step 4: Oracle check for outer sumcheck
+        //
+        // The last round poly at last challenge should equal:
+        //   eq(τ, r_x) · v_a · v_b - eq(τ, r_x) · v_c
+        //   = eq(τ, r_x) · (v_a · v_b - v_c)
+        //
+        // This is valid because we use a PRODUCT sumcheck:
+        // term1 oracle = eq(τ,r_x) · v_a · v_b
+        // term2 oracle = eq(τ,r_x) · (-v_c)
+        // -----------------------------------------------------------------------
+        let eq_tau_rx = eq_poly(&tau)
+            .evaluate(r_x.clone())
+            .map_err(|e| SpartanError::VerificationFailed(format!("eq eval error: {e:?}")))?;
+
+        let outer_oracle = &eq_tau_rx * &(&proof.v_a * &proof.v_b - &proof.v_c);
+
+        // The final evaluation from the last round polynomial at the last challenge
+        let last_outer_poly = proof.outer_sumcheck_polys.last().ok_or_else(|| {
+            SpartanError::VerificationFailed("Empty outer sumcheck polys".to_string())
+        })?;
+        let last_challenge = r_x.last().ok_or_else(|| {
+            SpartanError::VerificationFailed("Empty outer challenges".to_string())
+        })?;
+        let last_outer_eval = last_outer_poly.evaluate(last_challenge);
+
+        if last_outer_eval != outer_oracle {
+            return Ok(false);
+        }
+
+        // -----------------------------------------------------------------------
+        // Step 5: Append v_a, v_b, v_c to transcript
+        // -----------------------------------------------------------------------
+        transcript.append_bytes(b"v_a");
+        transcript.append_field_element(&proof.v_a);
+        transcript.append_bytes(b"v_b");
+        transcript.append_field_element(&proof.v_b);
+        transcript.append_bytes(b"v_c");
+        transcript.append_field_element(&proof.v_c);
+
+        // -----------------------------------------------------------------------
+        // Step 6: Draw batching challenges
+        // -----------------------------------------------------------------------
+        transcript.append_bytes(b"inner_challenges");
+        let rho = draw_challenges(&mut transcript, 3);
+        let (rho_a, rho_b, rho_c) = (&rho[0], &rho[1], &rho[2]);
+
+        let inner_claimed_sum = rho_a * &proof.v_a + rho_b * &proof.v_b + rho_c * &proof.v_c;
+
+        // -----------------------------------------------------------------------
+        // Step 7: Verify inner sumcheck
+        // -----------------------------------------------------------------------
+        transcript.append_bytes(b"inner_sumcheck");
+
+        let (inner_ok, r_y) = verify_sumcheck_round_polys(
+            inner_claimed_sum,
+            &proof.inner_sumcheck_polys,
+            2, // max degree for quadratic sumcheck (2 factors)
+            &mut transcript,
+        )?;
+
+        if !inner_ok {
+            return Ok(false);
+        }
+
+        if r_y != proof.inner_challenges {
+            return Ok(false);
+        }
+
+        // -----------------------------------------------------------------------
+        // Step 8: Oracle check for inner sumcheck
+        //
+        // Compute the combined matrix evaluation at (r_x, r_y):
+        //   rho_a * A(r_x, r_y) + rho_b * B(r_x, r_y) + rho_c * C(r_x, r_y)
+        // Then check: combined_matrix_eval * z̃(r_y) = last inner poly eval at r_y[last]
+        // -----------------------------------------------------------------------
+        let a_eval = matrix_mle_eval(&r1cs.a, num_constraints_padded, num_cols_padded, &r_x, &r_y);
+        let b_eval = matrix_mle_eval(&r1cs.b, num_constraints_padded, num_cols_padded, &r_x, &r_y);
+        let c_eval = matrix_mle_eval(&r1cs.c, num_constraints_padded, num_cols_padded, &r_x, &r_y);
+
+        let combined_matrix_eval = rho_a * &a_eval + rho_b * &b_eval + rho_c * &c_eval;
+
+        let inner_oracle_eval = &combined_matrix_eval * &proof.witness_eval;
+
+        let last_inner_poly = proof.inner_sumcheck_polys.last().ok_or_else(|| {
+            SpartanError::VerificationFailed("Empty inner sumcheck polys".to_string())
+        })?;
+        let last_inner_challenge = r_y.last().ok_or_else(|| {
+            SpartanError::VerificationFailed("Empty inner challenges".to_string())
+        })?;
+        let last_inner_eval = last_inner_poly.evaluate(last_inner_challenge);
+
+        if last_inner_eval != inner_oracle_eval {
+            return Ok(false);
+        }
+
+        // Absorb witness_eval into transcript for composability (mirrors prover).
+        transcript.append_bytes(b"witness_eval");
+        transcript.append_field_element(&proof.witness_eval);
+
+        // -----------------------------------------------------------------------
+        // Step 9: Verify PCS opening
+        // -----------------------------------------------------------------------
+        let pcs_ok = self
+            .pcs
+            .verify(
+                &proof.witness_commitment,
+                &r_y,
+                &proof.witness_eval,
+                &proof.witness_proof,
+            )
+            .map_err(|e| SpartanError::PcsError(e.to_string()))?;
+
+        if !pcs_ok {
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+}
+
+/// Verifies the two-term (GKR-style) sumcheck round polynomials.
+///
+/// Uses the same transcript format as `run_two_term_sumcheck` in the prover.
+fn verify_two_term_sumcheck_round_polys<F>(
+    claimed_sum: FieldElement<F>,
+    round_polys: &[Polynomial<FieldElement<F>>],
+    max_degree: usize,
+    transcript: &mut DefaultTranscript<F>,
+) -> Result<(bool, Vec<FieldElement<F>>), SpartanError>
+where
+    F: IsField + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+{
+    let num_vars = round_polys.len();
+
+    // Append initial sum to transcript (same as prover)
+    transcript.append_bytes(b"initial_sum");
+    transcript.append_field_element(&FieldElement::from(num_vars as u64));
+    transcript.append_field_element(&FieldElement::from(1u64));
+    transcript.append_field_element(&claimed_sum);
+
+    let mut current_claim = claimed_sum;
+    let mut challenges = Vec::with_capacity(num_vars);
+
+    for (round, g_j) in round_polys.iter().enumerate() {
+        // Check degree bound
+        if g_j.degree() > max_degree {
+            return Ok((false, challenges));
+        }
+
+        // Check g_j(0) + g_j(1) == current_claim
+        let eval_0 = g_j.evaluate(&FieldElement::<F>::zero());
+        let eval_1 = g_j.evaluate(&FieldElement::<F>::one());
+        let sum_check = eval_0 + eval_1;
+
+        if sum_check != current_claim {
+            return Ok((false, challenges));
+        }
+
+        // Append to transcript (same GKR format as prover)
+        let round_label = format!("round_{round}_poly");
+        transcript.append_bytes(round_label.as_bytes());
+        let coeffs = g_j.coefficients();
+        transcript.append_bytes(&(coeffs.len() as u64).to_be_bytes());
+        if coeffs.is_empty() {
+            transcript.append_field_element(&FieldElement::zero());
+        } else {
+            for coeff in coeffs {
+                transcript.append_field_element(coeff);
+            }
+        }
+
+        let r = transcript.sample_field_element();
+
+        // Update claim for next round
+        current_claim = g_j.evaluate(&r);
+        challenges.push(r);
+    }
+
+    Ok((true, challenges))
+}
+
+/// Verifies sumcheck round polynomials using the external transcript.
+///
+/// Uses the standard round polynomial transcript format.
+fn verify_sumcheck_round_polys<F>(
+    mut claimed_sum: FieldElement<F>,
+    round_polys: &[Polynomial<FieldElement<F>>],
+    max_degree: usize,
+    transcript: &mut DefaultTranscript<F>,
+) -> Result<(bool, Vec<FieldElement<F>>), SpartanError>
+where
+    F: IsField + HasDefaultTranscript,
+    F::BaseType: Send + Sync,
+    FieldElement<F>: ByteConversion,
+{
+    let num_vars = round_polys.len();
+    let mut challenges = Vec::with_capacity(num_vars);
+
+    // Bind the claimed sum to the transcript before rounds (mirrors prover).
+    transcript.append_bytes(b"initial_sum");
+    transcript.append_field_element(&FieldElement::from(num_vars as u64));
+    transcript.append_field_element(&FieldElement::from(1u64));
+    transcript.append_field_element(&claimed_sum);
+
+    for (round, g_j) in round_polys.iter().enumerate() {
+        // Check degree bound
+        if g_j.degree() > max_degree {
+            return Ok((false, challenges));
+        }
+
+        // Check g_j(0) + g_j(1) == claimed_sum
+        let eval_0 = g_j.evaluate(&FieldElement::<F>::zero());
+        let eval_1 = g_j.evaluate(&FieldElement::<F>::one());
+        let sum_check = eval_0 + eval_1;
+
+        if sum_check != claimed_sum {
+            return Ok((false, challenges));
+        }
+
+        // Append to transcript and draw challenge (same format as prover)
+        append_round_poly_to_transcript(transcript, round, g_j);
+        let r = transcript.sample_field_element();
+
+        // Update claimed sum for next round
+        claimed_sum = g_j.evaluate(&r);
+        challenges.push(r);
+    }
+
+    Ok((true, challenges))
+}

--- a/crates/provers/spartan/src/verifier.rs
+++ b/crates/provers/spartan/src/verifier.rs
@@ -75,15 +75,7 @@ where
         // Step 2: Draw tau (same as prover)
         // -----------------------------------------------------------------------
         let num_constraints_padded = next_power_of_two(r1cs.num_constraints).max(2);
-        let log_constraints = {
-            let mut k = 0;
-            let mut n = num_constraints_padded;
-            while n > 1 {
-                k += 1;
-                n >>= 1;
-            }
-            k
-        };
+        let log_constraints = num_constraints_padded.trailing_zeros() as usize;
         let num_cols_padded = next_power_of_two(r1cs.num_variables).max(2);
 
         transcript.append_bytes(b"tau_challenge");
@@ -100,10 +92,11 @@ where
 
         let outer_claimed_sum = FieldElement::<F>::zero();
 
-        let (outer_ok, r_x) = verify_two_term_sumcheck_round_polys(
+        let (outer_ok, r_x) = verify_sumcheck_round_polys(
             outer_claimed_sum,
             &proof.outer_sumcheck_polys,
             3, // max degree for cubic sumcheck
+            2, // two-term product sumcheck
             &mut transcript,
         )?;
 
@@ -173,7 +166,8 @@ where
         let (inner_ok, r_y) = verify_sumcheck_round_polys(
             inner_claimed_sum,
             &proof.inner_sumcheck_polys,
-            2, // max degree for quadratic sumcheck (2 factors)
+            2, // max degree for quadratic sumcheck
+            2, // two-factor product
             &mut transcript,
         )?;
 
@@ -275,13 +269,16 @@ where
     }
 }
 
-/// Verifies the two-term (GKR-style) sumcheck round polynomials.
+/// Verifies sumcheck round polynomials against a claimed sum.
 ///
-/// Uses the same transcript format as `run_two_term_sumcheck` in the prover.
-fn verify_two_term_sumcheck_round_polys<F>(
+/// Checks degree bounds, the g(0)+g(1) consistency at each round, and replays
+/// the transcript to re-derive challenges. Used for both the outer (two-term,
+/// cubic) and inner (quadratic) sumchecks.
+fn verify_sumcheck_round_polys<F>(
     claimed_sum: FieldElement<F>,
     round_polys: &[Polynomial<FieldElement<F>>],
     max_degree: usize,
+    num_terms: u64,
     transcript: &mut DefaultTranscript<F>,
 ) -> Result<(bool, Vec<FieldElement<F>>), SpartanError>
 where
@@ -290,98 +287,30 @@ where
     FieldElement<F>: ByteConversion,
 {
     let num_vars = round_polys.len();
-
-    // Append initial sum to transcript (same as prover)
-    transcript.append_bytes(b"initial_sum");
-    transcript.append_field_element(&FieldElement::from(num_vars as u64));
-    transcript.append_field_element(&FieldElement::from(2u64)); // two-term product sumcheck
-    transcript.append_field_element(&claimed_sum);
-
     let mut current_claim = claimed_sum;
-    let mut challenges = Vec::with_capacity(num_vars);
 
-    for (round, g_j) in round_polys.iter().enumerate() {
-        // Check degree bound
-        if g_j.degree() > max_degree {
-            return Ok((false, challenges));
-        }
-
-        // Check g_j(0) + g_j(1) == current_claim
-        let eval_0 = g_j.evaluate(&FieldElement::<F>::zero());
-        let eval_1 = g_j.evaluate(&FieldElement::<F>::one());
-        let sum_check = eval_0 + eval_1;
-
-        if sum_check != current_claim {
-            return Ok((false, challenges));
-        }
-
-        // Append to transcript (same GKR format as prover)
-        let round_label = format!("round_{round}_poly");
-        transcript.append_bytes(round_label.as_bytes());
-        let coeffs = g_j.coefficients();
-        transcript.append_bytes(&(coeffs.len() as u64).to_be_bytes());
-        if coeffs.is_empty() {
-            transcript.append_field_element(&FieldElement::zero());
-        } else {
-            for coeff in coeffs {
-                transcript.append_field_element(coeff);
-            }
-        }
-
-        let r = transcript.sample_field_element();
-
-        // Update claim for next round
-        current_claim = g_j.evaluate(&r);
-        challenges.push(r);
-    }
-
-    Ok((true, challenges))
-}
-
-/// Verifies sumcheck round polynomials using the external transcript.
-///
-/// Uses the standard round polynomial transcript format.
-fn verify_sumcheck_round_polys<F>(
-    mut claimed_sum: FieldElement<F>,
-    round_polys: &[Polynomial<FieldElement<F>>],
-    max_degree: usize,
-    transcript: &mut DefaultTranscript<F>,
-) -> Result<(bool, Vec<FieldElement<F>>), SpartanError>
-where
-    F: IsField + HasDefaultTranscript,
-    F::BaseType: Send + Sync,
-    FieldElement<F>: ByteConversion,
-{
-    let num_vars = round_polys.len();
-    let mut challenges = Vec::with_capacity(num_vars);
-
-    // Bind the claimed sum to the transcript before rounds (mirrors prover).
     transcript.append_bytes(b"initial_sum");
     transcript.append_field_element(&FieldElement::from(num_vars as u64));
-    transcript.append_field_element(&FieldElement::from(2u64)); // quadratic (2-factor) sumcheck
-    transcript.append_field_element(&claimed_sum);
+    transcript.append_field_element(&FieldElement::from(num_terms));
+    transcript.append_field_element(&current_claim);
+
+    let mut challenges = Vec::with_capacity(num_vars);
 
     for (round, g_j) in round_polys.iter().enumerate() {
-        // Check degree bound
         if g_j.degree() > max_degree {
             return Ok((false, challenges));
         }
 
-        // Check g_j(0) + g_j(1) == claimed_sum
-        let eval_0 = g_j.evaluate(&FieldElement::<F>::zero());
-        let eval_1 = g_j.evaluate(&FieldElement::<F>::one());
-        let sum_check = eval_0 + eval_1;
+        let sum =
+            g_j.evaluate(&FieldElement::<F>::zero()) + g_j.evaluate(&FieldElement::<F>::one());
 
-        if sum_check != claimed_sum {
+        if sum != current_claim {
             return Ok((false, challenges));
         }
 
-        // Append to transcript and draw challenge (same format as prover)
         append_round_poly_to_transcript(transcript, round, g_j);
         let r = transcript.sample_field_element();
-
-        // Update claimed sum for next round
-        claimed_sum = g_j.evaluate(&r);
+        current_claim = g_j.evaluate(&r);
         challenges.push(r);
     }
 

--- a/crates/provers/spartan/src/verifier.rs
+++ b/crates/provers/spartan/src/verifier.rs
@@ -15,7 +15,7 @@ use lambdaworks_math::polynomial::Polynomial;
 use lambdaworks_math::traits::ByteConversion;
 
 use crate::errors::SpartanError;
-use crate::mle::{eq_poly, index_to_multilinear_point, matrix_mle_eval, next_power_of_two};
+use crate::mle::{batch_matrix_mle_eval, eq_poly, index_to_multilinear_point, next_power_of_two};
 use crate::pcs::IsMultilinearPCS;
 use crate::prover::SpartanProof;
 use crate::r1cs::R1CS;
@@ -186,9 +186,11 @@ where
         //   rho_a * A(r_x, r_y) + rho_b * B(r_x, r_y) + rho_c * C(r_x, r_y)
         // Then check: combined_matrix_eval * z̃(r_y) = last inner poly eval at r_y[last]
         // -----------------------------------------------------------------------
-        let a_eval = matrix_mle_eval(&r1cs.a, num_constraints_padded, num_cols_padded, &r_x, &r_y);
-        let b_eval = matrix_mle_eval(&r1cs.b, num_constraints_padded, num_cols_padded, &r_x, &r_y);
-        let c_eval = matrix_mle_eval(&r1cs.c, num_constraints_padded, num_cols_padded, &r_x, &r_y);
+        let (a_eval, b_eval, c_eval) = batch_matrix_mle_eval(
+            &r1cs.a, &r1cs.b, &r1cs.c,
+            num_constraints_padded, num_cols_padded,
+            &r_x, &r_y,
+        );
 
         let combined_matrix_eval = rho_a * &a_eval + rho_b * &b_eval + rho_c * &c_eval;
 

--- a/crates/provers/spartan/src/verifier.rs
+++ b/crates/provers/spartan/src/verifier.rs
@@ -212,9 +212,9 @@ where
             return Ok(false);
         }
 
-        // Absorb witness_eval into transcript for composability (mirrors prover).
-        transcript.append_bytes(b"witness_eval");
-        transcript.append_field_element(&proof.witness_eval);
+        // Note: witness_eval is NOT absorbed into the transcript because no further
+        // Fiat-Shamir challenges are drawn after this point. The PCS opening proof
+        // binds witness_eval cryptographically.
 
         // -----------------------------------------------------------------------
         // Step 9: Verify PCS opening of z̃ at r_y
@@ -268,6 +268,27 @@ where
             }
         }
 
+        // -----------------------------------------------------------------------
+        // Step 11: Verify z̃(0,...,0) = 1 (R1CS constant term).
+        //
+        // The R1CS convention requires z[0] = 1. Without this check, a malicious
+        // prover could set z[0] to any value.
+        // -----------------------------------------------------------------------
+        let zero_point = vec![FieldElement::<F>::zero(); n_witness_vars];
+        let constant_ok = self
+            .pcs
+            .verify(
+                &proof.witness_commitment,
+                &zero_point,
+                &FieldElement::one(),
+                &proof.constant_proof,
+            )
+            .map_err(|e| SpartanError::PcsError(e.to_string()))?;
+
+        if !constant_ok {
+            return Ok(false);
+        }
+
         Ok(true)
     }
 }
@@ -291,7 +312,7 @@ where
     // Append initial sum to transcript (same as prover)
     transcript.append_bytes(b"initial_sum");
     transcript.append_field_element(&FieldElement::from(num_vars as u64));
-    transcript.append_field_element(&FieldElement::from(1u64));
+    transcript.append_field_element(&FieldElement::from(2u64)); // two-term product sumcheck
     transcript.append_field_element(&claimed_sum);
 
     let mut current_claim = claimed_sum;
@@ -355,7 +376,7 @@ where
     // Bind the claimed sum to the transcript before rounds (mirrors prover).
     transcript.append_bytes(b"initial_sum");
     transcript.append_field_element(&FieldElement::from(num_vars as u64));
-    transcript.append_field_element(&FieldElement::from(1u64));
+    transcript.append_field_element(&FieldElement::from(2u64)); // quadratic (2-factor) sumcheck
     transcript.append_field_element(&claimed_sum);
 
     for (round, g_j) in round_polys.iter().enumerate() {

--- a/crates/provers/spartan/src/verifier.rs
+++ b/crates/provers/spartan/src/verifier.rs
@@ -187,9 +187,13 @@ where
         // Then check: combined_matrix_eval * z̃(r_y) = last inner poly eval at r_y[last]
         // -----------------------------------------------------------------------
         let (a_eval, b_eval, c_eval) = batch_matrix_mle_eval(
-            &r1cs.a, &r1cs.b, &r1cs.c,
-            num_constraints_padded, num_cols_padded,
-            &r_x, &r_y,
+            &r1cs.a,
+            &r1cs.b,
+            &r1cs.c,
+            num_constraints_padded,
+            num_cols_padded,
+            &r_x,
+            &r_y,
         );
 
         let combined_matrix_eval = rho_a * &a_eval + rho_b * &b_eval + rho_c * &c_eval;

--- a/crates/provers/spartan/src/verifier.rs
+++ b/crates/provers/spartan/src/verifier.rs
@@ -234,59 +234,41 @@ where
         }
 
         // -----------------------------------------------------------------------
-        // Step 10: Verify public input consistency.
+        // Step 10: Verify public input consistency (including constant z[0] = 1).
         //
-        // Each proof entry (point, pi_proof) asserts z̃(point) == public_inputs[i-1].
-        // Without this step a malicious prover can commit to a witness that
-        // disagrees with the claimed public inputs while all sumcheck checks pass.
+        // z = (1, x_1, ..., x_l, w_1, ...) so the public part is (1, x_1, ..., x_l).
+        // The proof contains openings at boolean points for indices 0..=l:
+        //   index 0: z̃(bits(0)) = 1 (R1CS constant)
+        //   index i: z̃(bits(i)) = public_inputs[i-1] for i in 1..=l
         // -----------------------------------------------------------------------
-        if proof.public_input_proofs.len() != public_inputs.len() {
+        let expected_public: Vec<FieldElement<F>> = core::iter::once(FieldElement::one())
+            .chain(public_inputs.iter().cloned())
+            .collect();
+
+        if proof.public_input_proofs.len() != expected_public.len() {
             return Ok(false);
         }
 
-        // num_cols_padded is already computed above; derive the witness variable count.
         let n_witness_vars = num_cols_padded.trailing_zeros() as usize;
 
-        for (i, (pi, (point, pi_proof))) in public_inputs
+        for (i, (expected_val, (point, pi_proof))) in expected_public
             .iter()
             .zip(proof.public_input_proofs.iter())
             .enumerate()
         {
-            // Verify the evaluation point matches the expected boolean point for index i+1.
-            let expected_point = index_to_multilinear_point::<F>(i + 1, n_witness_vars);
+            let expected_point = index_to_multilinear_point::<F>(i, n_witness_vars);
             if *point != expected_point {
                 return Ok(false);
             }
 
             let pi_ok = self
                 .pcs
-                .verify(&proof.witness_commitment, point, pi, pi_proof)
+                .verify(&proof.witness_commitment, point, expected_val, pi_proof)
                 .map_err(|e| SpartanError::PcsError(e.to_string()))?;
 
             if !pi_ok {
                 return Ok(false);
             }
-        }
-
-        // -----------------------------------------------------------------------
-        // Step 11: Verify z̃(0,...,0) = 1 (R1CS constant term).
-        //
-        // The R1CS convention requires z[0] = 1. Without this check, a malicious
-        // prover could set z[0] to any value.
-        // -----------------------------------------------------------------------
-        let zero_point = vec![FieldElement::<F>::zero(); n_witness_vars];
-        let constant_ok = self
-            .pcs
-            .verify(
-                &proof.witness_commitment,
-                &zero_point,
-                &FieldElement::one(),
-                &proof.constant_proof,
-            )
-            .map_err(|e| SpartanError::PcsError(e.to_string()))?;
-
-        if !constant_ok {
-            return Ok(false);
         }
 
         Ok(true)


### PR DESCRIPTION
# Add spartan zkSNARK with Zeromorph PCS

## Description

[Spartan](https://eprint.iacr.org/2019/550) is a zkSNARK that proves R1CS satisfiability using two rounds of the Sumcheck Protocol and a multilinear PCS, with $O(n)$ prover work and no per-circuit trusted setup. 

This PR adds a full implementation of Spartan with a [Zeromorph](https://eprint.iacr.org/2023/917) PCS backend backed by BLS12-381 KZG. You can find this implementation in `crates/provers/spartan`.

### Protocol:
  1. Prover draws $\tau$ from transcript and runs an outer sumcheck on $\sum_x \widetilde{eq}(\tau,x)(v_A v_B - v_C) = 0$.
  2. Prover batches $\tilde{A}, \tilde{B}, \tilde{C}$ with random scalars and runs an inner sumcheck reducing to a single witness evaluation $\tilde{z}(r_y)$.
  3. Prover opens $\tilde{z}$ at $r_y$ using Zeromorph, which commits the witness as a univariate KZG polynomial and produces quotient commitments for each variable.

### How to Test

`cargo test -p lambdaworks-spartan`

## Type of change
- [x] New feature
