### PR TITLE
Add portable scalar fallback for packed Goldilocks

### DIFF
--- a/crates/math/src/field/fields/goldilocks_avx/mod.rs
+++ b/crates/math/src/field/fields/goldilocks_avx/mod.rs
@@ -52,6 +52,9 @@ pub mod avx512;
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
 pub mod avx2_ext;
 
+// Portable scalar fallback (always available)
+pub mod scalar;
+
 // Re-exports for base field
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
 pub use avx2::PackedGoldilocksAVX2;
@@ -62,3 +65,13 @@ pub use avx512::PackedGoldilocksAVX512;
 // Re-exports for extension fields
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
 pub use avx2_ext::{PackedGoldilocksFp2AVX2, PackedGoldilocksFp3AVX2};
+
+pub use scalar::PackedGoldilocksScalar;
+
+/// Auto-selecting type alias: uses AVX2 on x86_64 when available, scalar otherwise.
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+pub type PackedGoldilocks = PackedGoldilocksAVX2;
+
+/// Auto-selecting type alias: scalar fallback on non-AVX2 platforms.
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
+pub type PackedGoldilocks = PackedGoldilocksScalar;

--- a/crates/math/src/field/fields/goldilocks_avx/mod.rs
+++ b/crates/math/src/field/fields/goldilocks_avx/mod.rs
@@ -1,12 +1,15 @@
-//! AVX2/AVX-512 optimized Goldilocks field arithmetic.
+//! Packed Goldilocks field arithmetic.
 //!
-//! This module provides SIMD-accelerated implementations of Goldilocks field
-//! operations using x86-64 AVX2 and AVX-512 instructions.
+//! This module provides packed (multi-element) implementations of Goldilocks
+//! field operations.  On x86-64 with AVX2 or AVX-512, SIMD-accelerated paths
+//! are used; on all other platforms a portable scalar fallback is selected
+//! automatically via the [`PackedGoldilocks`] type alias.
 //!
-//! # Performance
+//! # Implementations
 //!
-//! - AVX2: Processes 4 field elements in parallel (256-bit registers)
-//! - AVX-512: Processes 8 field elements in parallel (512-bit registers)
+//! - **AVX2** (`avx2`): Processes 4 field elements in parallel (256-bit registers)
+//! - **AVX-512** (`avx512`): Processes 8 field elements in parallel (512-bit registers)
+//! - **Scalar** (`scalar`): Portable fallback, processes 4 elements sequentially
 //!
 //! # Supported Fields
 //!
@@ -18,27 +21,21 @@
 //!
 //! Compile with `RUSTFLAGS="-C target-feature=+avx2"` for AVX2, or
 //! `RUSTFLAGS="-C target-cpu=native"` to enable all CPU features.
+//! Without these flags (or on non-x86_64 targets), the scalar fallback is used.
 //!
 //! # Inspiration
 //!
-//! This implementation is based on [Plonky3's Goldilocks AVX implementation](https://github.com/Plonky3/Plonky3/tree/main/goldilocks).
+//! The SIMD implementations are based on [Plonky3's Goldilocks AVX implementation](https://github.com/Plonky3/Plonky3/tree/main/goldilocks).
 //!
 //! # Usage
 //!
 //! ```ignore
-//! use lambdaworks_math::field::fields::goldilocks_avx::{
-//!     PackedGoldilocksAVX2, PackedGoldilocksFp2AVX2
-//! };
+//! use lambdaworks_math::field::fields::goldilocks_avx::PackedGoldilocks;
 //!
-//! // Base field: 4 parallel operations
-//! let a = PackedGoldilocksAVX2::from_u64_array([1, 2, 3, 4]);
-//! let b = PackedGoldilocksAVX2::from_u64_array([5, 6, 7, 8]);
-//! let c = a + b; // SIMD parallel addition
-//!
-//! // Extension field: 4 Fp2 elements in parallel
-//! let fp2_a = PackedGoldilocksFp2AVX2::from_fp2_array([...]);
-//! let fp2_b = PackedGoldilocksFp2AVX2::from_fp2_array([...]);
-//! let fp2_c = fp2_a * fp2_b; // SIMD parallel Fp2 multiplication
+//! // Uses AVX2 on x86_64 when available, scalar fallback otherwise
+//! let a = PackedGoldilocks::from_u64_array([1, 2, 3, 4]);
+//! let b = PackedGoldilocks::from_u64_array([5, 6, 7, 8]);
+//! let c = a + b;
 //! ```
 
 // Base field implementations

--- a/crates/math/src/field/fields/goldilocks_avx/scalar.rs
+++ b/crates/math/src/field/fields/goldilocks_avx/scalar.rs
@@ -1,0 +1,182 @@
+//! Portable scalar fallback for packed Goldilocks field arithmetic.
+//!
+//! Provides the same API as the AVX2 module but uses element-wise scalar
+//! operations.  Automatically selected on non-x86_64 targets or when AVX2
+//! is not available.
+
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use crate::field::element::FieldElement;
+use crate::field::fields::u64_goldilocks_field::Goldilocks64Field;
+use crate::field::traits::IsField;
+
+/// Number of Goldilocks elements in a packed value (matches AVX2 width).
+pub const WIDTH: usize = 4;
+
+/// Packed Goldilocks field elements (scalar fallback).
+///
+/// Provides the same interface as [`super::avx2::PackedGoldilocksAVX2`] but
+/// uses plain scalar arithmetic, making it portable to any platform.
+#[derive(Copy, Clone, Debug)]
+#[repr(transparent)]
+pub struct PackedGoldilocksScalar(pub [FieldElement<Goldilocks64Field>; WIDTH]);
+
+impl PackedGoldilocksScalar {
+    #[inline]
+    pub fn new(elements: [FieldElement<Goldilocks64Field>; WIDTH]) -> Self {
+        Self(elements)
+    }
+
+    #[inline]
+    pub fn from_u64_array(values: [u64; WIDTH]) -> Self {
+        Self([
+            FieldElement::from(values[0]),
+            FieldElement::from(values[1]),
+            FieldElement::from(values[2]),
+            FieldElement::from(values[3]),
+        ])
+    }
+
+    #[inline]
+    pub fn zero() -> Self {
+        Self([FieldElement::zero(); WIDTH])
+    }
+
+    #[inline]
+    pub fn one() -> Self {
+        Self([FieldElement::one(); WIDTH])
+    }
+
+    #[inline]
+    pub fn to_array(self) -> [FieldElement<Goldilocks64Field>; WIDTH] {
+        self.0
+    }
+
+    #[inline]
+    pub fn from_slice(slice: &[FieldElement<Goldilocks64Field>]) -> Self {
+        debug_assert!(slice.len() >= WIDTH);
+        Self([slice[0], slice[1], slice[2], slice[3]])
+    }
+
+    #[inline]
+    pub fn store_to_slice(self, slice: &mut [FieldElement<Goldilocks64Field>]) {
+        debug_assert!(slice.len() >= WIDTH);
+        slice[..WIDTH].copy_from_slice(&self.0);
+    }
+
+    #[inline]
+    pub fn square(self) -> Self {
+        Self(core::array::from_fn(|i| self.0[i] * self.0[i]))
+    }
+}
+
+impl Default for PackedGoldilocksScalar {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
+impl PartialEq for PackedGoldilocksScalar {
+    fn eq(&self, other: &Self) -> bool {
+        (0..WIDTH).all(|i| <Goldilocks64Field as IsField>::eq(self.0[i].value(), other.0[i].value()))
+    }
+}
+
+impl Eq for PackedGoldilocksScalar {}
+
+impl Add for PackedGoldilocksScalar {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Self(core::array::from_fn(|i| self.0[i] + rhs.0[i]))
+    }
+}
+
+impl AddAssign for PackedGoldilocksScalar {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl Sub for PackedGoldilocksScalar {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Self(core::array::from_fn(|i| self.0[i] - rhs.0[i]))
+    }
+}
+
+impl SubAssign for PackedGoldilocksScalar {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl Neg for PackedGoldilocksScalar {
+    type Output = Self;
+    #[inline]
+    fn neg(self) -> Self {
+        Self(core::array::from_fn(|i| -self.0[i]))
+    }
+}
+
+impl Mul for PackedGoldilocksScalar {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        Self(core::array::from_fn(|i| self.0[i] * rhs.0[i]))
+    }
+}
+
+impl MulAssign for PackedGoldilocksScalar {
+    #[inline]
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scalar_add_works() {
+        let a = PackedGoldilocksScalar::from_u64_array([1, 2, 3, 4]);
+        let b = PackedGoldilocksScalar::from_u64_array([10, 20, 30, 40]);
+        let c = a + b;
+        assert_eq!(c, PackedGoldilocksScalar::from_u64_array([11, 22, 33, 44]));
+    }
+
+    #[test]
+    fn scalar_mul_works() {
+        let a = PackedGoldilocksScalar::from_u64_array([2, 3, 4, 5]);
+        let b = PackedGoldilocksScalar::from_u64_array([10, 10, 10, 10]);
+        let c = a * b;
+        assert_eq!(c, PackedGoldilocksScalar::from_u64_array([20, 30, 40, 50]));
+    }
+
+    #[test]
+    fn scalar_sub_works() {
+        let a = PackedGoldilocksScalar::from_u64_array([10, 20, 30, 40]);
+        let b = PackedGoldilocksScalar::from_u64_array([1, 2, 3, 4]);
+        let c = a - b;
+        assert_eq!(c, PackedGoldilocksScalar::from_u64_array([9, 18, 27, 36]));
+    }
+
+    #[test]
+    fn scalar_square_works() {
+        let a = PackedGoldilocksScalar::from_u64_array([3, 4, 5, 6]);
+        let b = a.square();
+        assert_eq!(b, PackedGoldilocksScalar::from_u64_array([9, 16, 25, 36]));
+    }
+
+    #[test]
+    fn scalar_neg_works() {
+        let a = PackedGoldilocksScalar::from_u64_array([1, 2, 3, 4]);
+        let b = -a;
+        let c = a + b;
+        assert_eq!(c, PackedGoldilocksScalar::zero());
+    }
+}

--- a/crates/math/src/field/fields/goldilocks_avx/scalar.rs
+++ b/crates/math/src/field/fields/goldilocks_avx/scalar.rs
@@ -8,7 +8,6 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::field::element::FieldElement;
 use crate::field::fields::u64_goldilocks_field::Goldilocks64Field;
-use crate::field::traits::IsField;
 
 /// Number of Goldilocks elements in a packed value (matches AVX2 width).
 pub const WIDTH: usize = 4;
@@ -78,7 +77,7 @@ impl Default for PackedGoldilocksScalar {
 
 impl PartialEq for PackedGoldilocksScalar {
     fn eq(&self, other: &Self) -> bool {
-        (0..WIDTH).all(|i| <Goldilocks64Field as IsField>::eq(self.0[i].value(), other.0[i].value()))
+        self.0 == other.0
     }
 }
 
@@ -140,6 +139,7 @@ impl MulAssign for PackedGoldilocksScalar {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::field::fields::u64_goldilocks_field::GOLDILOCKS_PRIME;
 
     #[test]
     fn scalar_add_works() {
@@ -178,5 +178,75 @@ mod tests {
         let b = -a;
         let c = a + b;
         assert_eq!(c, PackedGoldilocksScalar::zero());
+    }
+
+    #[test]
+    fn scalar_overflow_handling() {
+        let near_max = GOLDILOCKS_PRIME - 1;
+        let a = PackedGoldilocksScalar::from_u64_array([near_max, near_max, near_max, near_max]);
+        let one = PackedGoldilocksScalar::from_u64_array([1, 1, 1, 1]);
+
+        // Adding 1 to (p-1) should give 0
+        let result = a + one;
+        for elem in result.to_array() {
+            assert_eq!(elem, FieldElement::zero());
+        }
+    }
+
+    #[test]
+    fn scalar_sub_underflow() {
+        // 0 - 1 should give p - 1
+        let zero = PackedGoldilocksScalar::from_u64_array([0, 0, 0, 0]);
+        let one = PackedGoldilocksScalar::from_u64_array([1, 1, 1, 1]);
+        let result = zero - one;
+        let p_minus_1 = FieldElement::<Goldilocks64Field>::from(GOLDILOCKS_PRIME - 1);
+        for elem in result.to_array() {
+            assert_eq!(elem, p_minus_1, "0 - 1 should equal p - 1");
+        }
+
+        // 1 - 2 should give p - 1
+        let one = PackedGoldilocksScalar::from_u64_array([1, 1, 1, 1]);
+        let two = PackedGoldilocksScalar::from_u64_array([2, 2, 2, 2]);
+        let result = one - two;
+        for elem in result.to_array() {
+            assert_eq!(elem, p_minus_1, "1 - 2 should equal p - 1");
+        }
+    }
+
+    #[test]
+    fn scalar_neg_boundary() {
+        // -0 = 0
+        let zero = PackedGoldilocksScalar::from_u64_array([0, 0, 0, 0]);
+        let result = -zero;
+        for elem in result.to_array() {
+            assert_eq!(elem, FieldElement::zero(), "-0 should be 0");
+        }
+
+        // -(p-1) = 1
+        let p_minus_1 = GOLDILOCKS_PRIME - 1;
+        let a = PackedGoldilocksScalar::from_u64_array([p_minus_1; WIDTH]);
+        let result = -a;
+        for elem in result.to_array() {
+            assert_eq!(elem, FieldElement::one(), "-(p-1) should be 1");
+        }
+    }
+
+    #[test]
+    fn scalar_mul_near_modulus() {
+        // (p-1) * (p-1) should equal 1 (since (p-1) = -1, and (-1)*(-1) = 1)
+        let p_minus_1 = GOLDILOCKS_PRIME - 1;
+        let a = PackedGoldilocksScalar::from_u64_array([p_minus_1; WIDTH]);
+        let result = a * a;
+        for elem in result.to_array() {
+            assert_eq!(elem, FieldElement::one(), "(p-1)*(p-1) should be 1");
+        }
+
+        // (p-1) * 2 should equal p-2
+        let two = PackedGoldilocksScalar::from_u64_array([2; WIDTH]);
+        let result = a * two;
+        let expected = FieldElement::<Goldilocks64Field>::from(GOLDILOCKS_PRIME - 2);
+        for elem in result.to_array() {
+            assert_eq!(elem, expected, "(p-1)*2 should be p-2");
+        }
     }
 }

--- a/crates/math/src/field/fields/mod.rs
+++ b/crates/math/src/field/fields/mod.rs
@@ -1,10 +1,6 @@
 /// Implementation of two-adic prime fields to use with the Fast Fourier Transform (FFT).
 pub mod fft_friendly;
-/// AVX2/AVX-512 SIMD optimized Goldilocks field arithmetic
-#[cfg(all(
-    target_arch = "x86_64",
-    any(target_feature = "avx2", target_feature = "avx512f")
-))]
+/// Packed Goldilocks field arithmetic (AVX2/AVX-512 on x86_64, scalar fallback elsewhere)
 pub mod goldilocks_avx;
 /// Implementation of the 32-bit Mersenne Prime field (p = 2^31 - 1)
 pub mod mersenne31;


### PR DESCRIPTION
# Add portable scalar fallback for packed Goldilocks

## Description

The goldilocks_avx module was unavailable without AVX2. Add a scalar fallback (PackedGoldilocksScalar) with the same API that works on all platforms, and a PackedGoldilocks type alias that auto-selects AVX2 on x86_64 or scalar elsewhere.

Closes #1153

- [X] New feature
- [ ] Bug fix
- [ ] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
