### PR TITLE
Add fast sqrt path for p ≡ 3 (mod 4) primes

### DIFF
--- a/crates/math/src/field/element.rs
+++ b/crates/math/src/field/element.rs
@@ -1034,6 +1034,41 @@ mod tests {
         assert!(sqrt.is_none());
     }
 
+    // Tests targeting the fast sqrt path (p ≡ 3 mod 4).
+    // BN254 base field satisfies p ≡ 3 (mod 4), so these exercise the
+    // direct-exponentiation branch rather than Tonelli-Shanks.
+
+    #[test]
+    fn sqrt_fast_path_known_qr_bn254() {
+        type FE = FieldElement<BN254PrimeField>;
+        let a = FE::from(4);
+        let (r1, r2) = a.sqrt().unwrap();
+        assert_eq!(r1.square(), a);
+        assert_eq!(r2.square(), a);
+        assert_ne!(r1, r2);
+    }
+
+    #[test]
+    fn sqrt_fast_path_non_residue_bn254() {
+        type FE = FieldElement<BN254PrimeField>;
+        // 3 is a non-residue mod BN254 base field prime
+        let a = FE::from(3);
+        assert!(a.sqrt().is_none());
+    }
+
+    #[test]
+    fn sqrt_fast_path_roundtrip_bn254() {
+        type FE = FieldElement<BN254PrimeField>;
+        for v in [2u64, 7, 13, 100, 9999] {
+            let x = FE::from(v);
+            let a = x.square();
+            let (r1, r2) = a.sqrt().unwrap();
+            assert_eq!(r1.square(), a);
+            assert_eq!(r2.square(), a);
+            assert!(r1 == x || r2 == x);
+        }
+    }
+
     #[test]
     fn from_hex_1a_is_26_for_stark252_prime_field_element() {
         type F = Stark252PrimeField;

--- a/crates/math/src/field/traits.rs
+++ b/crates/math/src/field/traits.rs
@@ -256,6 +256,10 @@ pub trait IsPrimeField: IsField {
         if pm1 & integer_three == integer_two {
             let exp = (pm1 + integer_two) >> 2;
             let x = Self::pow(a, exp);
+            debug_assert!(
+                Self::eq(&Self::mul(&x, &x), a),
+                "fast sqrt path produced incorrect result"
+            );
             let neg_x = Self::neg(&x);
             return Some((x, neg_x));
         }

--- a/crates/math/src/field/traits.rs
+++ b/crates/math/src/field/traits.rs
@@ -236,7 +236,10 @@ pub trait IsPrimeField: IsField {
     }
 
     /// Returns the two square roots of `self` if they exist and
-    /// `None` otherwise
+    /// `None` otherwise.
+    ///
+    /// Uses a direct exponentiation when p ≡ 3 (mod 4), and falls back to
+    /// Tonelli-Shanks for the general case.
     fn sqrt(a: &Self::BaseType) -> Option<(Self::BaseType, Self::BaseType)> {
         match Self::legendre_symbol(a) {
             LegendreSymbol::Zero => return Some((Self::zero(), Self::zero())),
@@ -245,9 +248,21 @@ pub trait IsPrimeField: IsField {
         };
 
         let integer_one = Self::CanonicalType::from(1_u16);
-        let mut s: usize = 0;
-        let mut q = Self::modulus_minus_one();
+        let integer_two = Self::CanonicalType::from(2_u16);
+        let integer_three = Self::CanonicalType::from(3_u16);
+        let pm1 = Self::modulus_minus_one();
 
+        // Fast path: p ≡ 3 (mod 4) means sqrt(a) = a^((p+1)/4).
+        if pm1 & integer_three == integer_two {
+            let exp = (pm1 + integer_two) >> 2;
+            let x = Self::pow(a, exp);
+            let neg_x = Self::neg(&x);
+            return Some((x, neg_x));
+        }
+
+        // General case: Tonelli-Shanks.
+        let mut s: usize = 0;
+        let mut q = pm1;
         while q & integer_one != integer_one {
             s += 1;
             q >>= 1;
@@ -255,12 +270,10 @@ pub trait IsPrimeField: IsField {
 
         let one = Self::one();
         let mut c = {
-            // Calculate a non residue:
             let mut non_qr = Self::from_u64(2);
             while Self::legendre_symbol(&non_qr) != LegendreSymbol::MinusOne {
                 non_qr = Self::add(&non_qr, &one);
             }
-
             Self::pow(&non_qr, q)
         };
 


### PR DESCRIPTION
# Add fast sqrt path for p ≡ 3 (mod 4) primes

## Description

When the prime satisfies p ≡ 3 (mod 4), compute sqrt as a^((p+1)/4) instead of running full Tonelli-Shanks. This replaces a multi-step algorithm with a single exponentiation for the most common primes (BN254, BLS12-381, Stark252).

Closes #1041

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [X] Optimization

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [X] This change is an Optimization
  - [ ] Benchmarks added/run
