### PR TITLE
Speed up polynomial long division by subtracting shifted divisors in-place

### DIFF
--- a/crates/math/src/polynomial/mod.rs
+++ b/crates/math/src/polynomial/mod.rs
@@ -319,6 +319,12 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
         }
 
         let required_len = shift + other.coefficients.len();
+        debug_assert!(
+            required_len <= self.coefficients.len(),
+            "sub_scaled_shifted_assign: required_len ({required_len}) exceeds self.len ({}); \
+             caller invariant violated",
+            self.coefficients.len()
+        );
         if required_len > self.coefficients.len() {
             self.coefficients.resize(required_len, FieldElement::zero());
         }

--- a/crates/math/src/polynomial/mod.rs
+++ b/crates/math/src/polynomial/mod.rs
@@ -242,12 +242,9 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
                 .expect("Leading coefficient should be non-zero for non-zero polynomial");
             while !n.is_zero() && n.degree() >= divisor.degree() {
                 let new_coefficient = n.leading_coefficient() * &denominator;
-                q[n.degree() - divisor.degree()] = new_coefficient.clone();
-                let d = divisor.mul_with_ref(&Polynomial::new_monomial(
-                    new_coefficient,
-                    n.degree() - divisor.degree(),
-                ));
-                n -= d;
+                let shift = n.degree() - divisor.degree();
+                q[shift] = new_coefficient.clone();
+                n.sub_scaled_shifted_assign(divisor, &new_coefficient, shift);
             }
             Ok((Polynomial::new(&q), n))
         }
@@ -314,6 +311,33 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
     pub fn div_with_ref(self, divisor: &Self) -> Result<Self, PolynomialError> {
         let (quotient, _remainder) = self.long_division_with_remainder(divisor)?;
         Ok(quotient)
+    }
+
+    fn sub_scaled_shifted_assign(&mut self, other: &Self, scale: &FieldElement<F>, shift: usize) {
+        if other.coefficients.is_empty() {
+            return;
+        }
+
+        let required_len = shift + other.coefficients.len();
+        if required_len > self.coefficients.len() {
+            self.coefficients.resize(required_len, FieldElement::zero());
+        }
+
+        for (target, coeff) in self.coefficients[shift..required_len]
+            .iter_mut()
+            .zip(other.coefficients.iter())
+        {
+            let scaled_coeff = coeff * scale;
+            *target = &*target - &scaled_coeff;
+        }
+
+        while self
+            .coefficients
+            .last()
+            .is_some_and(|c| *c == FieldElement::zero())
+        {
+            self.coefficients.pop();
+        }
     }
 
     pub fn mul_with_ref(&self, factor: &Self) -> Self {
@@ -1241,6 +1265,43 @@ mod tests {
         let p2 = Polynomial::new(&[FE::new(1), FE::new(3)]);
         let p3 = p1.mul_with_ref(&p2);
         assert_eq!(p3 / p2, p1);
+    }
+
+    #[test]
+    fn long_division_reconstructs_dividend_with_remainder() {
+        let dividend =
+            Polynomial::new(&[FE::new(5), FE::new(0), FE::new(3), FE::new(4), FE::new(2)]);
+        let divisor = Polynomial::new(&[FE::new(3), FE::new(1), FE::new(1)]);
+
+        let (quotient, remainder) = dividend
+            .clone()
+            .long_division_with_remainder(&divisor)
+            .unwrap();
+
+        assert!(remainder.is_zero() || remainder.degree() < divisor.degree());
+        assert_eq!(quotient.mul_with_ref(&divisor) + remainder, dividend);
+    }
+
+    #[test]
+    fn long_division_reconstructs_dividend_for_wide_degree_gap() {
+        let dividend = Polynomial::new(&[
+            FE::new(7),
+            FE::new(0),
+            FE::new(0),
+            FE::new(2),
+            FE::new(0),
+            FE::new(0),
+            FE::new(4),
+        ]);
+        let divisor = Polynomial::new(&[FE::new(5), FE::new(1)]);
+
+        let (quotient, remainder) = dividend
+            .clone()
+            .long_division_with_remainder(&divisor)
+            .unwrap();
+
+        assert!(remainder.is_zero() || remainder.degree() < divisor.degree());
+        assert_eq!(quotient.mul_with_ref(&divisor) + remainder, dividend);
     }
 
     #[test]


### PR DESCRIPTION
1. What changed

This narrows polynomial long division to the actual work it needs to do.

Instead of building a temporary shifted monomial polynomial, multiplying the divisor by it, and subtracting that temporary result on every iteration, this PR subtracts the scaled and shifted divisor directly from the current remainder.

The public API is unchanged.


2. Key code

Before:

let d = divisor.mul_with_ref(&Polynomial::new_monomial(
    new_coefficient,
    n.degree() - divisor.degree(),
));
n -= d;

After:

let shift = n.degree() - divisor.degree();
q[shift] = new_coefficient.clone();
n.sub_scaled_shifted_assign(divisor, &new_coefficient, shift);

I also made the long division length invariant explicit with a debug_assert inside the helper.


3. Validation

a. Tests
cargo test --manifest-path crates/math/Cargo.toml long_division --lib
cargo test --manifest-path crates/math/
Cargo.toml polynomial::tests --lib

Passed: 2 targeted tests, 88 polynomial tests

b. Lint
cargo clippy --manifest-path crates/math/Cargo.toml --lib -- -D warnings

Passed


4. Benchmark

Command:
cargo bench --manifest-path crates/math/Cargo.toml --bench criterion_polynomial -- 'slow div big poly'

Repeated runs stayed in the same range.

main:
run 1: [472.53 us 473.23 us 474.02 us]
run 2: [473.58 us 474.14 us 474.71 us]

this branch:
run 1: [138.62 us 138.92 us 139.25 us]
run 2: [138.78 us 139.11 us 139.47 us]

One direct side by side comparison run produced:
main baseline: [472.03 us 472.64 us 473.36 us]
optimized branch: [136.79 us 136.91 us 137.04 us]

That run corresponds to about 472.64 us on main versus about 136.91 us on this branch, roughly a 3.45x speedup for this benchmark.
<img width="2410" height="648" alt="ScreenShot_2026-05-19_152237_945" src="https://github.com/user-attachments/assets/12370074-4851-4a3c-a5da-b2c09bbdd581" />