### PR TITLE
math/cuda: speed up large-input BLS12-381 MSM

### DIFF
--- a/crates/math/src/gpu/cuda/shaders/msm/bls12_381_msm.cu
+++ b/crates/math/src/gpu/cuda/shaders/msm/bls12_381_msm.cu
@@ -3,24 +3,90 @@
 // Compiled to .ptx by build.rs (nvcc -ptx)
 // The build system walks crates/math/src/gpu/cuda/shaders/ recursively
 // for .cu files, so this file is picked up automatically.
-//
-// WARNING: The bucket_accumulation kernel has a documented race condition
-// when multiple threads write to the same bucket without synchronization.
-// This first CUDA port carries the same limitation as the Metal MSM.
-// A correctness fix (sorting-based approach) is planned as follow-up.
 
 #include "msm.cuh"
 
 extern "C" {
 
-__global__ void bucket_accumulation_bls12_381(
+__global__ void count_bucket_entries_bls12_381(
     const int *scalars,
+    unsigned int *counts,
+    const unsigned int *config
+) {
+    unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    count_bucket_entries_384_impl(scalars, counts, config, gid);
+}
+
+__global__ void scatter_bucket_descriptors_bls12_381(
+    const int *scalars,
+    unsigned int *write_counts,
+    const unsigned int *offsets,
+    unsigned int *sorted_descriptors,
+    const unsigned int *config
+) {
+    unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    scatter_bucket_descriptors_384_impl(scalars, write_counts, offsets, sorted_descriptors, config, gid);
+}
+
+__global__ void segmented_bucket_accumulation_bls12_381(
+    const unsigned int *sorted_descriptors,
+    const unsigned int *offsets,
     const unsigned long long *points,
     unsigned long long *buckets,
     const unsigned int *config
 ) {
     unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;
-    bucket_accumulation_384_impl(scalars, points, buckets, config, gid);
+    segmented_bucket_accumulation_384_impl(sorted_descriptors, offsets, points, buckets, config, gid);
+}
+
+__global__ void partial_segment_accumulation_bls12_381(
+    const unsigned int *sorted_descriptors,
+    const unsigned int *task_starts,
+    const unsigned int *task_lengths,
+    const unsigned long long *points,
+    unsigned long long *partial_buckets,
+    const unsigned int *config
+) {
+    unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    partial_segment_accumulation_384_impl(
+        sorted_descriptors,
+        task_starts,
+        task_lengths,
+        points,
+        partial_buckets,
+        config,
+        gid
+    );
+}
+
+__global__ void finalize_segment_accumulation_bls12_381(
+    const unsigned int *task_offsets,
+    unsigned long long *partial_buckets,
+    unsigned long long *buckets,
+    const unsigned int *config
+) {
+    unsigned int bucket_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    finalize_segment_accumulation_384_impl(task_offsets, partial_buckets, buckets, config, bucket_idx);
+}
+
+__global__ void partial_bucket_reduction_bls12_381(
+    unsigned long long *buckets,
+    unsigned long long *partial_sums,
+    unsigned long long *partial_results,
+    const unsigned int *config
+) {
+    unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    partial_bucket_reduction_384_impl(buckets, partial_sums, partial_results, config, gid);
+}
+
+__global__ void finalize_bucket_reduction_bls12_381(
+    unsigned long long *partial_sums,
+    unsigned long long *partial_results,
+    unsigned long long *window_sums,
+    const unsigned int *config
+) {
+    unsigned int window_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    finalize_bucket_reduction_384_impl(partial_sums, partial_results, window_sums, config, window_idx);
 }
 
 __global__ void bucket_reduction_bls12_381(

--- a/crates/math/src/gpu/cuda/shaders/msm/msm.cuh
+++ b/crates/math/src/gpu/cuda/shaders/msm/msm.cuh
@@ -1,8 +1,5 @@
 // MSM kernel templates for CUDA (384-bit)
 // Ported from lambdaworks Metal MSM kernels
-//
-// WARNING: The bucket_accumulation kernel has a RACE CONDITION when multiple
-// threads write to the same bucket. See bls12_381_msm.cu for details.
 
 #ifndef MSM384_CUH
 #define MSM384_CUH
@@ -15,64 +12,262 @@
 // config[2] = num_buckets
 // config[3] = window_size
 
-// Bucket accumulation kernel
-// WARNING: This kernel has a RACE CONDITION when multiple threads write to the same bucket.
-// For production use, implement one of:
-// 1. Sorting-based approach (cuZK paper) - sort (bucket_idx, point) pairs, then scan
-// 2. Atomic operations for point addition (complex for 384-bit)
-// 3. Per-thread local buckets with tree reduction
-//
-// Current behavior: The last thread to write to a bucket wins, producing incorrect results
-// when multiple points map to the same bucket.
-__device__ void bucket_accumulation_384_impl(
+#define MSM_DESC_SIGN_BIT_384 0x80000000u
+#define MSM_DESC_INDEX_MASK_384 0x7fffffffu
+#define MSM_SEGMENT_CHUNK_SIZE_384 256u
+
+__device__ void count_bucket_entries_384_impl(
     const int *scalars,
-    const unsigned long long *points,
-    unsigned long long *buckets,
+    unsigned int *counts,
     const unsigned int *config,
     unsigned int gid
 ) {
     unsigned int num_scalars = config[0];
     unsigned int num_windows = config[1];
     unsigned int num_buckets = config[2];
+    unsigned int total_digits = num_scalars * num_windows;
 
-    // Each thread handles one (scalar, window) pair
-    unsigned int scalar_idx = gid / num_windows;
-    unsigned int window_idx = gid % num_windows;
+    if (gid >= total_digits) return;
 
-    if (scalar_idx >= num_scalars) return;
-
-    // Get the signed digit for this scalar and window
-    int digit = scalars[scalar_idx * num_windows + window_idx];
-
+    int digit = scalars[gid];
     if (digit == 0) return;
 
-    // Load the point
-    JacobianPoint384 p = load_point_384(points, scalar_idx);
+    unsigned int scalar_idx = gid / num_windows;
+    unsigned int window_idx = gid - scalar_idx * num_windows;
+    unsigned int abs_digit = (digit < 0) ? (unsigned int)(-digit) : (unsigned int)digit;
+    unsigned int bucket_idx = abs_digit - 1;
 
-    // Determine bucket index and whether to negate
-    unsigned int bucket_idx;
-    bool negate;
-    if (digit > 0) {
-        bucket_idx = (unsigned int)(digit - 1);
-        negate = false;
-    } else {
-        bucket_idx = (unsigned int)(-digit - 1);
-        negate = true;
+    if (bucket_idx >= num_buckets) return;
+
+    unsigned int key = window_idx * num_buckets + bucket_idx;
+    atomicAdd(&counts[key], 1u);
+}
+
+__device__ void scatter_bucket_descriptors_384_impl(
+    const int *scalars,
+    unsigned int *write_counts,
+    const unsigned int *offsets,
+    unsigned int *sorted_descriptors,
+    const unsigned int *config,
+    unsigned int gid
+) {
+    unsigned int num_scalars = config[0];
+    unsigned int num_windows = config[1];
+    unsigned int num_buckets = config[2];
+    unsigned int total_digits = num_scalars * num_windows;
+
+    if (gid >= total_digits) return;
+
+    int digit = scalars[gid];
+    if (digit == 0) return;
+
+    unsigned int scalar_idx = gid / num_windows;
+    unsigned int window_idx = gid - scalar_idx * num_windows;
+    unsigned int abs_digit = (digit < 0) ? (unsigned int)(-digit) : (unsigned int)digit;
+    unsigned int bucket_idx = abs_digit - 1;
+
+    if (bucket_idx >= num_buckets) return;
+
+    unsigned int key = window_idx * num_buckets + bucket_idx;
+    unsigned int write_idx = atomicAdd(&write_counts[key], 1u);
+    unsigned int descriptor = scalar_idx & MSM_DESC_INDEX_MASK_384;
+
+    if (digit < 0) {
+        descriptor |= MSM_DESC_SIGN_BIT_384;
     }
 
-    // Negate point if needed
-    if (negate) {
+    sorted_descriptors[offsets[key] + write_idx] = descriptor;
+}
+
+__device__ JacobianPoint384 load_signed_descriptor_point_384(
+    const unsigned int *sorted_descriptors,
+    const unsigned long long *points,
+    unsigned int descriptor_idx
+) {
+    unsigned int descriptor = sorted_descriptors[descriptor_idx];
+    unsigned int scalar_idx = descriptor & MSM_DESC_INDEX_MASK_384;
+    JacobianPoint384 p = load_point_384(points, scalar_idx);
+
+    if ((descriptor & MSM_DESC_SIGN_BIT_384) != 0) {
         p = jacobian_neg_384(p, BLS12_381_P);
     }
 
-    // Calculate global bucket index
-    unsigned int global_bucket_idx = window_idx * num_buckets + bucket_idx;
+    return p;
+}
 
-    // Load current bucket value, add point, store back
-    // WARNING: This read-modify-write is NOT atomic and causes race conditions
-    JacobianPoint384 bucket = load_point_384(buckets, global_bucket_idx);
-    bucket = jacobian_add_384(bucket, p, BLS12_381_P, BLS12_381_INV);
-    store_point_384(buckets, global_bucket_idx, bucket);
+__device__ void segmented_bucket_accumulation_384_impl(
+    const unsigned int *sorted_descriptors,
+    const unsigned int *offsets,
+    const unsigned long long *points,
+    unsigned long long *buckets,
+    const unsigned int *config,
+    unsigned int gid
+) {
+    unsigned int num_windows = config[1];
+    unsigned int num_buckets = config[2];
+    unsigned int total_buckets = num_windows * num_buckets;
+
+    if (gid >= total_buckets) return;
+
+    unsigned int start = offsets[gid];
+    unsigned int end = offsets[gid + 1];
+    JacobianPoint384 bucket = jacobian_identity_384();
+
+    for (unsigned int i = start; i < end; i++) {
+        JacobianPoint384 p = load_signed_descriptor_point_384(sorted_descriptors, points, i);
+        bucket = jacobian_add_384(bucket, p, BLS12_381_P, BLS12_381_INV);
+    }
+
+    store_point_384(buckets, gid, bucket);
+}
+
+__device__ void partial_segment_accumulation_384_impl(
+    const unsigned int *sorted_descriptors,
+    const unsigned int *task_starts,
+    const unsigned int *task_lengths,
+    const unsigned long long *points,
+    unsigned long long *partial_buckets,
+    const unsigned int *config,
+    unsigned int gid
+) {
+    unsigned int total_tasks = config[0];
+
+    if (gid >= total_tasks) return;
+
+    unsigned int start = task_starts[gid];
+    unsigned int len = task_lengths[gid];
+    unsigned int end = start + len;
+    JacobianPoint384 bucket = jacobian_identity_384();
+
+    for (unsigned int i = start; i < end; i++) {
+        JacobianPoint384 p = load_signed_descriptor_point_384(sorted_descriptors, points, i);
+        bucket = jacobian_add_384(bucket, p, BLS12_381_P, BLS12_381_INV);
+    }
+
+    store_point_384(partial_buckets, gid, bucket);
+}
+
+__device__ void finalize_segment_accumulation_384_impl(
+    const unsigned int *task_offsets,
+    unsigned long long *partial_buckets,
+    unsigned long long *buckets,
+    const unsigned int *config,
+    unsigned int bucket_idx
+) {
+    unsigned int total_buckets = config[1];
+
+    if (bucket_idx >= total_buckets) return;
+
+    unsigned int start = task_offsets[bucket_idx];
+    unsigned int end = task_offsets[bucket_idx + 1];
+    JacobianPoint384 bucket = jacobian_identity_384();
+
+    for (unsigned int i = start; i < end; i++) {
+        JacobianPoint384 partial = load_point_384(partial_buckets, i);
+        bucket = jacobian_add_384(bucket, partial, BLS12_381_P, BLS12_381_INV);
+    }
+
+    store_point_384(buckets, bucket_idx, bucket);
+}
+
+__device__ JacobianPoint384 jacobian_mul_u32_384(JacobianPoint384 point, unsigned int scalar) {
+    JacobianPoint384 result = jacobian_identity_384();
+
+    while (scalar != 0) {
+        if ((scalar & 1u) != 0) {
+            result = jacobian_add_384(result, point, BLS12_381_P, BLS12_381_INV);
+        }
+        scalar >>= 1;
+        if (scalar != 0) {
+            point = jacobian_double_384(point, BLS12_381_P, BLS12_381_INV);
+        }
+    }
+
+    return result;
+}
+
+__device__ void partial_bucket_reduction_384_impl(
+    unsigned long long *buckets,
+    unsigned long long *partial_sums,
+    unsigned long long *partial_results,
+    const unsigned int *config,
+    unsigned int gid
+) {
+    unsigned int num_windows = config[0];
+    unsigned int num_buckets = config[1];
+    unsigned int chunk_size = config[2];
+    unsigned int chunks_per_window = config[3];
+    unsigned int total_chunks = num_windows * chunks_per_window;
+
+    if (gid >= total_chunks) return;
+
+    unsigned int window_idx = gid / chunks_per_window;
+    unsigned int chunk_idx = gid - window_idx * chunks_per_window;
+    unsigned int chunk_start = chunk_idx * chunk_size;
+    unsigned int chunk_end = chunk_start + chunk_size;
+
+    if (chunk_start >= num_buckets) {
+        store_point_384(partial_sums, gid, jacobian_identity_384());
+        store_point_384(partial_results, gid, jacobian_identity_384());
+        return;
+    }
+    if (chunk_end > num_buckets) {
+        chunk_end = num_buckets;
+    }
+
+    unsigned int bucket_base = window_idx * num_buckets;
+    JacobianPoint384 running_sum = jacobian_identity_384();
+    JacobianPoint384 result = jacobian_identity_384();
+
+    for (int i = (int)chunk_end - 1; i >= (int)chunk_start; i--) {
+        JacobianPoint384 bucket = load_point_384(buckets, bucket_base + (unsigned int)i);
+        running_sum = jacobian_add_384(running_sum, bucket, BLS12_381_P, BLS12_381_INV);
+        result = jacobian_add_384(result, running_sum, BLS12_381_P, BLS12_381_INV);
+    }
+
+    store_point_384(partial_sums, gid, running_sum);
+    store_point_384(partial_results, gid, result);
+}
+
+__device__ void finalize_bucket_reduction_384_impl(
+    unsigned long long *partial_sums,
+    unsigned long long *partial_results,
+    unsigned long long *window_sums,
+    const unsigned int *config,
+    unsigned int window_idx
+) {
+    unsigned int num_windows = config[0];
+    unsigned int num_buckets = config[1];
+    unsigned int chunk_size = config[2];
+    unsigned int chunks_per_window = config[3];
+
+    if (window_idx >= num_windows) return;
+
+    JacobianPoint384 higher_chunks_sum = jacobian_identity_384();
+    JacobianPoint384 result = jacobian_identity_384();
+    unsigned int partial_base = window_idx * chunks_per_window;
+
+    for (int chunk_idx = (int)chunks_per_window - 1; chunk_idx >= 0; chunk_idx--) {
+        unsigned int chunk_start = (unsigned int)chunk_idx * chunk_size;
+        if (chunk_start >= num_buckets) continue;
+
+        unsigned int chunk_end = chunk_start + chunk_size;
+        if (chunk_end > num_buckets) {
+            chunk_end = num_buckets;
+        }
+        unsigned int chunk_len = chunk_end - chunk_start;
+        unsigned int partial_idx = partial_base + (unsigned int)chunk_idx;
+
+        JacobianPoint384 carry = jacobian_mul_u32_384(higher_chunks_sum, chunk_len);
+        JacobianPoint384 partial_result = load_point_384(partial_results, partial_idx);
+        JacobianPoint384 partial_sum = load_point_384(partial_sums, partial_idx);
+
+        result = jacobian_add_384(result, carry, BLS12_381_P, BLS12_381_INV);
+        result = jacobian_add_384(result, partial_result, BLS12_381_P, BLS12_381_INV);
+        higher_chunks_sum = jacobian_add_384(higher_chunks_sum, partial_sum, BLS12_381_P, BLS12_381_INV);
+    }
+
+    store_point_384(window_sums, window_idx, result);
 }
 
 // Bucket reduction kernel
@@ -90,13 +285,9 @@ __device__ void bucket_reduction_384_impl(
     if (window_idx >= num_windows) return;
 
     unsigned int bucket_base = window_idx * num_buckets;
-
-    // Running sum for bucket reduction
     JacobianPoint384 running_sum = jacobian_identity_384();
-    // Accumulated result
     JacobianPoint384 result = jacobian_identity_384();
 
-    // Process buckets in reverse order (highest weight first)
     for (int i = (int)num_buckets - 1; i >= 0; i--) {
         JacobianPoint384 bucket = load_point_384(buckets, bucket_base + (unsigned int)i);
 
@@ -104,7 +295,6 @@ __device__ void bucket_reduction_384_impl(
         result = jacobian_add_384(result, running_sum, BLS12_381_P, BLS12_381_INV);
     }
 
-    // Store the window sum
     store_point_384(window_sums, window_idx, result);
 }
 

--- a/crates/math/src/msm/cuda.rs
+++ b/crates/math/src/msm/cuda.rs
@@ -14,19 +14,19 @@
 //! 4. **Window combination**: Combine window results with Horner's method (CPU)
 //!
 //! # Known Limitations
-//! - The bucket accumulation kernel has a race condition when multiple threads
-//!   write to the same bucket. This is the same limitation as the Metal MSM.
-//!   A sorting-based fix is planned as follow-up.
 //! - Only BLS12-381 is supported. Constants are hardcoded.
 //! - CPU-side MSM logic is duplicated from the Metal MSM module. A follow-up
 //!   should extract shared code.
 
-use cudarc::driver::{CudaDevice, LaunchAsync, LaunchConfig};
+use cudarc::driver::{safe::CudaSlice, CudaDevice, LaunchAsync, LaunchConfig};
 use cudarc::nvrtc::safe::Ptx;
 use lambdaworks_gpu::cuda::abstractions::errors::CudaError;
 use std::sync::Arc;
 
 const BLS12_381_MSM_PTX: &str = include_str!("../gpu/cuda/shaders/msm/bls12_381_msm.ptx");
+const MSM_DESCRIPTOR_INDEX_MASK: usize = 0x7fff_ffff;
+const SEGMENT_ACCUMULATION_CHUNK_SIZE: usize = 256;
+const BUCKET_REDUCTION_CHUNK_SIZE: usize = 256;
 
 /// Configuration for MSM computation.
 ///
@@ -92,6 +92,56 @@ pub struct CudaMSM {
     config: MSMConfig,
 }
 
+fn checked_u32_len(value: usize, name: &str) -> Result<u32, CudaError> {
+    u32::try_from(value)
+        .map_err(|_| CudaError::FunctionError(format!("{name} {value} exceeds u32::MAX")))
+}
+
+fn exclusive_scan_counts(counts: &[u32]) -> Result<(Vec<u32>, u32), CudaError> {
+    let mut offsets = Vec::with_capacity(counts.len() + 1);
+    let mut running = 0u32;
+
+    for &count in counts {
+        offsets.push(running);
+        running = running.checked_add(count).ok_or_else(|| {
+            CudaError::FunctionError("Bucket descriptor count overflowed u32".to_string())
+        })?;
+    }
+
+    offsets.push(running);
+    Ok((offsets, running))
+}
+
+fn build_segment_tasks(counts: &[u32]) -> Result<(Vec<u32>, Vec<u32>, Vec<u32>, u32), CudaError> {
+    let mut task_offsets = Vec::with_capacity(counts.len() + 1);
+    let mut task_starts = Vec::new();
+    let mut task_lengths = Vec::new();
+    let mut descriptor_offset = 0u32;
+    let mut task_count = 0u32;
+
+    for &count in counts {
+        task_offsets.push(task_count);
+
+        let mut consumed = 0u32;
+        while consumed < count {
+            let len = (count - consumed).min(SEGMENT_ACCUMULATION_CHUNK_SIZE as u32);
+            task_starts.push(descriptor_offset + consumed);
+            task_lengths.push(len);
+            consumed += len;
+            task_count = task_count.checked_add(1).ok_or_else(|| {
+                CudaError::FunctionError("Segment task count overflowed u32".to_string())
+            })?;
+        }
+
+        descriptor_offset = descriptor_offset.checked_add(count).ok_or_else(|| {
+            CudaError::FunctionError("Segment descriptor offset overflowed u32".to_string())
+        })?;
+    }
+
+    task_offsets.push(task_count);
+    Ok((task_offsets, task_starts, task_lengths, task_count))
+}
+
 impl CudaMSM {
     /// Creates a new CudaMSM instance with the given configuration.
     pub fn new(config: MSMConfig) -> Result<Self, CudaError> {
@@ -103,7 +153,13 @@ impl CudaMSM {
                 Ptx::from_src(BLS12_381_MSM_PTX),
                 "bls12_381_msm",
                 &[
-                    "bucket_accumulation_bls12_381",
+                    "count_bucket_entries_bls12_381",
+                    "scatter_bucket_descriptors_bls12_381",
+                    "segmented_bucket_accumulation_bls12_381",
+                    "partial_segment_accumulation_bls12_381",
+                    "finalize_segment_accumulation_bls12_381",
+                    "partial_bucket_reduction_bls12_381",
+                    "finalize_bucket_reduction_bls12_381",
                     "bucket_reduction_bls12_381",
                 ],
             )
@@ -172,23 +228,40 @@ impl CudaMSM {
             return Err(CudaError::FunctionError("Empty input".to_string()));
         }
 
-        // TODO: Remove this guard once bucket accumulation race condition is fixed
-        // (sorting-based approach or per-thread local buckets with tree reduction)
-        if num_scalars > 1 {
-            return Err(CudaError::FunctionError(
-                "Multi-point MSM not yet supported: bucket accumulation has a known \
-                 race condition. Use single-point MSM or CPU pippenger for multiple points."
-                    .to_string(),
-            ));
+        let num_buckets = self.config.num_buckets();
+        let effective_windows = self.config.num_windows() + 1;
+
+        if num_scalars > MSM_DESCRIPTOR_INDEX_MASK {
+            return Err(CudaError::FunctionError(format!(
+                "Scalars count {} exceeds descriptor capacity {}",
+                num_scalars, MSM_DESCRIPTOR_INDEX_MASK
+            )));
         }
+
+        let total_bucket_keys = effective_windows.checked_mul(num_buckets).ok_or_else(|| {
+            CudaError::FunctionError("Bucket key count overflowed usize".to_string())
+        })?;
+        let total_digits = num_scalars.checked_mul(effective_windows).ok_or_else(|| {
+            CudaError::FunctionError("Signed digit count overflowed usize".to_string())
+        })?;
+        let total_bucket_elements =
+            total_bucket_keys
+                .checked_mul(limbs_per_point)
+                .ok_or_else(|| {
+                    CudaError::FunctionError("Bucket buffer length overflowed usize".to_string())
+                })?;
+
+        let num_scalars_u32 = checked_u32_len(num_scalars, "num_scalars")?;
+        let effective_windows_u32 = checked_u32_len(effective_windows, "effective_windows")?;
+        let num_buckets_u32 = checked_u32_len(num_buckets, "num_buckets")?;
+        let total_digits_u32 = checked_u32_len(total_digits, "total_digits")?;
+        let total_bucket_keys_u32 = checked_u32_len(total_bucket_keys, "total_bucket_keys")?;
+        let window_size_u32 = checked_u32_len(self.config.window_size, "window_size")?;
 
         // Step 1: Recode scalars to signed digits (CPU)
         let signed_digits = self.recode_scalars_signed(scalars, num_scalars);
 
-        // Step 2: Create GPU buffers
-        let num_buckets = self.config.num_buckets();
-        let effective_windows = self.config.num_windows() + 1;
-
+        // Step 2: Count and compact nonzero signed digits into bucket segments
         let scalars_buf = self
             .device
             .htod_sync_copy(&signed_digits)
@@ -199,80 +272,279 @@ impl CudaMSM {
             .htod_sync_copy(points)
             .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
 
-        // Zero-initialized buckets (identity points have z=0)
-        let total_bucket_elements = effective_windows * num_buckets * limbs_per_point;
-        let bucket_data = vec![0u64; total_bucket_elements];
-        let mut buckets_buf = self
-            .device
-            .htod_sync_copy(&bucket_data)
-            .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
-
-        // Config for accumulation: [num_scalars, num_windows, num_buckets, window_size]
         let config_data: [u32; 4] = [
-            num_scalars as u32,
-            effective_windows as u32,
-            num_buckets as u32,
-            self.config.window_size as u32,
+            num_scalars_u32,
+            effective_windows_u32,
+            num_buckets_u32,
+            window_size_u32,
         ];
         let config_buf = self
             .device
             .htod_sync_copy(&config_data)
             .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
 
-        // Step 3: Run bucket accumulation kernel
-        let accum_func = self
+        let mut counts_buf: CudaSlice<u32> = self
             .device
-            .get_func("bls12_381_msm", "bucket_accumulation_bls12_381")
-            .ok_or_else(|| CudaError::FunctionError("bucket_accumulation_bls12_381".to_string()))?;
+            .alloc_zeros(total_bucket_keys)
+            .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
 
-        let total_threads = num_scalars * effective_windows;
+        let count_func = self
+            .device
+            .get_func("bls12_381_msm", "count_bucket_entries_bls12_381")
+            .ok_or_else(|| {
+                CudaError::FunctionError("count_bucket_entries_bls12_381".to_string())
+            })?;
+
         let block_size = 256u32;
-        let grid_size = ((total_threads as u32) + block_size - 1) / block_size;
-
-        let accum_config = LaunchConfig {
-            grid_dim: (grid_size, 1, 1),
+        let digit_grid_size = total_digits_u32.div_ceil(block_size);
+        let digit_launch_config = LaunchConfig {
+            grid_dim: (digit_grid_size, 1, 1),
             block_dim: (block_size, 1, 1),
             shared_mem_bytes: 0,
         };
 
         unsafe {
-            accum_func.launch(
-                accum_config,
-                (&scalars_buf, &points_buf, &mut buckets_buf, &config_buf),
+            count_func.launch(
+                digit_launch_config,
+                (&scalars_buf, &mut counts_buf, &config_buf),
             )
         }
         .map_err(|err| CudaError::Launch(err.to_string()))?;
 
-        // Step 4: Run bucket reduction kernel
+        let counts = self
+            .device
+            .sync_reclaim(counts_buf)
+            .map_err(|err| CudaError::RetrieveMemory(err.to_string()))?;
+        let (offsets, nonzero_items) = exclusive_scan_counts(&counts)?;
+        let (task_offsets, task_starts, task_lengths, segment_task_count) =
+            build_segment_tasks(&counts)?;
+        let sorted_descriptor_len = (nonzero_items as usize).max(1);
+        let segment_task_len = (segment_task_count as usize).max(1);
+        let segment_task_count_u32 =
+            checked_u32_len(segment_task_count as usize, "segment_task_count")?;
+        let task_starts_upload = if task_starts.is_empty() {
+            vec![0]
+        } else {
+            task_starts
+        };
+        let task_lengths_upload = if task_lengths.is_empty() {
+            vec![0]
+        } else {
+            task_lengths
+        };
+        let partial_bucket_elements =
+            segment_task_len
+                .checked_mul(limbs_per_point)
+                .ok_or_else(|| {
+                    CudaError::FunctionError("Partial segment buffer overflowed usize".to_string())
+                })?;
+
+        let offsets_buf = self
+            .device
+            .htod_sync_copy(&offsets)
+            .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
+        let mut write_counts_buf: CudaSlice<u32> = self
+            .device
+            .alloc_zeros(total_bucket_keys)
+            .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
+        let mut sorted_descriptors_buf: CudaSlice<u32> = self
+            .device
+            .alloc_zeros(sorted_descriptor_len)
+            .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
+
+        let scatter_func = self
+            .device
+            .get_func("bls12_381_msm", "scatter_bucket_descriptors_bls12_381")
+            .ok_or_else(|| {
+                CudaError::FunctionError("scatter_bucket_descriptors_bls12_381".to_string())
+            })?;
+
+        unsafe {
+            scatter_func.launch(
+                digit_launch_config,
+                (
+                    &scalars_buf,
+                    &mut write_counts_buf,
+                    &offsets_buf,
+                    &mut sorted_descriptors_buf,
+                    &config_buf,
+                ),
+            )
+        }
+        .map_err(|err| CudaError::Launch(err.to_string()))?;
+
+        let mut buckets_buf: CudaSlice<u64> = self
+            .device
+            .alloc_zeros(total_bucket_elements)
+            .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
+
+        let task_offsets_buf = self
+            .device
+            .htod_sync_copy(&task_offsets)
+            .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
+        let task_starts_buf = self
+            .device
+            .htod_sync_copy(&task_starts_upload)
+            .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
+        let task_lengths_buf = self
+            .device
+            .htod_sync_copy(&task_lengths_upload)
+            .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
+        let segment_config_data: [u32; 4] = [segment_task_count_u32, total_bucket_keys_u32, 0, 0];
+        let segment_config_buf = self
+            .device
+            .htod_sync_copy(&segment_config_data)
+            .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
+        let mut partial_buckets_buf: CudaSlice<u64> = self
+            .device
+            .alloc_zeros(partial_bucket_elements)
+            .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
+
+        let partial_segment_func = self
+            .device
+            .get_func("bls12_381_msm", "partial_segment_accumulation_bls12_381")
+            .ok_or_else(|| {
+                CudaError::FunctionError("partial_segment_accumulation_bls12_381".to_string())
+            })?;
+        let finalize_segment_func = self
+            .device
+            .get_func("bls12_381_msm", "finalize_segment_accumulation_bls12_381")
+            .ok_or_else(|| {
+                CudaError::FunctionError("finalize_segment_accumulation_bls12_381".to_string())
+            })?;
+
+        let segment_task_grid_size = segment_task_count_u32.div_ceil(block_size).max(1);
+        let segment_task_launch_config = LaunchConfig {
+            grid_dim: (segment_task_grid_size, 1, 1),
+            block_dim: (block_size, 1, 1),
+            shared_mem_bytes: 0,
+        };
+
+        unsafe {
+            partial_segment_func.launch(
+                segment_task_launch_config,
+                (
+                    &sorted_descriptors_buf,
+                    &task_starts_buf,
+                    &task_lengths_buf,
+                    &points_buf,
+                    &mut partial_buckets_buf,
+                    &segment_config_buf,
+                ),
+            )
+        }
+        .map_err(|err| CudaError::Launch(err.to_string()))?;
+
+        let bucket_grid_size = total_bucket_keys_u32.div_ceil(block_size);
+        let bucket_launch_config = LaunchConfig {
+            grid_dim: (bucket_grid_size, 1, 1),
+            block_dim: (block_size, 1, 1),
+            shared_mem_bytes: 0,
+        };
+
+        unsafe {
+            finalize_segment_func.launch(
+                bucket_launch_config,
+                (
+                    &task_offsets_buf,
+                    &mut partial_buckets_buf,
+                    &mut buckets_buf,
+                    &segment_config_buf,
+                ),
+            )
+        }
+        .map_err(|err| CudaError::Launch(err.to_string()))?;
+
+        // Step 3: Run bucket reduction kernel
         let window_sums_data = vec![0u64; effective_windows * limbs_per_point];
         let mut window_sums_buf = self
             .device
             .htod_sync_copy(&window_sums_data)
             .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
 
-        // Reduction config: [num_windows, num_buckets]
-        let reduction_config_data: [u32; 2] = [effective_windows as u32, num_buckets as u32];
+        let reduction_chunk_size = BUCKET_REDUCTION_CHUNK_SIZE.min(num_buckets);
+        let chunks_per_window = num_buckets.div_ceil(reduction_chunk_size);
+        let total_reduction_chunks = effective_windows
+            .checked_mul(chunks_per_window)
+            .ok_or_else(|| {
+                CudaError::FunctionError("Reduction chunk count overflowed usize".to_string())
+            })?;
+        let reduction_chunk_size_u32 =
+            checked_u32_len(reduction_chunk_size, "reduction_chunk_size")?;
+        let chunks_per_window_u32 = checked_u32_len(chunks_per_window, "chunks_per_window")?;
+        let total_reduction_chunks_u32 =
+            checked_u32_len(total_reduction_chunks, "total_reduction_chunks")?;
+
+        let reduction_config_data: [u32; 4] = [
+            effective_windows_u32,
+            num_buckets_u32,
+            reduction_chunk_size_u32,
+            chunks_per_window_u32,
+        ];
         let reduction_config_buf = self
             .device
             .htod_sync_copy(&reduction_config_data)
             .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
 
-        let reduce_func = self
+        let partial_buffer_elements = total_reduction_chunks
+            .checked_mul(limbs_per_point)
+            .ok_or_else(|| {
+                CudaError::FunctionError("Partial reduction buffer overflowed usize".to_string())
+            })?;
+        let mut partial_sums_buf: CudaSlice<u64> = self
             .device
-            .get_func("bls12_381_msm", "bucket_reduction_bls12_381")
-            .ok_or_else(|| CudaError::FunctionError("bucket_reduction_bls12_381".to_string()))?;
+            .alloc_zeros(partial_buffer_elements)
+            .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
+        let mut partial_results_buf: CudaSlice<u64> = self
+            .device
+            .alloc_zeros(partial_buffer_elements)
+            .map_err(|err| CudaError::AllocateMemory(err.to_string()))?;
 
-        let reduce_config = LaunchConfig {
-            grid_dim: (effective_windows as u32, 1, 1),
-            block_dim: (1, 1, 1),
+        let partial_reduce_func = self
+            .device
+            .get_func("bls12_381_msm", "partial_bucket_reduction_bls12_381")
+            .ok_or_else(|| {
+                CudaError::FunctionError("partial_bucket_reduction_bls12_381".to_string())
+            })?;
+        let finalize_reduce_func = self
+            .device
+            .get_func("bls12_381_msm", "finalize_bucket_reduction_bls12_381")
+            .ok_or_else(|| {
+                CudaError::FunctionError("finalize_bucket_reduction_bls12_381".to_string())
+            })?;
+
+        let reduction_grid_size = total_reduction_chunks_u32.div_ceil(block_size);
+        let partial_reduce_config = LaunchConfig {
+            grid_dim: (reduction_grid_size, 1, 1),
+            block_dim: (block_size, 1, 1),
             shared_mem_bytes: 0,
         };
 
         unsafe {
-            reduce_func.launch(
-                reduce_config,
+            partial_reduce_func.launch(
+                partial_reduce_config,
                 (
                     &mut buckets_buf,
+                    &mut partial_sums_buf,
+                    &mut partial_results_buf,
+                    &reduction_config_buf,
+                ),
+            )
+        }
+        .map_err(|err| CudaError::Launch(err.to_string()))?;
+
+        let finalize_reduce_config = LaunchConfig {
+            grid_dim: (effective_windows_u32.div_ceil(block_size), 1, 1),
+            block_dim: (block_size, 1, 1),
+            shared_mem_bytes: 0,
+        };
+
+        unsafe {
+            finalize_reduce_func.launch(
+                finalize_reduce_config,
+                (
+                    &mut partial_sums_buf,
+                    &mut partial_results_buf,
                     &mut window_sums_buf,
                     &reduction_config_buf,
                 ),
@@ -682,6 +954,32 @@ mod tests {
     }
 
     #[test]
+    fn test_exclusive_scan_counts_all_zero() {
+        let (offsets, total) = exclusive_scan_counts(&[0, 0, 0]).expect("scan failed");
+        assert_eq!(offsets, vec![0, 0, 0, 0]);
+        assert_eq!(total, 0);
+    }
+
+    #[test]
+    fn test_exclusive_scan_counts_single_nonzero() {
+        let (offsets, total) = exclusive_scan_counts(&[0, 3, 0]).expect("scan failed");
+        assert_eq!(offsets, vec![0, 0, 3, 3]);
+        assert_eq!(total, 3);
+    }
+
+    #[test]
+    fn test_exclusive_scan_counts_multiple_buckets() {
+        let (offsets, total) = exclusive_scan_counts(&[2, 0, 5, 1]).expect("scan failed");
+        assert_eq!(offsets, vec![0, 2, 2, 7, 8]);
+        assert_eq!(total, 8);
+    }
+
+    #[test]
+    fn test_exclusive_scan_counts_overflow() {
+        assert!(exclusive_scan_counts(&[u32::MAX, 1]).is_err());
+    }
+
+    #[test]
     fn test_scalar_recoding_simple() {
         let config = MSMConfig {
             window_size: 4,
@@ -832,22 +1130,6 @@ mod tests {
 
     #[test]
     fn test_cuda_msm_single_point() {
-        use crate::{
-            cyclic_group::IsGroup,
-            elliptic_curve::{
-                short_weierstrass::{
-                    curves::bls12_381::{
-                        curve::BLS12381Curve, field_extension::BLS12381PrimeField,
-                    },
-                    point::ShortWeierstrassJacobianPoint,
-                },
-                traits::IsEllipticCurve,
-            },
-            field::element::FieldElement,
-            msm::pippenger,
-            unsigned_integer::element::UnsignedInteger,
-        };
-
         let g = BLS12381Curve::generator();
         let scalar = UnsignedInteger::<4>::from_u64(7);
 
@@ -874,22 +1156,6 @@ mod tests {
 
     #[test]
     fn test_cuda_msm_small() {
-        use crate::{
-            cyclic_group::IsGroup,
-            elliptic_curve::{
-                short_weierstrass::{
-                    curves::bls12_381::{
-                        curve::BLS12381Curve, field_extension::BLS12381PrimeField,
-                    },
-                    point::ShortWeierstrassJacobianPoint,
-                },
-                traits::IsEllipticCurve,
-            },
-            field::element::FieldElement,
-            msm::pippenger,
-            unsigned_integer::element::UnsignedInteger,
-        };
-
         // Single-point MSMs to avoid the race condition
         let g = BLS12381Curve::generator();
 
@@ -918,22 +1184,6 @@ mod tests {
 
     #[test]
     fn test_cuda_msm_large_scalar() {
-        use crate::{
-            cyclic_group::IsGroup,
-            elliptic_curve::{
-                short_weierstrass::{
-                    curves::bls12_381::{
-                        curve::BLS12381Curve, field_extension::BLS12381PrimeField,
-                    },
-                    point::ShortWeierstrassJacobianPoint,
-                },
-                traits::IsEllipticCurve,
-            },
-            field::element::FieldElement,
-            msm::pippenger,
-            unsigned_integer::element::UnsignedInteger,
-        };
-
         let g = BLS12381Curve::generator();
         let scalar = UnsignedInteger::<4>::from_limbs([
             0x0000000000000001,
@@ -961,18 +1211,156 @@ mod tests {
         assert_eq!(cpu_affine.y(), gpu_affine.y(), "y mismatch");
     }
 
+    #[test]
+    fn test_cuda_msm_multi_point_matches_cpu() {
+        let g = BLS12381Curve::generator();
+        let scalars: Vec<_> = [1u64, 2, 7, 42, 255, 1337, 65536, 1 << 20]
+            .into_iter()
+            .map(UnsignedInteger::<4>::from_u64)
+            .collect();
+        let points: Vec<_> = (1u64..=scalars.len() as u64)
+            .map(|power| g.operate_with_self(power))
+            .collect();
+
+        let cpu_result = pippenger::msm(&scalars, &points).expect("CPU MSM failed");
+        let cpu_affine = cpu_result.to_affine();
+
+        let scalars_flat: Vec<_> = scalars.iter().flat_map(scalar_to_gpu_limbs).collect();
+        let points_flat: Vec<_> = points.iter().flat_map(point_to_gpu_flat).collect();
+
+        let msm = CudaMSM::new_bls12_381().expect("CUDA device required");
+        let gpu_result_flat = msm
+            .compute(&scalars_flat, &points_flat)
+            .expect("CUDA MSM compute failed");
+
+        let gpu_point = gpu_flat_to_point(&gpu_result_flat);
+        let gpu_affine = gpu_point.to_affine();
+
+        assert_eq!(cpu_affine.x(), gpu_affine.x(), "x mismatch");
+        assert_eq!(cpu_affine.y(), gpu_affine.y(), "y mismatch");
+    }
+
+    #[test]
+    fn test_cuda_msm_bucket_collision_matches_cpu() {
+        let g = BLS12381Curve::generator();
+        let scalars: Vec<_> = [1u64; 8]
+            .into_iter()
+            .map(UnsignedInteger::<4>::from_u64)
+            .collect();
+        let points: Vec<_> = (1u64..=scalars.len() as u64)
+            .map(|power| g.operate_with_self(power))
+            .collect();
+
+        let cpu_result = pippenger::msm(&scalars, &points).expect("CPU MSM failed");
+        let cpu_affine = cpu_result.to_affine();
+
+        let scalars_flat: Vec<_> = scalars.iter().flat_map(scalar_to_gpu_limbs).collect();
+        let points_flat: Vec<_> = points.iter().flat_map(point_to_gpu_flat).collect();
+
+        let msm = CudaMSM::new_bls12_381().expect("CUDA device required");
+        let gpu_result_flat = msm
+            .compute(&scalars_flat, &points_flat)
+            .expect("CUDA MSM compute failed");
+
+        let gpu_point = gpu_flat_to_point(&gpu_result_flat);
+        let gpu_affine = gpu_point.to_affine();
+
+        assert_eq!(cpu_affine.x(), gpu_affine.x(), "x mismatch");
+        assert_eq!(cpu_affine.y(), gpu_affine.y(), "y mismatch");
+    }
+
+    #[test]
+    fn test_cuda_msm_small_window_bucket_collision_matches_cpu() {
+        assert_cuda_msm_matches_cpu_with_config(
+            &[1u64; 8],
+            MSMConfig {
+                window_size: 4,
+                num_limbs: 4,
+                bits_per_limb: 64,
+                point_coord_limbs: 6,
+            },
+        );
+    }
+
+    #[test]
+    fn test_cuda_msm_negative_signed_digits_match_cpu() {
+        assert_cuda_msm_matches_cpu_with_config(
+            &[8u64, 9, 15, 24, 31, 40, 127, 255],
+            MSMConfig {
+                window_size: 4,
+                num_limbs: 4,
+                bits_per_limb: 64,
+                point_coord_limbs: 6,
+            },
+        );
+    }
+
+    #[test]
+    fn test_cuda_msm_zero_heavy_scalars_match_cpu() {
+        assert_cuda_msm_matches_cpu_with_config(
+            &[0u64, 0, 1, 0, 256, 0, 1 << 20, 0],
+            MSMConfig::bls12_381(),
+        );
+    }
+
+    #[test]
+    fn test_cuda_msm_medium_deterministic_input_matches_cpu() {
+        let scalars: Vec<_> = (0..257)
+            .map(|i| {
+                (i as u64 + 1)
+                    .wrapping_mul(0x9e37_79b9_7f4a_7c15)
+                    .rotate_left((i % 63) as u32)
+            })
+            .collect();
+        assert_cuda_msm_matches_cpu_with_config(&scalars, MSMConfig::bls12_381());
+    }
+
     // =========================================================================
     // Helpers for converting between lambdaworks types and GPU limb format
     // =========================================================================
 
     use crate::{
-        elliptic_curve::short_weierstrass::{
-            curves::bls12_381::{curve::BLS12381Curve, field_extension::BLS12381PrimeField},
-            point::ShortWeierstrassJacobianPoint,
+        cyclic_group::IsGroup,
+        elliptic_curve::{
+            short_weierstrass::{
+                curves::bls12_381::{curve::BLS12381Curve, field_extension::BLS12381PrimeField},
+                point::ShortWeierstrassJacobianPoint,
+            },
+            traits::IsEllipticCurve,
         },
         field::element::FieldElement,
+        msm::pippenger,
         unsigned_integer::element::UnsignedInteger,
     };
+
+    fn assert_cuda_msm_matches_cpu_with_config(scalar_values: &[u64], config: MSMConfig) {
+        let g = BLS12381Curve::generator();
+        let scalars: Vec<_> = scalar_values
+            .iter()
+            .copied()
+            .map(UnsignedInteger::<4>::from_u64)
+            .collect();
+        let points: Vec<_> = (1u64..=scalars.len() as u64)
+            .map(|power| g.operate_with_self(power))
+            .collect();
+
+        let cpu_result = pippenger::msm(&scalars, &points).expect("CPU MSM failed");
+        let cpu_affine = cpu_result.to_affine();
+
+        let scalars_flat: Vec<_> = scalars.iter().flat_map(scalar_to_gpu_limbs).collect();
+        let points_flat: Vec<_> = points.iter().flat_map(point_to_gpu_flat).collect();
+
+        let msm = CudaMSM::new(config).expect("CUDA device required");
+        let gpu_result_flat = msm
+            .compute(&scalars_flat, &points_flat)
+            .expect("CUDA MSM compute failed");
+
+        let gpu_point = gpu_flat_to_point(&gpu_result_flat);
+        let gpu_affine = gpu_point.to_affine();
+
+        assert_eq!(cpu_affine.x(), gpu_affine.x(), "x mismatch");
+        assert_eq!(cpu_affine.y(), gpu_affine.y(), "y mismatch");
+    }
 
     fn fe_to_gpu_limbs(fe: &FieldElement<BLS12381PrimeField>) -> [u64; 6] {
         let be_limbs = fe.value().limbs;

--- a/crates/math/src/msm/cuda.rs
+++ b/crates/math/src/msm/cuda.rs
@@ -155,12 +155,10 @@ impl CudaMSM {
                 &[
                     "count_bucket_entries_bls12_381",
                     "scatter_bucket_descriptors_bls12_381",
-                    "segmented_bucket_accumulation_bls12_381",
                     "partial_segment_accumulation_bls12_381",
                     "finalize_segment_accumulation_bls12_381",
                     "partial_bucket_reduction_bls12_381",
                     "finalize_bucket_reduction_bls12_381",
-                    "bucket_reduction_bls12_381",
                 ],
             )
             .map_err(|err| CudaError::PtxError(err.to_string()))?;
@@ -1156,7 +1154,6 @@ mod tests {
 
     #[test]
     fn test_cuda_msm_small() {
-        // Single-point MSMs to avoid the race condition
         let g = BLS12381Curve::generator();
 
         for k in [1u64, 2, 7, 42, 255, 1337, 65536] {


### PR DESCRIPTION
This speeds up the opt-in CUDA BLS12-381 MSM path for large inputs without changing `CudaMSM::compute` or default CPU MSM selection.

Summary

1. Replace the previous CUDA bucket path with a fixed-key pipeline: count, prefix-scan, scatter, task-list accumulation, and two-stage bucket reduction.

2. Keep the public API unchanged and leave CPU MSM selection untouched.

Validation

1. CUDA output was checked against CPU `pippenger::msm`.

2. Checked cases include mixed inputs, deliberate bucket collisions, small-window collisions, negative signed digits, zero-heavy inputs, and a deterministic 257-point input.

3. All checked outputs matched CPU affine coordinates.

Benchmark

1. Windows, local RTX 5090-class run:
65,536 points: CPU 225.135 ms, CUDA 74.398 ms, 3.0x faster.
1,048,576 points: CPU 3655.832 ms, CUDA 187.013 ms, 19.5x faster.

2. WSL on the same machine:
65,536 points: CPU 221.848 ms, CUDA 82.839 ms, 2.7x faster.
1,048,576 points: CPU 2582.938 ms, CUDA 233.516 ms, 11.1x faster.

3. Every benchmark row was correctness-checked against CPU output.

Caveats

1. Small inputs are still dominated by CUDA launch and host/device synchronization overhead, so this should stay an opt-in CUDA path improvement rather than a default-path switch.

2. Repo-local Windows tests are still blocked before MSM tests by the existing unconditional `pprof v0.13.0` dev-dependency issue on this target.

3. Repo-local WSL tests are still blocked before MSM tests by an unrelated `koalabear` / `rustc 1.95.0` type-checking ICE path.

4. Because of those repo-local blockers, validation used an external harness depending only on local `lambdaworks-math` with `default-features = false` and `features = ["std", "cuda"]`.

Screenshot

![CUDA MSM benchmark screenshot](https://raw.githubusercontent.com/peter941221/lambdaworks/94e732b2d8172a58cfd21d9dc933f42b3b916a32/.github/benchmark-artifacts/lambdaworks-730-cuda-msm-benchmark.png)

Part of #730