### PR TITLE
Change IsPairing::compute_batch to accept owned point pairs

### DIFF
--- a/crates/crypto/src/commitments/kzg.rs
+++ b/crates/crypto/src/commitments/kzg.rs
@@ -197,12 +197,12 @@ impl<const N: usize, F: IsPrimeField<CanonicalType = UnsignedInteger<N>>, P: IsP
 
         let e = P::compute_batch(&[
             (
-                &p_commitment.operate_with(&(g1.operate_with_self(y.canonical())).neg()),
-                g2,
+                p_commitment.operate_with(&(g1.operate_with_self(y.canonical())).neg()),
+                g2.clone(),
             ),
             (
-                &proof.neg(),
-                &(alpha_g2.operate_with(&(g2.operate_with_self(x.canonical())).neg())),
+                proof.neg(),
+                alpha_g2.operate_with(&(g2.operate_with_self(x.canonical())).neg()),
             ),
         ]);
         e == Ok(FieldElement::one())

--- a/crates/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
+++ b/crates/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
@@ -7,6 +7,7 @@ use super::{
     twist::BLS12377TwistCurve,
 };
 use crate::{cyclic_group::IsGroup, elliptic_curve::traits::IsPairing, errors::PairingError};
+use core::borrow::Borrow;
 
 use crate::{
     elliptic_curve::short_weierstrass::{
@@ -106,10 +107,12 @@ impl IsPairing for BLS12377AtePairing {
 
     /// Compute the product of the ate pairings for a list of point pairs.
     fn compute_batch(
-        pairs: &[(Self::G1Point, Self::G2Point)],
+        pairs: &[(impl Borrow<Self::G1Point>, impl Borrow<Self::G2Point>)],
     ) -> Result<FieldElement<Self::OutputField>, PairingError> {
         let mut result = FieldElement::one();
         for (p, q) in pairs {
+            let p = p.borrow();
+            let q = q.borrow();
             if !p.is_in_subgroup() || !q.is_in_subgroup() {
                 return Err(PairingError::PointNotInSubgroup);
             }
@@ -556,12 +559,12 @@ mod tests {
     fn ate_pairing_returns_one_when_one_element_is_the_neutral_element() {
         let p = BLS12377Curve::generator().to_affine();
         let q = ShortWeierstrassProjectivePoint::neutral_element();
-        let result = BLS12377AtePairing::compute_batch(&[(p.to_affine().clone(), q.clone())]).unwrap();
+        let result = BLS12377AtePairing::compute_batch(&[(p.to_affine(), q.clone())]).unwrap();
         assert_eq!(result, FieldElement::one());
 
         let p = ShortWeierstrassProjectivePoint::neutral_element();
         let q = BLS12377TwistCurve::generator();
-        let result = BLS12377AtePairing::compute_batch(&[(p.clone(), q.to_affine().clone())]).unwrap();
+        let result = BLS12377AtePairing::compute_batch(&[(p.clone(), q.to_affine())]).unwrap();
         assert_eq!(result, FieldElement::one());
     }
 
@@ -576,7 +579,7 @@ mod tests {
         ])
         .unwrap();
         let q = ShortWeierstrassProjectivePoint::neutral_element();
-        let result = BLS12377AtePairing::compute_batch(&[(p.to_affine().clone(), q.clone())]);
+        let result = BLS12377AtePairing::compute_batch(&[(p.to_affine(), q.clone())]);
         assert!(result.is_err())
     }
 

--- a/crates/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
+++ b/crates/math/src/elliptic_curve/short_weierstrass/curves/bls12_377/pairing.rs
@@ -106,7 +106,7 @@ impl IsPairing for BLS12377AtePairing {
 
     /// Compute the product of the ate pairings for a list of point pairs.
     fn compute_batch(
-        pairs: &[(&Self::G1Point, &Self::G2Point)],
+        pairs: &[(Self::G1Point, Self::G2Point)],
     ) -> Result<FieldElement<Self::OutputField>, PairingError> {
         let mut result = FieldElement::one();
         for (p, q) in pairs {
@@ -540,12 +540,12 @@ mod tests {
 
         let result = BLS12377AtePairing::compute_batch(&[
             (
-                &p.operate_with_self(a).to_affine(),
-                &q.operate_with_self(b).to_affine(),
+                p.operate_with_self(a).to_affine(),
+                q.operate_with_self(b).to_affine(),
             ),
             (
-                &p.operate_with_self(a * b).to_affine(),
-                &q.neg().to_affine(),
+                p.operate_with_self(a * b).to_affine(),
+                q.neg().to_affine(),
             ),
         ])
         .unwrap();
@@ -556,12 +556,12 @@ mod tests {
     fn ate_pairing_returns_one_when_one_element_is_the_neutral_element() {
         let p = BLS12377Curve::generator().to_affine();
         let q = ShortWeierstrassProjectivePoint::neutral_element();
-        let result = BLS12377AtePairing::compute_batch(&[(&p.to_affine(), &q)]).unwrap();
+        let result = BLS12377AtePairing::compute_batch(&[(p.to_affine().clone(), q.clone())]).unwrap();
         assert_eq!(result, FieldElement::one());
 
         let p = ShortWeierstrassProjectivePoint::neutral_element();
         let q = BLS12377TwistCurve::generator();
-        let result = BLS12377AtePairing::compute_batch(&[(&p, &q.to_affine())]).unwrap();
+        let result = BLS12377AtePairing::compute_batch(&[(p.clone(), q.to_affine().clone())]).unwrap();
         assert_eq!(result, FieldElement::one());
     }
 
@@ -576,7 +576,7 @@ mod tests {
         ])
         .unwrap();
         let q = ShortWeierstrassProjectivePoint::neutral_element();
-        let result = BLS12377AtePairing::compute_batch(&[(&p.to_affine(), &q)]);
+        let result = BLS12377AtePairing::compute_batch(&[(p.to_affine().clone(), q.clone())]);
         assert!(result.is_err())
     }
 

--- a/crates/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/fuzz_tests.rs
+++ b/crates/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/fuzz_tests.rs
@@ -117,11 +117,11 @@ proptest! {
         let lw_ap = lw_p.operate_with_self(a).to_affine();
         let lw_bq = lw_q.operate_with_self(b).to_affine();
 
-        let lw_result = BLS12381AtePairing::compute_batch(&[(&lw_ap, &lw_bq)])
+        let lw_result = BLS12381AtePairing::compute_batch(&[(lw_ap.clone(), lw_bq.clone())])
             .expect("pairing should not fail for valid subgroup points");
 
         let lw_base = BLS12381AtePairing::compute_batch(&[
-            (&lw_p.to_affine(), &lw_q.to_affine()),
+            (lw_p.to_affine(), lw_q.to_affine()),
         ]).expect("pairing should not fail for generator points");
 
         let lw_base_ab = lw_base.pow(a * b);
@@ -133,7 +133,7 @@ proptest! {
         // Test that e(sP, Q) matches between lambdaworks and arkworks
         let lw_p = BLS12381Curve::generator().operate_with_self(s).to_affine();
         let lw_q = BLS12381TwistCurve::generator().to_affine();
-        let lw_result = BLS12381AtePairing::compute_batch(&[(&lw_p, &lw_q)])
+        let lw_result = BLS12381AtePairing::compute_batch(&[(lw_p.clone(), lw_q.clone())])
             .expect("pairing should not fail for valid subgroup points");
 
         let ark_p = (ArkG1::generator() * <ark_bls12_381::Fr as From<u64>>::from(s)).into_affine();

--- a/crates/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/crates/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -6,6 +6,7 @@ use super::{
     twist::BLS12381TwistCurve,
 };
 use crate::{cyclic_group::IsGroup, elliptic_curve::traits::IsPairing, errors::PairingError};
+use core::borrow::Borrow;
 use crate::{
     elliptic_curve::short_weierstrass::{
         curves::bls12_381::field_extension::Degree6ExtensionField,
@@ -267,11 +268,13 @@ impl IsPairing for BLS12381AtePairing {
     /// exponentiation. Without `parallel`, uses a shared-square multi-Miller
     /// loop that saves (n-1)×63 Fp12 squares.
     fn compute_batch(
-        pairs: &[(Self::G1Point, Self::G2Point)],
+        pairs: &[(impl Borrow<Self::G1Point>, impl Borrow<Self::G2Point>)],
     ) -> Result<FieldElement<Self::OutputField>, PairingError> {
         // Validate subgroup membership and filter neutral elements
         let mut valid_pairs = Vec::with_capacity(pairs.len());
         for (p, q) in pairs {
+            let p = p.borrow();
+            let q = q.borrow();
             if !p.is_in_subgroup() || !q.is_in_subgroup() {
                 return Err(PairingError::PointNotInSubgroup);
             }
@@ -1147,12 +1150,12 @@ mod tests {
     fn ate_pairing_returns_one_when_one_element_is_the_neutral_element() {
         let p = BLS12381Curve::generator().to_affine();
         let q = ShortWeierstrassJacobianPoint::neutral_element();
-        let result = BLS12381AtePairing::compute_batch(&[(p.to_affine().clone(), q.clone())]).unwrap();
+        let result = BLS12381AtePairing::compute_batch(&[(p.to_affine(), q.clone())]).unwrap();
         assert_eq!(result, FieldElement::one());
 
         let p = ShortWeierstrassJacobianPoint::neutral_element();
         let q = BLS12381TwistCurve::generator();
-        let result = BLS12381AtePairing::compute_batch(&[(p.clone(), q.to_affine().clone())]).unwrap();
+        let result = BLS12381AtePairing::compute_batch(&[(p.clone(), q.to_affine())]).unwrap();
         assert_eq!(result, FieldElement::one());
     }
 
@@ -1167,7 +1170,7 @@ mod tests {
         ])
         .unwrap();
         let q = ShortWeierstrassJacobianPoint::neutral_element();
-        let result = BLS12381AtePairing::compute_batch(&[(p.to_affine().clone(), q.clone())]);
+        let result = BLS12381AtePairing::compute_batch(&[(p.to_affine(), q.clone())]);
         assert!(result.is_err())
     }
 

--- a/crates/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
+++ b/crates/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/pairing.rs
@@ -267,7 +267,7 @@ impl IsPairing for BLS12381AtePairing {
     /// exponentiation. Without `parallel`, uses a shared-square multi-Miller
     /// loop that saves (n-1)×63 Fp12 squares.
     fn compute_batch(
-        pairs: &[(&Self::G1Point, &Self::G2Point)],
+        pairs: &[(Self::G1Point, Self::G2Point)],
     ) -> Result<FieldElement<Self::OutputField>, PairingError> {
         // Validate subgroup membership and filter neutral elements
         let mut valid_pairs = Vec::with_capacity(pairs.len());
@@ -1131,12 +1131,12 @@ mod tests {
 
         let result = BLS12381AtePairing::compute_batch(&[
             (
-                &p.operate_with_self(a).to_affine(),
-                &q.operate_with_self(b).to_affine(),
+                p.operate_with_self(a).to_affine(),
+                q.operate_with_self(b).to_affine(),
             ),
             (
-                &p.operate_with_self(a * b).to_affine(),
-                &q.neg().to_affine(),
+                p.operate_with_self(a * b).to_affine(),
+                q.neg().to_affine(),
             ),
         ])
         .unwrap();
@@ -1147,12 +1147,12 @@ mod tests {
     fn ate_pairing_returns_one_when_one_element_is_the_neutral_element() {
         let p = BLS12381Curve::generator().to_affine();
         let q = ShortWeierstrassJacobianPoint::neutral_element();
-        let result = BLS12381AtePairing::compute_batch(&[(&p.to_affine(), &q)]).unwrap();
+        let result = BLS12381AtePairing::compute_batch(&[(p.to_affine().clone(), q.clone())]).unwrap();
         assert_eq!(result, FieldElement::one());
 
         let p = ShortWeierstrassJacobianPoint::neutral_element();
         let q = BLS12381TwistCurve::generator();
-        let result = BLS12381AtePairing::compute_batch(&[(&p, &q.to_affine())]).unwrap();
+        let result = BLS12381AtePairing::compute_batch(&[(p.clone(), q.to_affine().clone())]).unwrap();
         assert_eq!(result, FieldElement::one());
     }
 
@@ -1167,7 +1167,7 @@ mod tests {
         ])
         .unwrap();
         let q = ShortWeierstrassJacobianPoint::neutral_element();
-        let result = BLS12381AtePairing::compute_batch(&[(&p.to_affine(), &q)]);
+        let result = BLS12381AtePairing::compute_batch(&[(p.to_affine().clone(), q.clone())]);
         assert!(result.is_err())
     }
 

--- a/crates/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
+++ b/crates/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
@@ -157,7 +157,7 @@ impl IsPairing for BN254AtePairing {
     /// Computes the product of the ate pairing for a list of point pairs.
     /// Uses multi-Miller loop optimization: shares squarings across all pairs.
     fn compute_batch(
-        pairs: &[(&Self::G1Point, &Self::G2Point)],
+        pairs: &[(Self::G1Point, Self::G2Point)],
     ) -> Result<FieldElement<Self::OutputField>, PairingError> {
         // Validate and prepare pairs
         let mut valid_pairs: Vec<(G1Point, G2Point)> = Vec::new();
@@ -188,7 +188,7 @@ impl IsPairing for BN254AtePairing {
 
     /// Computes the product of the ate pairing for a list of point pairs.
     fn compute_batch(
-        pairs: &[(&Self::G1Point, &Self::G2Point)],
+        pairs: &[(Self::G1Point, Self::G2Point)],
     ) -> Result<FieldElement<Self::OutputField>, PairingError> {
         let mut result = Fp12E::one();
         for (p, q) in pairs {
@@ -692,39 +692,39 @@ mod tests {
         let b = U384::from_u64(93);
 
         let result_1 = BN254AtePairing::compute_batch(&[
-            (&p.operate_with_self(a), &q.operate_with_self(b)),
-            (&p.operate_with_self(a * b), &q.neg()),
+            (p.operate_with_self(a), q.operate_with_self(b)),
+            (p.operate_with_self(a * b), q.neg()),
         ])
         .unwrap();
         assert_eq!(result_1, Fp12E::one());
 
         let result_2 = BN254AtePairing::compute_batch(&[
-            (&p.operate_with_self(a), &q.operate_with_self(b)),
-            (&p.neg(), &q.operate_with_self(a * b)),
+            (p.operate_with_self(a), q.operate_with_self(b)),
+            (p.neg(), q.operate_with_self(a * b)),
         ])
         .unwrap();
         assert_eq!(result_2, Fp12E::one());
 
         let result_3 = BN254AtePairing::compute_batch(&[
-            (&p.operate_with_self(a), &q.operate_with_self(b)),
-            (&p.operate_with_self(b), &q.operate_with_self(a).neg()),
+            (p.operate_with_self(a), q.operate_with_self(b)),
+            (p.operate_with_self(b), q.operate_with_self(a).neg()),
         ])
         .unwrap();
         assert_eq!(result_3, Fp12E::one());
 
         let result_4 = BN254AtePairing::compute_batch(&[
-            (&p.operate_with_self(a), &q.operate_with_self(b).neg()),
-            (&p.operate_with_self(b), &q),
-            (&p.operate_with_self(b), &q),
-            (&p.operate_with_self(b), &q),
-            (&p.operate_with_self(b), &q),
-            (&p.operate_with_self(b), &q),
-            (&p.operate_with_self(b), &q),
-            (&p.operate_with_self(b), &q),
-            (&p.operate_with_self(b), &q),
-            (&p.operate_with_self(b), &q),
-            (&p.operate_with_self(b), &q),
-            (&p.operate_with_self(b), &q),
+            (p.operate_with_self(a), q.operate_with_self(b).neg()),
+            (p.operate_with_self(b), q.clone()),
+            (p.operate_with_self(b), q.clone()),
+            (p.operate_with_self(b), q.clone()),
+            (p.operate_with_self(b), q.clone()),
+            (p.operate_with_self(b), q.clone()),
+            (p.operate_with_self(b), q.clone()),
+            (p.operate_with_self(b), q.clone()),
+            (p.operate_with_self(b), q.clone()),
+            (p.operate_with_self(b), q.clone()),
+            (p.operate_with_self(b), q.clone()),
+            (p.operate_with_self(b), q.clone()),
         ])
         .unwrap();
         assert_eq!(result_4, Fp12E::one());
@@ -734,15 +734,15 @@ mod tests {
     fn ate_pairing_returns_one_when_one_element_is_the_neutral_element() {
         let p1 = BN254Curve::generator();
         let q1 = G2Point::neutral_element();
-        let result_1 = BN254AtePairing::compute_batch(&[(&p1, &q1)]).unwrap();
+        let result_1 = BN254AtePairing::compute_batch(&[(p1.clone(), q1.clone())]).unwrap();
         assert_eq!(result_1, Fp12E::one());
 
         let p2 = G1Point::neutral_element();
         let q2 = BN254TwistCurve::generator();
-        let result_2 = BN254AtePairing::compute_batch(&[(&p2, &q2)]).unwrap();
+        let result_2 = BN254AtePairing::compute_batch(&[(p2.clone(), q2.clone())]).unwrap();
         assert_eq!(result_2, Fp12E::one());
 
-        let result_3 = BN254AtePairing::compute_batch(&[(&p2, &q1)]).unwrap();
+        let result_3 = BN254AtePairing::compute_batch(&[(p2.clone(), q1.clone())]).unwrap();
         assert_eq!(result_3, Fp12E::one());
     }
 
@@ -769,7 +769,7 @@ mod tests {
             Fp2E::one(),
         ])
         .unwrap();
-        let result = BN254AtePairing::compute_batch(&[(&p, &q)]);
+        let result = BN254AtePairing::compute_batch(&[(p.clone(), q.clone())]);
         assert!(result.is_err())
     }
 
@@ -871,7 +871,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = BN254AtePairing::compute_batch(&[(&p1, &q1), (&p2, &q2)]).unwrap();
+        let result = BN254AtePairing::compute_batch(&[(p1.clone(), q1.clone()), (p2.clone(), q2.clone())]).unwrap();
 
         assert_eq!(result, Fp12E::one());
     }
@@ -938,7 +938,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = BN254AtePairing::compute_batch(&[(&p1, &q1), (&p2, &q2)]).unwrap();
+        let result = BN254AtePairing::compute_batch(&[(p1.clone(), q1.clone()), (p2.clone(), q2.clone())]).unwrap();
         assert_eq!(result, Fp12E::one());
     }
 
@@ -1004,7 +1004,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = BN254AtePairing::compute_batch(&[(&p1, &q1), (&p2, &q2)]).unwrap();
+        let result = BN254AtePairing::compute_batch(&[(p1.clone(), q1.clone()), (p2.clone(), q2.clone())]).unwrap();
         assert!(result != Fp12E::one());
     }
 
@@ -1100,7 +1100,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = BN254AtePairing::compute_batch(&[(&p1, &q1), (&p2, &q2), (&p3, &q3)]).unwrap();
+        let result = BN254AtePairing::compute_batch(&[(p1.clone(), q1.clone()), (p2.clone(), q2.clone()), (p3.clone(), q3.clone())]).unwrap();
         assert!(result != Fp12E::one());
     }
 
@@ -1112,7 +1112,7 @@ mod tests {
     fn pairing_result_pow_r_is_one() {
         let p = BN254Curve::generator();
         let q = BN254TwistCurve::generator();
-        let pairing_result = BN254AtePairing::compute_batch(&[(&p, &q)]).unwrap();
+        let pairing_result = BN254AtePairing::compute_batch(&[(p.clone(), q.clone())]).unwrap();
         assert_eq!(pairing_result.pow(R), Fp12E::one());
     }
 
@@ -1120,7 +1120,7 @@ mod tests {
     fn pairing_is_non_degenerate() {
         let p = BN254Curve::generator();
         let q = BN254TwistCurve::generator();
-        let pairing_result = BN254AtePairing::compute_batch(&[(&p, &q)]).unwrap();
+        let pairing_result = BN254AtePairing::compute_batch(&[(p.clone(), q.clone())]).unwrap();
         assert_ne!(pairing_result, Fp12E::one());
     }
 

--- a/crates/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
+++ b/crates/math/src/elliptic_curve/short_weierstrass/curves/bn_254/pairing.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     errors::PairingError,
 };
+use core::borrow::Borrow;
 use crate::{
     elliptic_curve::short_weierstrass::{
         curves::bn_254::field_extension::Degree6ExtensionField,
@@ -157,11 +158,13 @@ impl IsPairing for BN254AtePairing {
     /// Computes the product of the ate pairing for a list of point pairs.
     /// Uses multi-Miller loop optimization: shares squarings across all pairs.
     fn compute_batch(
-        pairs: &[(Self::G1Point, Self::G2Point)],
+        pairs: &[(impl Borrow<Self::G1Point>, impl Borrow<Self::G2Point>)],
     ) -> Result<FieldElement<Self::OutputField>, PairingError> {
         // Validate and prepare pairs
         let mut valid_pairs: Vec<(G1Point, G2Point)> = Vec::new();
         for (p, q) in pairs {
+            let p = p.borrow();
+            let q = q.borrow();
             if !q.is_in_subgroup() {
                 return Err(PairingError::PointNotInSubgroup);
             }
@@ -188,10 +191,12 @@ impl IsPairing for BN254AtePairing {
 
     /// Computes the product of the ate pairing for a list of point pairs.
     fn compute_batch(
-        pairs: &[(Self::G1Point, Self::G2Point)],
+        pairs: &[(impl Borrow<Self::G1Point>, impl Borrow<Self::G2Point>)],
     ) -> Result<FieldElement<Self::OutputField>, PairingError> {
         let mut result = Fp12E::one();
         for (p, q) in pairs {
+            let p = p.borrow();
+            let q = q.borrow();
             if !q.is_in_subgroup() {
                 return Err(PairingError::PointNotInSubgroup);
             }

--- a/crates/math/src/elliptic_curve/traits.rs
+++ b/crates/math/src/elliptic_curve/traits.rs
@@ -60,7 +60,7 @@ pub trait IsPairing {
     /// Compute the product of the pairings for a list of point pairs.
     /// More efficient than just calling the pairing for each pair of points individually
     fn compute_batch(
-        pairs: &[(&Self::G1Point, &Self::G2Point)],
+        pairs: &[(Self::G1Point, Self::G2Point)],
     ) -> Result<FieldElement<Self::OutputField>, PairingError>;
 
     /// Compute the ate pairing between point `p` in G1 and `q` in G2.
@@ -68,6 +68,6 @@ pub trait IsPairing {
         p: &Self::G1Point,
         q: &Self::G2Point,
     ) -> Result<FieldElement<Self::OutputField>, PairingError> {
-        Self::compute_batch(&[(p, q)])
+        Self::compute_batch(&[(p.clone(), q.clone())])
     }
 }

--- a/crates/math/src/elliptic_curve/traits.rs
+++ b/crates/math/src/elliptic_curve/traits.rs
@@ -3,6 +3,7 @@ use crate::{
     errors::PairingError,
     field::{element::FieldElement, traits::IsField},
 };
+use core::borrow::Borrow;
 use core::fmt::{self, Debug};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -60,7 +61,7 @@ pub trait IsPairing {
     /// Compute the product of the pairings for a list of point pairs.
     /// More efficient than just calling the pairing for each pair of points individually
     fn compute_batch(
-        pairs: &[(Self::G1Point, Self::G2Point)],
+        pairs: &[(impl Borrow<Self::G1Point>, impl Borrow<Self::G2Point>)],
     ) -> Result<FieldElement<Self::OutputField>, PairingError>;
 
     /// Compute the ate pairing between point `p` in G1 and `q` in G2.
@@ -68,6 +69,6 @@ pub trait IsPairing {
         p: &Self::G1Point,
         q: &Self::G2Point,
     ) -> Result<FieldElement<Self::OutputField>, PairingError> {
-        Self::compute_batch(&[(p.clone(), q.clone())])
+        Self::compute_batch(&[(p, q)])
     }
 }

--- a/crates/provers/groth16/src/verifier.rs
+++ b/crates/provers/groth16/src/verifier.rs
@@ -44,9 +44,9 @@ pub fn verify(
     let neg_pi3 = proof.pi3.neg();
 
     let lhs = Pairing::compute_batch(&[
-        (&proof.pi1, &proof.pi2),
-        (&neg_k_tau_g1, &vk.gamma_g2),
-        (&neg_pi3, &vk.delta_g2),
+        (proof.pi1.clone(), proof.pi2.clone()),
+        (neg_k_tau_g1, vk.gamma_g2.clone()),
+        (neg_pi3, vk.delta_g2.clone()),
     ])
     .map_err(Groth16Error::pairing)?;
 

--- a/examples/bls-signature/src/bls.rs
+++ b/examples/bls-signature/src/bls.rs
@@ -160,12 +160,12 @@ impl PublicKey {
         let g1 = BLS12381Curve::generator();
 
         // Compute e(pk, H(m))
-        let lhs = BLS12381AtePairing::compute_batch(&[(&self.pk.to_affine(), &h.to_affine())])
+        let lhs = BLS12381AtePairing::compute_batch(&[(self.pk.to_affine(), h.to_affine())])
             .map_err(|_| BlsError::PairingError)?;
 
         // Compute e(G1, sig)
         let rhs =
-            BLS12381AtePairing::compute_batch(&[(&g1.to_affine(), &signature.sig.to_affine())])
+            BLS12381AtePairing::compute_batch(&[(g1.to_affine(), signature.sig.to_affine())])
                 .map_err(|_| BlsError::PairingError)?;
 
         if lhs == rhs {
@@ -335,7 +335,7 @@ pub fn batch_verify(
     let lhs = final_exponentiation(&lhs).map_err(|_| BlsError::PairingError)?;
 
     // Compute e(G1, sig_sum)
-    let rhs = BLS12381AtePairing::compute_batch(&[(&g1.to_affine(), &sig_sum.to_affine())])
+    let rhs = BLS12381AtePairing::compute_batch(&[(g1.to_affine(), sig_sum.to_affine())])
         .map_err(|_| BlsError::PairingError)?;
 
     if lhs == rhs {

--- a/fuzz/no_gpu_fuzz/fuzz_targets/curve/curve_bls12_381.rs
+++ b/fuzz/no_gpu_fuzz/fuzz_targets/curve/curve_bls12_381.rs
@@ -82,20 +82,20 @@ fuzz_target!(|values: (u64, u64)| {
     let b = U384::from_u64(b_val);
     let result = BLS12381AtePairing::compute_batch(&[
         (
-            &a_g1.operate_with_self(a).to_affine(),
-            &a_g2.operate_with_self(b).to_affine(),
+            a_g1.operate_with_self(a).to_affine(),
+            a_g2.operate_with_self(b).to_affine(),
         ),
         (
-            &a_g1.operate_with_self(a * b).to_affine(),
-            &a_g2.neg().to_affine(),
+            a_g1.operate_with_self(a * b).to_affine(),
+            a_g2.neg().to_affine(),
         ),
     ]);
     assert_eq!(result, FieldElement::<Degree12ExtensionField>::one());
 
     // Ate Pairing returns one with one element is neutral element
-    let result = BLS12381AtePairing::compute_batch(&[(&a_g1.to_affine(), &LambdaG2::neutral_element())]);
+    let result = BLS12381AtePairing::compute_batch(&[(a_g1.to_affine(), LambdaG2::neutral_element())]);
     assert_eq!(result, FieldElement::<Degree12ExtensionField>::one());
 
-    let result = BLS12381AtePairing::compute_batch(&[(&LambdaG1::neutral_element(), &a_g2.to_affine())]);
+    let result = BLS12381AtePairing::compute_batch(&[(LambdaG1::neutral_element(), a_g2.to_affine())]);
     assert_eq!(result, FieldElement::<Degree12ExtensionField>::one());
 });

--- a/fuzz/no_gpu_fuzz/fuzz_targets/curve/curve_bn254.rs
+++ b/fuzz/no_gpu_fuzz/fuzz_targets/curve/curve_bn254.rs
@@ -81,20 +81,20 @@ fuzz_target!(|values: (u64, u64)| {
     let b = U256::from_u64(b_val);
     let result = BN254AtePairing::compute_batch(&[
         (
-            &a_g1.operate_with_self(a).to_affine(),
-            &a_g2.operate_with_self(b).to_affine(),
+            a_g1.operate_with_self(a).to_affine(),
+            a_g2.operate_with_self(b).to_affine(),
         ),
         (
-            &a_g1.operate_with_self(a * b).to_affine(),
-            &a_g2.neg().to_affine(),
+            a_g1.operate_with_self(a * b).to_affine(),
+            a_g2.neg().to_affine(),
         ),
     ]);
     assert_eq!(result, FieldElement::<Degree12ExtensionField>::one());
 
     // Ate Pairing returns one with one element is neutral element
-    let result = BN254AtePairing::compute_batch(&[(&a_g1.to_affine(), &LambdaG2::neutral_element())]);
+    let result = BN254AtePairing::compute_batch(&[(a_g1.to_affine(), LambdaG2::neutral_element())]);
     assert_eq!(result, FieldElement::<Degree12ExtensionField>::one());
 
-    let result = BN254AtePairing::compute_batch(&[(&LambdaG1::neutral_element(), &a_g2.to_affine())]);
+    let result = BN254AtePairing::compute_batch(&[(LambdaG1::neutral_element(), a_g2.to_affine())]);
     assert_eq!(result, FieldElement::<Degree12ExtensionField>::one());
 });


### PR DESCRIPTION
# Change IsPairing::compute_batch to accept owned point pairs

## Description

Change signature from &[(&G1, &G2)] to &[(G1, G2)], eliminating the need for callers with owned points to allocate a separate Vec of references. Points are Clone (trivial memcpy vs. pairing cost).

Closes #1019

- [ ] New feature
- [ ] Bug fix
- [X] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [X] This change is an Optimization
  - [ ] Benchmarks added/run
