### PR TITLE
Optimize FieldElement subtraction with in-place SubAssign

### DIFF
--- a/crates/math/benches/fields/stark252.rs
+++ b/crates/math/benches/fields/stark252.rs
@@ -140,6 +140,18 @@ pub fn starkfield_ops_benchmarks(c: &mut Criterion) {
     }
 
     for i in input.clone().into_iter() {
+        group.bench_with_input(format!("sub_assign {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, y) in i {
+                    let mut z = *x;
+                    z -= *y;
+                    black_box(z);
+                }
+            });
+        });
+    }
+
+    for i in input.clone().into_iter() {
         group.bench_with_input(format!("inv {:?}", &i.len()), &i, |bench, i| {
             bench.iter(|| {
                 for (x, _) in i {

--- a/crates/math/benches/fields/u64_goldilocks.rs
+++ b/crates/math/benches/fields/u64_goldilocks.rs
@@ -110,6 +110,18 @@ pub fn u64_goldilocks_ops_benchmarks(c: &mut Criterion) {
     }
 
     for i in input.clone().into_iter() {
+        group.bench_with_input(format!("sub_assign {:?}", &i.len()), &i, |bench, i| {
+            bench.iter(|| {
+                for (x, y) in i {
+                    let mut z = *x;
+                    z -= *y;
+                    black_box(z);
+                }
+            });
+        });
+    }
+
+    for i in input.clone().into_iter() {
         group.bench_with_input(format!("inv {:?}", &i.len()), &i, |bench, i| {
             bench.iter(|| {
                 for (x, _) in i {

--- a/crates/math/src/field/element.rs
+++ b/crates/math/src/field/element.rs
@@ -18,7 +18,7 @@ use core::iter::Sum;
     feature = "lambdaworks-serde-string"
 ))]
 use core::marker::PhantomData;
-use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub};
+use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 #[cfg(feature = "alloc")]
 use num_bigint::BigUint;
 #[cfg(feature = "alloc")]
@@ -327,6 +327,32 @@ where
     #[inline]
     fn sub(self, rhs: FieldElement<L>) -> Self::Output {
         self - &rhs
+    }
+}
+
+/// SubAssign operator overloading for field elements
+impl<F, L> SubAssign<FieldElement<F>> for FieldElement<L>
+where
+    F: IsSubFieldOf<L>,
+    L: IsField,
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: FieldElement<F>) {
+        let rhs = <F as IsSubFieldOf<L>>::embed(rhs.value);
+        self.value = L::sub(&self.value, &rhs);
+    }
+}
+
+/// SubAssign operator overloading for field elements
+impl<F, L> SubAssign<&FieldElement<F>> for FieldElement<L>
+where
+    F: IsSubFieldOf<L>,
+    L: IsField,
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: &FieldElement<F>) {
+        let rhs = <F as IsSubFieldOf<L>>::embed(rhs.value.clone());
+        self.value = L::sub(&self.value, &rhs);
     }
 }
 
@@ -1238,6 +1264,24 @@ mod tests {
     fn sub_element_from_itself_gives_zero() {
         let a = FieldElement::<U64TestField>::from(12345u64);
         assert_eq!(&a - &a, FieldElement::<U64TestField>::zero());
+    }
+
+    #[test]
+    fn sub_assign_owned_matches_subtraction() {
+        let mut a = FieldElement::<U64TestField>::from(12345u64);
+        let b = FieldElement::<U64TestField>::from(6789u64);
+        let expected = &a - &b;
+        a -= b;
+        assert_eq!(a, expected);
+    }
+
+    #[test]
+    fn sub_assign_borrowed_matches_subtraction() {
+        let mut a = FieldElement::<U64TestField>::from(12345u64);
+        let b = FieldElement::<U64TestField>::from(6789u64);
+        let expected = &a - &b;
+        a -= &b;
+        assert_eq!(a, expected);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds missing in-place subtraction for FieldElement.

In focused Criterion benchmarks at 1,000,000 operations, the new sub_assign path was faster than regular sub in both tested fields:

Stark252: about 4% faster
u64 Goldilocks: about 24% to 30% faster

Summary

1. Added SubAssign<FieldElement<F>> and SubAssign<&FieldElement<F>> for FieldElement<L>, enabling both a -= b and a -= &b.

2. Kept the existing subtraction API unchanged.

3. Added correctness tests for owned and borrowed RHS subtraction.

4. Added focused Criterion benchmarks for sub_assign next to the existing sub benchmarks in Stark252 and u64 Goldilocks field operations.

Validation

cargo check passed:

    cargo check --manifest-path crates/math/Cargo.toml --lib

Focused tests passed:

    cargo test --manifest-path crates/math/Cargo.toml sub_assign --lib -- --nocapture

    running 7 tests
    test field::element::tests::sub_assign_borrowed_matches_subtraction ... ok
    test field::element::tests::sub_assign_owned_matches_subtraction ... ok
    test polynomial::tests::test_sub_assign ... ok
    test polynomial::tests::test_sub_assign_trait ... ok
    test polynomial::tests::test_sub_assign_trait_owned ... ok
    test polynomial::tests::test_sub_assign_trims_zeros ... ok
    test polynomial::tests::test_sub_assign_different_lengths ... ok

    test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1381 filtered out; finished in 0.05s

Benchmark

Command:

    RUSTFLAGS="-C target-cpu=native" cargo bench --manifest-path crates/math/Cargo.toml --bench criterion_field -- "(Stark FP operations/sub 1000000|Stark FP operations/sub_assign 1000000|u64 Goldilocks FP operations/sub 1000000|u64 Goldilocks FP operations/sub_assign 1000000)"

Results:

    Stark FP operations/sub 1000000
        time: [6.0808 ms 6.0954 ms 6.1104 ms]

    Stark FP operations/sub_assign 1000000
        time: [5.8279 ms 5.8543 ms 5.8818 ms]
        change: [-8.1329% -7.3329% -6.5979%] (p = 0.00 < 0.05)
        Performance has improved.

    u64 Goldilocks FP operations/sub 1000000
        time: [554.16 µs 559.43 µs 564.82 µs]

    u64 Goldilocks FP operations/sub_assign 1000000
        time: [422.81 µs 425.45 µs 428.42 µs]

The benchmark uses owned RHS, z -= *y, so it measures the in-place subtraction path directly without adding borrowed-RHS clone cost.
