### PR TITLE
Review/guruswami sudan panics perf

### DIFF
--- a/examples/reed-solomon-codes/src/guruswami_sudan.rs
+++ b/examples/reed-solomon-codes/src/guruswami_sudan.rs
@@ -43,7 +43,9 @@ use lambdaworks_math::field::element::FieldElement;
 use lambdaworks_math::field::traits::IsField;
 use lambdaworks_math::polynomial::Polynomial;
 
-use crate::polynomial_utils::{find_polynomial_roots_with_domain, BivariatePolynomial};
+use crate::polynomial_utils::{
+    find_polynomial_roots_with_domain, pascal_table_fe, BivariatePolynomial,
+};
 use crate::reed_solomon::ReedSolomonCode;
 
 /// Result of Guruswami-Sudan list decoding.
@@ -139,6 +141,13 @@ fn choose_parameters(n: usize, k: usize) -> (usize, usize) {
 
 /// Counts monomials x^i y^j with (1, w)-weighted degree i + w*j < D.
 fn count_monomials(d: usize, w: usize) -> usize {
+    // With w == 0 the weighted degree i + w*j = i is independent of j, so there
+    // are infinitely many monomials below any bound. Callers must use
+    // w = k - 1 >= 1 (i.e. k >= 2); guard here so we never divide by zero.
+    if w == 0 {
+        return 0;
+    }
+
     let mut count = 0;
     let max_j = d / w + 1;
 
@@ -173,6 +182,11 @@ pub fn gs_list_decode<F: IsField + Clone>(
         received.len(),
         n,
         "Received word length must equal code length"
+    );
+    assert!(
+        k >= 2,
+        "Guruswami-Sudan decoding requires dimension k >= 2 (got k = {k}); \
+         the (1, k-1)-weighted degree is undefined for k < 2"
     );
 
     let (m, d) = choose_parameters(n, k);
@@ -223,6 +237,17 @@ pub fn gs_list_decode_with_multiplicity<F: IsField + Clone>(
     let n = code.code_length();
     let k = code.dimension();
     let domain = code.domain();
+
+    assert_eq!(
+        received.len(),
+        n,
+        "Received word length must equal code length"
+    );
+    assert!(
+        k >= 2,
+        "Guruswami-Sudan decoding requires dimension k >= 2 (got k = {k}); \
+         the (1, k-1)-weighted degree is undefined for k < 2"
+    );
 
     let m = multiplicity;
 
@@ -288,6 +313,19 @@ fn interpolate_with_multiplicity<F: IsField + Clone>(
 
     let num_monomials = monomials.len();
 
+    // Largest x- and y-exponents appearing in any monomial. Used to size the
+    // precomputed power tables and the binomial-coefficient table. The 0 default
+    // is only hit when `monomials` is empty (degenerate d), in which case the
+    // matrix below is empty too and the bound is irrelevant.
+    let max_i_exp = monomials.iter().map(|(i, _)| *i).max().unwrap_or(0);
+    let max_j_exp = monomials.iter().map(|(_, j)| *j).max().unwrap_or(0);
+
+    // Binomial coefficients C(i, a) and C(j, b) reduced into the field. Built via
+    // Pascal's rule (additions only), so it never overflows — unlike computing
+    // C(i, a) as a machine integer, where C(d, m) blows past u64 for the degree
+    // bounds this algorithm produces.
+    let binom_table = pascal_table_fe::<F>(max_i_exp.max(max_j_exp));
+
     // Build constraint matrix
     // Each point contributes m*(m+1)/2 constraints (all partial derivatives)
     let constraints_per_point = m * (m + 1) / 2;
@@ -296,6 +334,11 @@ fn interpolate_with_multiplicity<F: IsField + Clone>(
     let mut matrix: Vec<Vec<FieldElement<F>>> = Vec::with_capacity(total_constraints);
 
     for (alpha, y) in domain.iter().zip(received.iter()) {
+        // Precompute α^e and y^e once per point, rather than recomputing them
+        // for every (monomial, constraint) cell as `alpha.pow(..)` did before.
+        let alpha_powers = power_table(alpha, max_i_exp);
+        let y_powers = power_table(y, max_j_exp);
+
         // For multiplicity m, we need the (a, b)-th partial derivative to vanish
         // for all a + b < m, i.e., a + b ∈ {0, 1, ..., m-1}
         for total_order in 0..m {
@@ -312,16 +355,9 @@ fn interpolate_with_multiplicity<F: IsField + Clone>(
                         // Derivative is zero
                         row.push(FieldElement::<F>::zero());
                     } else {
-                        let binom_i_a = binomial(i, a);
-                        let binom_j_b = binomial(j, b);
-                        let coeff_scalar = (binom_i_a * binom_j_b) as u64;
-
+                        let binom = &binom_table[i][a] * &binom_table[j][b];
                         // α^{i-a} * y^{j-b}
-                        let alpha_power = alpha.pow(i - a);
-                        let y_power = y.pow(j - b);
-
-                        let coeff =
-                            &FieldElement::<F>::from(coeff_scalar) * &(&alpha_power * &y_power);
+                        let coeff = &binom * &(&alpha_powers[i - a] * &y_powers[j - b]);
                         row.push(coeff);
                     }
                 }
@@ -420,7 +456,13 @@ fn find_kernel_vector<F: IsField + Clone>(
         pivot_cols.push(col);
 
         let pivot = mat[pivot_row][col].clone();
-        let pivot_inv = pivot.inv().unwrap_or_else(|_| FieldElement::<F>::one());
+        // `pivot` is the first non-zero entry found in this column, and every
+        // non-zero element of a field is invertible, so this never fails. Use
+        // `expect` rather than a silent `unwrap_or(one())` fallback, which would
+        // mask a logic error by producing a wrong kernel vector instead.
+        let pivot_inv = pivot
+            .inv()
+            .expect("non-zero pivot is invertible in a field");
         for elem in &mut mat[pivot_row][col..n] {
             *elem = &*elem * &pivot_inv;
         }
@@ -440,13 +482,13 @@ fn find_kernel_vector<F: IsField + Clone>(
         pivot_row += 1;
     }
 
-    let mut free_col = None;
-    for col in 0..n {
-        if !pivot_cols.contains(&col) {
-            free_col = Some(col);
-            break;
-        }
+    // Mark pivot columns so the free-column lookup is O(n) instead of scanning
+    // `pivot_cols` for every column.
+    let mut is_pivot = vec![false; n];
+    for &pc in &pivot_cols {
+        is_pivot[pc] = true;
     }
+    let free_col = (0..n).find(|&col| !is_pivot[col]);
 
     let mut kernel = vec![FieldElement::<F>::zero(); n];
 
@@ -464,21 +506,16 @@ fn find_kernel_vector<F: IsField + Clone>(
     kernel
 }
 
-/// Computes binomial coefficient C(n, k).
-fn binomial(n: usize, k: usize) -> usize {
-    if k > n {
-        return 0;
+/// Returns `[base^0, base^1, ..., base^max_exp]` so callers can index powers
+/// instead of recomputing `base.pow(e)` repeatedly.
+fn power_table<F: IsField + Clone>(base: &FieldElement<F>, max_exp: usize) -> Vec<FieldElement<F>> {
+    let mut powers = Vec::with_capacity(max_exp + 1);
+    let mut current = FieldElement::<F>::one();
+    for _ in 0..=max_exp {
+        powers.push(current.clone());
+        current = &current * base;
     }
-    if k == 0 || k == n {
-        return 1;
-    }
-
-    let k = k.min(n - k);
-    let mut result = 1;
-    for i in 0..k {
-        result = result * (n - i) / (i + 1);
-    }
-    result
+    powers
 }
 
 #[cfg(test)]

--- a/examples/reed-solomon-codes/src/polynomial_utils.rs
+++ b/examples/reed-solomon-codes/src/polynomial_utils.rs
@@ -812,42 +812,13 @@ fn find_univariate_roots_with_hints<F: IsField + Clone>(
 
     // Also try small field elements as fallback
     let max_search = 2000; // Increased to catch roots like 1002
-    let mut found_count = 0;
     for i in 0..max_search {
         let elem = FieldElement::<F>::from(i as u64);
-        if poly.evaluate(&elem) == FieldElement::<F>::zero() {
-            found_count += 1;
-            if !roots.contains(&elem) {
-                roots.push(elem.clone());
-                // Debug: print when we find roots around 1000
-                if std::env::var("RR_DEBUG").is_ok() && (1000..=1010).contains(&i) {
-                    eprintln!("  Found root at i={}", i);
-                }
-                if roots.len() >= max_roots {
-                    // Debug: check why we're returning early
-                    if std::env::var("RR_DEBUG").is_ok() && max_roots < 15 {
-                        eprintln!(
-                            "  Returning early: {} roots found, max_roots={}, last i={}",
-                            roots.len(),
-                            max_roots,
-                            i
-                        );
-                    }
-                    return roots;
-                }
+        if poly.evaluate(&elem) == FieldElement::<F>::zero() && !roots.contains(&elem) {
+            roots.push(elem);
+            if roots.len() >= max_roots {
+                return roots;
             }
-        }
-    }
-    // Debug: if we searched everything but didn't find 1002
-    if std::env::var("RR_DEBUG").is_ok() && found_count > 0 && poly.degree() > 5 {
-        let test_1002 = FieldElement::<F>::from(1002u64);
-        let is_root = poly.evaluate(&test_1002) == FieldElement::<F>::zero();
-        if is_root && !roots.contains(&test_1002) {
-            eprintln!(
-                "  WARNING: 1002 is a root but wasn't added! found_count={}, roots.len()={}",
-                found_count,
-                roots.len()
-            );
         }
     }
 
@@ -892,6 +863,9 @@ fn substitute_and_divide<F: IsField + Clone>(
     let mut result_coeffs: Vec<Vec<FieldElement<F>>> =
         vec![vec![FieldElement::<F>::zero(); max_x_deg + 2]; max_y_deg + 1];
 
+    // Binomial coefficients C(j, k) reduced into the field, overflow-free.
+    let binom_table = pascal_table_fe::<F>(y_deg);
+
     for (j, qj) in q.coeffs.iter().enumerate() {
         // Contribution of Qⱼ(x) * (c + xy)^j
         // (c + xy)^j = Σₖ C(j,k) c^{j-k} x^k y^k
@@ -899,10 +873,9 @@ fn substitute_and_divide<F: IsField + Clone>(
         let qj_coeffs = qj.coefficients();
 
         for (k, result_row) in result_coeffs.iter_mut().enumerate().take(j + 1) {
-            let binom = binomial(j, k);
             // c^{j-k}
             let c_power = c.pow(j - k);
-            let binom_c = &FieldElement::<F>::from(binom as u64) * &c_power;
+            let binom_c = &binom_table[j][k] * &c_power;
 
             // Multiply Qⱼ(x) by binom_c * x^k, add to coefficient of y^k
             for (i, qi_coeff) in qj_coeffs.iter().enumerate() {
@@ -941,14 +914,16 @@ fn shift_y<F: IsField + Clone>(
     let y_deg = q.y_degree();
     let mut result_coeffs: Vec<Polynomial<FieldElement<F>>> = vec![Polynomial::zero(); y_deg + 1];
 
+    // Binomial coefficients C(j, k) reduced into the field, overflow-free.
+    let binom_table = pascal_table_fe::<F>(y_deg);
+
     // Q(x, y + c) = Σⱼ Qⱼ(x) (y + c)^j
     // We need to expand (y + c)^j using binomial theorem
     for (j, qj) in q.coeffs.iter().enumerate() {
         // (y + c)^j = Σₖ C(j,k) y^k c^{j-k}
         let mut c_power = FieldElement::<F>::one();
         for (k, result_coeff) in result_coeffs.iter_mut().enumerate().take(j + 1) {
-            let binom = binomial(j, k);
-            let coeff = &c_power * &FieldElement::<F>::from(binom as u64);
+            let coeff = &c_power * &binom_table[j][k];
 
             // Add binom * c^{j-k} * Qⱼ(x) to coefficient of y^k
             let term: Vec<_> = qj.coefficients().iter().map(|x| x * &coeff).collect();
@@ -985,15 +960,30 @@ fn divide_by_x<F: IsField + Clone>(q: &BivariatePolynomial<F>) -> BivariatePolyn
     BivariatePolynomial::new(coeffs)
 }
 
-/// Computes binomial coefficient C(n, k).
-fn binomial(n: usize, k: usize) -> usize {
-    if k > n {
-        return 0;
+/// Builds Pascal's triangle up to row `max_n`, with each binomial coefficient
+/// reduced into the field `F`.
+///
+/// `table[n][k]` is C(n, k) for `0 <= k <= n <= max_n`.
+///
+/// Computing coefficients this way (additions only, via Pascal's rule) has two
+/// advantages over a direct integer computation:
+///
+/// * **No overflow.** C(n, k) exceeds `u64`/`usize` for the degrees these
+///   decoders reach, which would panic in debug builds and silently corrupt the
+///   result in release builds. Field additions never overflow.
+/// * **No exponential blowup.** The previous recursive `binomial` recomputed the
+///   same sub-coefficients repeatedly (O(2^n)); this is O(max_n^2) and cached.
+pub(crate) fn pascal_table_fe<F: IsField + Clone>(max_n: usize) -> Vec<Vec<FieldElement<F>>> {
+    let mut table: Vec<Vec<FieldElement<F>>> = Vec::with_capacity(max_n + 1);
+    for n in 0..=max_n {
+        // C(n, 0) = C(n, n) = 1; interior entries come from Pascal's rule.
+        let mut row = vec![FieldElement::<F>::one(); n + 1];
+        for k in 1..n {
+            row[k] = &table[n - 1][k - 1] + &table[n - 1][k];
+        }
+        table.push(row);
     }
-    if k == 0 || k == n {
-        return 1;
-    }
-    binomial(n - 1, k - 1) + binomial(n - 1, k)
+    table
 }
 
 /// Lagrange interpolation to find f(0) given points (x_i, y_i).
@@ -1182,12 +1172,16 @@ mod tests {
     }
 
     #[test]
-    fn test_binomial() {
-        assert_eq!(binomial(5, 0), 1);
-        assert_eq!(binomial(5, 1), 5);
-        assert_eq!(binomial(5, 2), 10);
-        assert_eq!(binomial(5, 3), 10);
-        assert_eq!(binomial(5, 4), 5);
-        assert_eq!(binomial(5, 5), 1);
+    fn test_pascal_table() {
+        let table = pascal_table_fe::<Babybear31PrimeField>(5);
+        // Row 5 of Pascal's triangle: 1 5 10 10 5 1
+        assert_eq!(table[5][0], FE::one());
+        assert_eq!(table[5][1], FE::from(5u64));
+        assert_eq!(table[5][2], FE::from(10u64));
+        assert_eq!(table[5][3], FE::from(10u64));
+        assert_eq!(table[5][4], FE::from(5u64));
+        assert_eq!(table[5][5], FE::one());
+        // Spot-check a smaller row.
+        assert_eq!(table[3][1], FE::from(3u64));
     }
 }


### PR DESCRIPTION
Panics:
- Require k >= 2 in gs_list_decode / gs_list_decode_with_multiplicity, turning a cryptic divide-by-zero (w = k-1 = 0) and k-1 underflow into a clear precondition. Guard count_monomials against w == 0.
- Replace integer binomial coefficients (which overflow u64 at the degree bounds this algorithm reaches) with an in-field Pascal-table computation.
- find_kernel_vector: expect() on the non-zero pivot inverse instead of a silent unwrap_or(one()) that masked logic errors.

Performance:
- Replace the O(2^n) recursive binomial with a cached O(n^2) field Pascal table.
- Precompute alpha^e / y^e per interpolation point instead of pow() per cell.
- Remove RR_DEBUG env-var lookups from the inner root-search loop.
- find_kernel_vector: O(n) free-column lookup via a boolean mask.
