### PR TITLE
Make Mersenne31 as_canonical branchless

### DIFF
--- a/crates/math/src/field/fields/mersenne31/field.rs
+++ b/crates/math/src/field/fields/mersenne31/field.rs
@@ -33,11 +33,10 @@ impl Mersenne31Field {
 
     #[inline(always)]
     fn as_canonical(n: &u32) -> u32 {
-        if *n == MERSENNE_31_PRIME_FIELD_ORDER {
-            0
-        } else {
-            *n
-        }
+        // Branchless canonicalization. The only non-canonical value is p (representing 0).
+        // n + 1 overflows into bit 31 iff n == p, giving is_p = 1.
+        let is_p = n.wrapping_add(1) >> 31;
+        n & is_p.wrapping_sub(1)
     }
 
     #[inline]

--- a/crates/math/src/field/fields/mersenne31/field.rs
+++ b/crates/math/src/field/fields/mersenne31/field.rs
@@ -525,6 +525,11 @@ mod tests {
     }
 
     #[test]
+    fn canonical_of_prime_is_zero() {
+        assert_eq!(F::canonical(&MERSENNE_31_PRIME_FIELD_ORDER), 0u32);
+    }
+
+    #[test]
     fn mul_by_inv() {
         let x = 3476715743_u32;
         assert_eq!(FE::from(&x).inv().unwrap() * FE::from(&x), FE::one());


### PR DESCRIPTION
# Make Mersenne31 as_canonical branchless

## Description

Replace the branch on n == p with arithmetic: (n + 1) >> 31 detects the sole non-canonical value (p itself), and a wrapping mask zeros it without a branch.

Closes #1031

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [X] Optimization

## Checklist
- [X] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [X] This change is an Optimization
  - [ ] Benchmarks added/run
