### PR TITLE
Add signed MSM benchmark comparison grid

### DIFF
--- a/crates/math/benches/criterion_msm.rs
+++ b/crates/math/benches/criterion_msm.rs
@@ -40,7 +40,7 @@ pub fn historical_window_msm_benchmarks_with_size(
     assert_eq!(cs.len(), points.len());
     let msm_size = cs.len();
 
-    let mut group = c.benchmark_group(format!("MSM historical windows (size {msm_size})"));
+    let mut group = c.benchmark_group(format!("MSM benchmarks with size {msm_size}"));
 
     group.bench_function("Naive", |bench| {
         bench.iter(|| black_box(naive::msm(cs, points)));

--- a/crates/math/benches/criterion_msm.rs
+++ b/crates/math/benches/criterion_msm.rs
@@ -73,6 +73,8 @@ pub fn signed_comparison_msm_benchmarks_with_size(
     let msm_size = cs.len();
 
     // Keep signed benchmarks on a separate grid so historical unsigned data stays comparable.
+    // This benchmark group is intended to compare already-existing signed MSM paths against the
+    // unsigned ones, without changing runtime defaults in the same PR.
     let mut group = c.benchmark_group(format!("MSM signed comparison (size {msm_size})"));
 
     for &window_size in window_sizes {
@@ -111,6 +113,8 @@ pub fn signed_comparison_msm_benchmarks_with_size(
 pub fn run_benchmarks(c: &mut Criterion) {
     let exponents = 1..=10;
     let legacy_window_sizes = vec![1, 2, 4, 8, 12];
+    // Signed MSM clamps window sizes to a minimum of 2, includes an odd window (3) for contrast,
+    // and samples medium windows (4, 6, 8) without growing the benchmark matrix too much.
     let signed_window_sizes = vec![2, 3, 4, 6, 8];
 
     for exp in exponents {

--- a/crates/math/benches/criterion_msm.rs
+++ b/crates/math/benches/criterion_msm.rs
@@ -31,7 +31,7 @@ pub fn generate_cs_and_points(msm_size: usize) -> (Vec<UI>, Vec<FP>) {
     (cs, points)
 }
 
-pub fn msm_benchmarks_with_size(
+pub fn historical_window_msm_benchmarks_with_size(
     c: &mut Criterion,
     cs: &[UI],
     points: &[FP],
@@ -40,7 +40,7 @@ pub fn msm_benchmarks_with_size(
     assert_eq!(cs.len(), points.len());
     let msm_size = cs.len();
 
-    let mut group = c.benchmark_group(format!("MSM benchmarks with size {msm_size}"));
+    let mut group = c.benchmark_group(format!("MSM historical windows (size {msm_size})"));
 
     group.bench_function("Naive", |bench| {
         bench.iter(|| black_box(naive::msm(cs, points)));
@@ -63,15 +63,62 @@ pub fn msm_benchmarks_with_size(
     }
 }
 
+pub fn signed_comparison_msm_benchmarks_with_size(
+    c: &mut Criterion,
+    cs: &[UI],
+    points: &[FP],
+    window_sizes: &[usize],
+) {
+    assert_eq!(cs.len(), points.len());
+    let msm_size = cs.len();
+
+    // Keep signed benchmarks on a separate grid so historical unsigned data stays comparable.
+    let mut group = c.benchmark_group(format!("MSM signed comparison (size {msm_size})"));
+
+    for &window_size in window_sizes {
+        group.bench_function(
+            BenchmarkId::new("Sequential Pippenger", window_size),
+            |bench| {
+                bench.iter(|| black_box(pippenger::msm_with(cs, points, window_size)));
+            },
+        );
+
+        group.bench_function(
+            BenchmarkId::new("Sequential Signed Pippenger", window_size),
+            |bench| {
+                bench.iter(|| black_box(pippenger::msm_with_signed(cs, points, window_size)));
+            },
+        );
+
+        group.bench_function(
+            BenchmarkId::new("Parallel Pippenger", window_size),
+            |bench| {
+                bench.iter(|| black_box(pippenger::parallel_msm_with(cs, points, window_size)));
+            },
+        );
+
+        group.bench_function(
+            BenchmarkId::new("Parallel Signed Pippenger", window_size),
+            |bench| {
+                bench.iter(|| {
+                    black_box(pippenger::parallel_msm_with_signed(cs, points, window_size))
+                });
+            },
+        );
+    }
+}
+
 pub fn run_benchmarks(c: &mut Criterion) {
     let exponents = 1..=10;
-    let window_sizes = vec![1, 2, 4, 8, 12];
+    let legacy_window_sizes = vec![1, 2, 4, 8, 12];
+    let signed_window_sizes = vec![2, 3, 4, 6, 8];
 
     for exp in exponents {
         let msm_size = 1 << exp;
         let (cs, points) = generate_cs_and_points(msm_size);
 
-        msm_benchmarks_with_size(c, &cs, &points, &window_sizes);
+        historical_window_msm_benchmarks_with_size(c, &cs, &points, &legacy_window_sizes);
+        signed_comparison_msm_benchmarks_with_size(c, &cs, &points, &signed_window_sizes);
     }
 }
 


### PR DESCRIPTION
## Summary
- preserve the historical unsigned MSM benchmark window grid in its own Criterion group
- add a separate signed comparison group covering sequential and parallel signed Pippenger
- keep this PR benchmark-only with no runtime MSM behavior changes

## Benchmark layout
- `MSM historical windows (size N)` keeps the prior unsigned window grid: `1, 2, 4, 8, 12`
- `MSM signed comparison (size N)` adds a signed-vs-unsigned grid: `2, 3, 4, 6, 8`

This split keeps older unsigned runs comparable while making the signed comparison easier to read in Criterion reports.

## Verification
- `cargo fmt --all`
- Bench compilation is still blocked on this Windows host by an existing `pprof v0.13.0` dependency issue in the bench graph, so no repo-local `cargo bench` result is attached here.

Refs #730
